### PR TITLE
chore: add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug Report
+description: Report something broken or behaving unexpectedly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Please fill in what you can — the more detail, the faster the fix.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug.
+      placeholder: |
+        1. Run `bun run cli -- query --question "..." --mode verbose`
+        2. Observe error in stdout
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - src/runtime/ (compiler & query engine)
+        - src/mcp/ (MCP tools & contracts)
+        - CLI
+        - Hono server
+        - LM Studio integration
+        - Logging & observability
+        - Docs (Rspress)
+        - .github/ (CI & docs deploy)
+        - Cross-cutting
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Commit or version
+      description: Output of `git rev-parse --short HEAD`
+      placeholder: e.g. 5110fe0
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error output / logs
+      description: Paste relevant errors/logs only, and redact secrets/tokens/PII before submitting.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Environment, OS, Bun version, LM Studio model, or anything else relevant.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     id: logs
     attributes:
       label: Error output / logs
-      description: Paste relevant errors/logs only, and redact secrets/tokens/PII before submitting.
+      description: Paste relevant errors/logs (e.g. from .runtime/logs/mastra.log or ai-traces.jsonl) and redact secrets/tokens/PII before submitting.
       render: shell
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: README & Quickstart
+    url: https://github.com/venikman/fpf-memory#readme
+    about: Check the README before opening an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature Request
+description: Suggest a new capability or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe what you'd like and why. Remember this repo is scoped to local FPF-spec.md runtime — no vector database, no remote indexing, no Python.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this solve, or what becomes possible?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How should it work? Include API surface, CLI flags, MCP tool changes, or behavior changes.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - src/runtime/ (compiler & query engine)
+        - src/mcp/ (MCP tools & contracts)
+        - CLI
+        - Hono server
+        - LM Studio integration
+        - Logging & observability
+        - Docs (Rspress)
+        - .github/ (CI & docs deploy)
+        - Cross-cutting
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why they're less suitable.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, screenshots, related issues, or references.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,80 @@
+name: Task
+description: A concrete work item — research, refactor, chore, or agent-delegable task
+labels: ["task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for actionable work items that aren't bugs or feature requests.
+        Tasks can be picked up by humans or AI agents.
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What needs to be done and what does "done" look like?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind
+      options:
+        - research / exploration
+        - refactor
+        - chore (deps, CI, cleanup)
+        - docs
+        - test coverage
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - src/runtime/ (compiler & query engine)
+        - src/mcp/ (MCP tools & contracts)
+        - CLI
+        - Hono server
+        - LM Studio integration
+        - Logging & observability
+        - Docs (Rspress)
+        - .github/ (CI & docs deploy)
+        - Cross-cutting
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checklist or conditions that mark this task as complete.
+      placeholder: |
+        - [ ] criterion 1
+        - [ ] criterion 2
+    validations:
+      required: false
+
+  - type: dropdown
+    id: agent_delegable
+    attributes:
+      label: Agent-delegable?
+      description: Can an AI agent (Devin, Claude Code, Hermes, Codex, etc.) handle this autonomously?
+      options:
+        - "yes"
+        - "partially — needs human review"
+        - "no — requires human judgment"
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, prior art, constraints, or related issues.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,9 @@
 
 ## Validation
 
-- [ ] `bun run lint && bun run check && bun run test` passes locally
+- [ ] `bun run lint` passes locally
+- [ ] `bun run check` passes locally
+- [ ] `bun run test` passes locally
 - [ ] No new warnings introduced
 - [ ] `bun run build` succeeds (if runtime/server code touched)
 - [ ] `bun run docs:build` succeeds (if docs touched)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+## What
+
+<!-- Brief description of what this PR does -->
+
+## Why
+
+<!-- Motivation or link to issue -->
+
+## Type
+
+- [ ] `feat` — new capability
+- [ ] `fix` — bug fix
+- [ ] `refactor` — code restructuring
+- [ ] `docs` — documentation only
+- [ ] `chore` — maintenance (deps, CI, cleanup)
+
+## Changes
+
+<!-- Key changes, one bullet per logical unit -->
+
+## Validation
+
+- [ ] `bun run lint && bun run check && bun run test` passes locally
+- [ ] No new warnings introduced
+- [ ] `bun run build` succeeds (if runtime/server code touched)
+- [ ] `bun run docs:build` succeeds (if docs touched)
+- [ ] Relevant docs updated (README, docs/, inline JSDoc if applicable)
+
+## Boundary check
+
+- [ ] Runtime source set is `FPF-spec.md` only — no additional corpora added
+- [ ] No vector database or remote indexing introduced
+- [ ] No Python code added
+- [ ] MCP tool contracts stay in `src/mcp/tool-contracts.ts`
+
+## Agent metadata
+
+<!-- Fill in if this PR was authored or co-authored by an AI agent -->
+<!-- Do not include secrets, credentials, tokens, private URLs, or PII in Session/Prompt fields -->
+
+| Field   | Value |
+|---------|-------|
+| Agent   | <!-- e.g. Devin, Claude Code, Hermes, Codex --> |
+| Session | <!-- link or ID --> |
+| Prompt  | <!-- original task description --> |


### PR DESCRIPTION
## What

Adds GitHub PR template and issue form templates (bug report, feature request, task) to standardize contributions from both humans and AI agents.

## Why

The repo had no PR or issue templates. Structured templates help:
- Enforce the repo's scope boundaries (FPF-spec.md only, no vector DB, no Python, no remote indexing)
- Make validation checklists explicit (`bun run lint && bun run check && bun run test`)
- Track AI agent provenance via the agent metadata table
- Guide issue reporters through structured YAML forms with area dropdowns matching the actual codebase layout

## Type

- [ ] `feat` — new capability
- [ ] `fix` — bug fix
- [ ] `refactor` — code restructuring
- [ ] `docs` — documentation only
- [x] `chore` — maintenance (deps, CI, cleanup)

## Changes

- **`.github/pull_request_template.md`** — PR template with type checkboxes, validation checklist (`lint`, `check`, `test`, `build`, `docs:build`), boundary check, and agent metadata section
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — Bug report form with affected area dropdown, repro steps, and error log paste with redaction warning
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — Feature request form with scope reminder (no vector DB, no remote indexing, no Python), area dropdown
- **`.github/ISSUE_TEMPLATE/task.yml`** — Task form with agent-delegable flag, acceptance criteria, kind/area dropdowns
- **`.github/ISSUE_TEMPLATE/config.yml`** — Template chooser config with README link, blank issues enabled

Area dropdown options across all templates:
- `src/runtime/` (compiler & query engine)
- `src/mcp/` (MCP tools & contracts)
- CLI
- Hono server
- LM Studio integration
- Logging & observability
- Docs (Rspress)
- `.github/` (CI & docs deploy)
- Cross-cutting
- Other

## Validation

- [x] `bun run lint && bun run check && bun run test` passes locally — N/A (no code changes, only markdown/YAML templates)
- [x] No new warnings introduced
- [x] `bun run build` succeeds (if runtime/server code touched) — not touched
- [x] `bun run docs:build` succeeds (if docs touched) — not touched
- [x] Relevant docs updated (README, docs/, inline JSDoc if applicable) — N/A

## Boundary check

- [x] Runtime source set is `FPF-spec.md` only — no additional corpora added
- [x] No vector database or remote indexing introduced
- [x] No Python code added
- [x] MCP tool contracts stay in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
|---------|-------|
| Agent   | Devin |
| Session | https://app.devin.ai/sessions/963448a1d1034666bd8605f5dd629636 |
| Prompt  | review repo again and check if its still make sense and if yes add those templates |

Requested by: @venikman
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added structured GitHub issue templates for bug reports, feature requests, and tasks, including required/optional fields, dropdowns for affected areas, and guidance to standardize submissions.
  * Added issue configuration to allow blank issues and surface a README/Quickstart contact link.

* **Chores**
  * Added a standardized pull request template with sections for description, type, validation checklist, and contribution boundary checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->