### PR TITLE
fix: set base path for GitHub Pages deployment

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -27,6 +27,7 @@ const navigation = buildDocsNavigation(snapshot);
 export default defineConfig({
   root: docsRoot,
   outDir,
+  base: '/fpf-memory/',
   title: 'FPF Reference',
   description: 'Compiler-backed FPF reference docs generated from FPF-spec.md.',
   globalStyles: resolve(process.cwd(), 'src/docs/density.css'),


### PR DESCRIPTION
## What

Adds `base: '/fpf-memory/'` to rspress.config.ts so static assets load from the correct path on GitHub Pages.

## Why

After the rspress v2 upgrade (#19), the deployed docs at https://venikman.github.io/fpf-memory/ have broken CSS/JS because all assets are loaded from `https://venikman.github.io/static/...` (404) instead of `https://venikman.github.io/fpf-memory/static/...`.

This was likely also broken before the upgrade but may not have been noticed if the site wasn't actively deployed.

## Type

- [ ] `feat` — new capability
- [x] `fix` — bug fix
- [ ] `refactor` — code restructuring
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance (deps, CI, cleanup)

## Changes

- Added `base: '/fpf-memory/'` to the rspress defineConfig in `rspress.config.ts`

## Validation

- [x] `bun run lint` passes locally
- [x] `bun run check` passes locally
- [ ] `bun run test` passes locally
- [x] No new warnings introduced
- [ ] `bun run build` succeeds (if runtime/server code touched)
- [x] `bun run docs:build` succeeds (if docs touched)
- [x] Verified built HTML references `/fpf-memory/static/css/...` paths
- [ ] Relevant docs updated (README, docs/, inline JSDoc if applicable)

## Boundary check

- [x] Runtime source set is `FPF-spec.md` only — no additional corpora added
- [x] No vector database or remote indexing introduced
- [x] No Python code added
- [x] MCP tool contracts stay in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
|---------|-------|
| Agent   | Devin |
| Session | https://app.devin.ai/sessions/f29391a9d614483ba76558826caa98fd |
| Prompt  | fix broken CSS on deployed docs |

Requested by: @venikman
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application's base path configuration for deployment routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->