### PR TITLE
Add Codex MCP packaging and decision record

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,17 @@
+#:schema https://developers.openai.com/codex/config-schema.json
+
+[mcp_servers.fpf_memory]
+command = "node"
+args = ["--import", "tsx", "src/mcp-stdio.ts"]
+cwd = "."
+enabled_tools = [
+  "ask_fpf",
+  "query_fpf_spec",
+  "read_fpf_doc",
+  "trace_fpf_path",
+  "get_fpf_index_status",
+  "refresh_fpf_index",
+]
+required = false
+startup_timeout_sec = 15
+tool_timeout_sec = 60

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,7 +3,6 @@ name: Deploy Docs to GitHub Pages
 on:
   push:
     branches: [main]
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 doc_build
 .mastra
 .runtime
+.claude
 .env
 .env.development
 output.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# fpf_memory MCP Usage
+
+Use the `fpf_memory` MCP server whenever the task requires grounded answers, exact FPF IDs, canonical generated docs, or deterministic retrieval provenance from the local `FPF-spec.md` runtime.
+
+Prefer these tools:
+
+- `ask_fpf` for markdown-first answers
+- `query_fpf_spec` for structured answer envelopes
+- `read_fpf_doc` for exact generated markdown pages
+- `trace_fpf_path` for retrieval evidence and provenance
+- `get_fpf_index_status` or `refresh_fpf_index` for runtime freshness checks

--- a/README.md
+++ b/README.md
@@ -116,6 +116,56 @@ Start the hosted Mastra runtime on the Hono engine:
 bun run start
 ```
 
+## Codex Setup
+
+Decision record for this interface choice:
+
+- [DRR-0001: MCP As The First-Class Codex Interface](docs/drr/DRR-0001-mcp-first-class-interface.md)
+
+For Codex registration, use the direct Node stdio entry point instead of the Bun script wrapper:
+
+- Command: `node`
+- Arguments: `--import`, `tsx`, `src/mcp-stdio.ts`
+- Working directory: your local `fpf-memory` repo root
+
+The desktop app fields map directly to those values.
+
+Equivalent `~/.codex/config.toml` entry:
+
+```toml
+[mcp_servers.fpf_memory]
+command = "node"
+args = ["--import", "tsx", "src/mcp-stdio.ts"]
+cwd = "/absolute/path/to/fpf-memory"
+enabled_tools = [
+  "ask_fpf",
+  "query_fpf_spec",
+  "read_fpf_doc",
+  "trace_fpf_path",
+  "get_fpf_index_status",
+  "refresh_fpf_index",
+]
+required = false
+startup_timeout_sec = 15
+tool_timeout_sec = 60
+```
+
+This repo now also ships the same project-scoped configuration at `.codex/config.toml`. Once the project is trusted, Codex can load the `fpf_memory` server directly from the repo without copying the snippet into your user config.
+
+Local development can keep using the Bun shortcut:
+
+```bash
+bun run mcp
+```
+
+Recommended Codex tasks:
+
+- answer a question: `Use only the fpf_memory MCP server. Call ask_fpf with question: "What is U.PromiseContent?"`
+- read a generated page: `Use only the fpf_memory MCP server. Call read_fpf_doc with selector: "A.1.1"`
+- inspect retrieval evidence: `Use only the fpf_memory MCP server. Call trace_fpf_path with question: "How do U.RoleAssignment and U.BoundedContext connect?"`
+- check runtime freshness: `Use only the fpf_memory MCP server. Call get_fpf_index_status`
+- rebuild the local index: `Use only the fpf_memory MCP server. Call refresh_fpf_index`
+
 Smoke-test the same runtime surface locally before wiring it into Codex:
 
 ```bash
@@ -132,6 +182,12 @@ Run the end-to-end verification script for the real CLI, MCP stdio, and hosted H
 
 ```bash
 ./scripts/verify-runtime.sh
+```
+
+The verification script also checks the direct Codex launcher:
+
+```bash
+node --import tsx src/mcp-stdio.ts
 ```
 
 If this repo is registered as a Codex MCP server, restart Codex after changes and then test with a forced tool-use prompt such as:

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ The verification script also checks the direct Codex launcher:
 node --import tsx src/mcp-stdio.ts
 ```
 
+This starts a long-running stdio server; for a manual smoke check, stop it with `Ctrl+C` after startup confirmation.
+
 If this repo is registered as a Codex MCP server, restart Codex after changes and then test with a forced tool-use prompt such as:
 
 ```text

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "@types/node": "^25.6.0",
         "bun-types": "^1.3.12",
         "rspress": "^1.47.1",
+        "tsx": "^4.21.0",
         "typescript": "^6.0.2",
       },
     },
@@ -51,6 +52,58 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
 
@@ -524,6 +577,8 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
@@ -611,6 +666,8 @@
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
+
+    "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
@@ -1046,6 +1103,8 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "rspack-plugin-virtual-module": ["rspack-plugin-virtual-module@0.1.13", "", { "dependencies": { "fs-extra": "^11.1.1" } }, "sha512-VC0HiVHH6dtGfTgfpbDgVTt6LlYv+uAg9CWGWAR5lBx9FbKPEZeGz7iRUUP8vMymx+PGI8ps0u4a25dne0rtuQ=="],
@@ -1197,6 +1256,8 @@
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 

--- a/docs/drr/DRR-0001-mcp-first-class-interface.md
+++ b/docs/drr/DRR-0001-mcp-first-class-interface.md
@@ -1,0 +1,82 @@
+---
+title: "DRR-0001: MCP As The First-Class Codex Interface"
+description: "Design-Rationale Record for the Codex-facing interface decision in fpf_memory."
+---
+
+# DRR-0001: MCP As The First-Class Codex Interface
+
+Status: accepted for the bounded context `CodexAccess:LocalFPFSpecRuntime`
+
+## Problem frame
+
+`fpf_memory` needs a Codex-facing interface for grounded access to the local `FPF-spec.md` runtime. The repo already exposes a local MCP server, a Bun CLI, and a hosted Hono/Mastra runtime path, but the interface promise was implicit rather than recorded as an explicit decision.
+
+Without a documented decision, the same word "interface" can collapse several different things:
+
+- the thing itself: the local runtime over `FPF-spec.md`
+- the access point: stdio or HTTP transport
+- the public promise: what Codex can ask for
+- the delivery work and evidence: traces, freshness checks, verification runs
+
+That ambiguity is exactly the sort of boundary drift FPF warns against. A Codex setup PR should therefore carry an explicit rationale record instead of relying on README prose and local memory.
+
+## Decision
+
+For the bounded context `CodexAccess:LocalFPFSpecRuntime`, `fpf_memory` adopts **MCP as the first-class agent-facing interface**.
+
+The decision includes these commitments:
+
+1. The primary Codex integration surface is the `fpf_memory` MCP server.
+2. The CLI remains an operator/debug surface, not the primary semantic boundary for agent use.
+3. Hosted HTTP remains a transport/hosting option, not the first interface to optimize for in this repo slice.
+4. The Codex registration path is documented and packaged around the stdio entry point:
+   `node --import tsx src/mcp-stdio.ts`
+5. This decision is recorded as a DRR outside the normative FPF core, consistent with `E.9`.
+
+## Rationale
+
+This choice keeps the FPF layers separate.
+
+- **Promise content:** Codex can ask for grounded answers, structured envelopes, exact generated docs, retrieval traces, status, and refresh.
+- **Ability:** the repo already implements those capabilities in the local runtime and MCP server.
+- **Performance / work evidence:** the repo can verify the launcher and runtime behavior through local CLI checks, MCP startup checks, and the verification script.
+
+Why MCP, rather than the alternatives:
+
+- **Against CLI-first:** the CLI is useful for operators and smoke tests, but it is not the native tool-selection boundary for Codex.
+- **Against custom HTTP-first:** Codex already supports MCP natively, so a bespoke API would add interface work without solving the current local integration problem.
+- **For MCP-first:** the repo already ships an MCP server, Codex natively supports MCP configuration, and the server contract matches the bounded need for grounded retrieval over local spec artifacts.
+
+This also follows FPF boundary discipline:
+
+- `A.2.3`: keep promise, capability, and work evidence distinct.
+- `E.10.D2`: do not collapse thing, description, and actual work.
+- `A.6.8`: avoid vague service-language blobs; name the boundary facet explicitly.
+
+The current caveat is not protocol fitness but surface shape. The repo is still tool-heavy and discovery-light. That is a later ergonomics problem, tracked separately, and does not overturn the MCP-first decision.
+
+## Consequences
+
+Positive consequences:
+
+- The PR can point to one explicit decision record instead of spreading rationale across comments and setup docs.
+- Codex setup, packaging metadata, and verification can all align around a single published interface decision.
+- Future work can distinguish between:
+  - boundary choice: MCP-first
+  - transport choice: stdio now, HTTP optional later
+  - surface-shape work: discovery, browse/search, tools/resources/prompts
+
+Trade-offs and follow-up consequences:
+
+- A tool-only MCP surface is still heavier than ideal for first-pass discovery, so later work should improve discovery without changing this decision.
+- Documentation now has one more artifact to keep current; that is acceptable because the DRR is the durable rationale carrier.
+- If the bounded context changes from local Codex use to a hosted multi-tenant product, a later DRR may designate HTTP as an additional first-class external boundary for that different scope.
+
+References:
+
+- `E.9` Design-Rationale Record method
+- `A.2.3` promise / capability / work distinctions
+- `E.10.D2` thing / description / work separation
+- `A.6.8` boundary-language discipline
+- Issue `#14` for Codex packaging and setup
+- Issue `#15` for later discovery-layer ergonomics

--- a/docs/mcp-interface.md
+++ b/docs/mcp-interface.md
@@ -7,6 +7,10 @@ description: "Spec-oriented interface contract for the local FPF stdio MCP serve
 
 This page documents the public MCP surface implemented by `fpf_memory`.
 
+Decision record:
+
+- [DRR-0001: MCP As The First-Class Codex Interface](/drr/DRR-0001-mcp-first-class-interface/)
+
 The runtime itself is compiler-backed and local:
 
 - authored source: `FPF-spec.md`
@@ -19,9 +23,42 @@ The runtime itself is compiler-backed and local:
 - transport: stdio
 - server name: `fpf_memory`
 - protocol version: `2024-11-05`
-- local entry point: `bun run mcp`
+- Codex entry point: `node --import tsx src/mcp-stdio.ts`
+- local dev shortcut: `bun run mcp`
 
 Hosted/server surfaces still use the Mastra Hono adapter under `src/mastra.ts` and `src/server.ts`.
+
+## Codex Setup
+
+Codex desktop app fields:
+
+- command: `node`
+- arguments: `--import`, `tsx`, `src/mcp-stdio.ts`
+- working directory: absolute path to the local repo root
+
+Equivalent `~/.codex/config.toml` entry:
+
+```toml
+[mcp_servers.fpf_memory]
+command = "node"
+args = ["--import", "tsx", "src/mcp-stdio.ts"]
+cwd = "/absolute/path/to/fpf-memory"
+enabled_tools = [
+  "ask_fpf",
+  "query_fpf_spec",
+  "read_fpf_doc",
+  "trace_fpf_path",
+  "get_fpf_index_status",
+  "refresh_fpf_index",
+]
+required = false
+startup_timeout_sec = 15
+tool_timeout_sec = 60
+```
+
+`enabled_tools` is optional. The list above gives Codex the default answer, doc-read, evidence, status, and refresh flows without exposing every debug tool by default.
+
+This repo also ships the same project-scoped configuration at `.codex/config.toml`. Codex will load that file after the project is trusted.
 
 ## Tool Catalog
 
@@ -86,4 +123,5 @@ bun run test
 bun run docs:build
 bun run cli -- read-doc --selector "A.1.1"
 bun run mcp
+node --import tsx src/mcp-stdio.ts
 ```

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "fpf_memory",
+  "version": "1.0.0",
+  "description": "Local vectorless FPF-spec runtime with MCP tools for answers, docs, evidence, status, and refresh.",
+  "tools": [
+    "refresh_fpf_index",
+    "get_fpf_index_status",
+    "query_fpf_spec",
+    "ask_fpf",
+    "trace_fpf_path",
+    "inspect_fpf_node",
+    "read_fpf_doc",
+    "inspect_fpf_anchor",
+    "expand_fpf_citations"
+  ],
+  "transport": "stdio",
+  "runtime": {
+    "bun": "bun src/mcp-stdio.ts",
+    "node": "node --import tsx src/mcp-stdio.ts"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/node": "^25.6.0",
     "bun-types": "^1.3.12",
     "rspress": "^1.47.1",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.2"
   }
 }

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -47,6 +47,10 @@ export default defineConfig({
         text: 'Preface',
         link: '/generated/preface/index',
       },
+      {
+        text: 'Decision Records',
+        link: '/drr/DRR-0001-mcp-first-class-interface/',
+      },
     ],
     sidebar: {
       '/': [
@@ -129,6 +133,30 @@ export default defineConfig({
         },
       ],
       '/mcp-interface/': [
+        {
+          text: 'Additional',
+          items: [
+            {
+              text: 'MCP Interface',
+              link: '/mcp-interface/',
+            },
+            {
+              text: 'DRR-0001',
+              link: '/drr/DRR-0001-mcp-first-class-interface/',
+            },
+          ],
+        },
+      ],
+      '/drr/': [
+        {
+          text: 'Decision Records',
+          items: [
+            {
+              text: 'DRR-0001',
+              link: '/drr/DRR-0001-mcp-first-class-interface/',
+            },
+          ],
+        },
         {
           text: 'Additional',
           items: [

--- a/scripts/verify-runtime.sh
+++ b/scripts/verify-runtime.sh
@@ -41,6 +41,31 @@ trap - EXIT
 
 grep -q '"msg":"MCP stdio server start"' "$MAS_LOG"
 
+printf '==> Starting MCP stdio server via Node/tsx briefly\n'
+node_before_size="$(wc -c <"$MAS_LOG" | tr -d ' ')"
+node_fifo="$(mktemp -u "${TMPDIR:-/tmp}/fpf-node-mcp.XXXXXX")"
+mkfifo "$node_fifo"
+exec 3<>"$node_fifo"
+rm -f "$node_fifo"
+node --import tsx src/mcp-stdio.ts <&3 >/dev/null 2>&1 &
+node_mcp_pid="$!"
+trap 'kill "$node_mcp_pid" 2>/dev/null || true; wait "$node_mcp_pid" 2>/dev/null || true' EXIT
+sleep 2
+if ! kill -0 "$node_mcp_pid" 2>/dev/null; then
+  wait "$node_mcp_pid" 2>/dev/null || true
+  exec 3>&-
+  printf 'Node/tsx MCP runtime exited before verification completed\n' >&2
+  exit 1
+fi
+kill "$node_mcp_pid" 2>/dev/null || true
+wait "$node_mcp_pid" 2>/dev/null || true
+exec 3>&-
+trap - EXIT
+
+node_after_size="$(wc -c <"$MAS_LOG" | tr -d ' ')"
+(( node_after_size > node_before_size ))
+tail -c +"$((node_before_size + 1))" "$MAS_LOG" | grep -q '"msg":"MCP stdio server start"'
+
 printf '==> Starting hosted Hono runtime briefly\n'
 hosted_before_size="$(wc -c <"$MAS_LOG" | tr -d ' ')"
 FPF_VERIFY_PORT="${FPF_VERIFY_PORT:-42111}"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,13 @@
+{
+  "name": "fpf_memory",
+  "version": "1.0.0",
+  "description": "Local vectorless FPF-spec runtime for Codex and other MCP clients.",
+  "transport": "stdio",
+  "command": "node",
+  "cwd": ".",
+  "args": ["--import", "tsx", "src/mcp-stdio.ts"],
+  "env": {
+    "FPF_SPEC_SOURCE_PATH": "FPF-spec.md",
+    "FPF_RUNTIME_ARTIFACT_DIR": ".runtime/fpf-index"
+  }
+}


### PR DESCRIPTION
## Summary
- add Codex-facing MCP packaging artifacts and a project-scoped `.codex/config.toml`
- document the Codex setup path in the README and MCP interface docs
- add `DRR-0001` so the MCP-first interface choice is recorded in FPF-recommended format
- extend runtime verification to cover the direct `node --import tsx src/mcp-stdio.ts` launcher

## Validation
- [x] `bun run docs:build`
- [x] `./scripts/verify-runtime.sh`

## Boundary Check
- [x] runtime source remains the local `FPF-spec.md` pipeline
- [x] no vector database introduced
- [x] no Python runtime added for the MCP path
- [x] MCP contracts remain in the existing repo runtime surface (`server.json`, `manifest.json`, `src/mcp-*`)

Closes #14
