### PR TITLE
fix: use relative path in index redirect for base path compatibility

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -9,13 +9,13 @@ import { useEffect } from 'react';
 export default function IndexRedirect() {
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      window.location.replace('./generated/patterns/index');
+      window.location.replace('/fpf-memory/generated/patterns/index');
     }
   }, []);
 
   return (
     <>
-      <p>Redirecting to <a href="./generated/patterns/index">Pattern Catalog</a>…</p>
+      <p>Redirecting to <a href="/fpf-memory/generated/patterns/index">Pattern Catalog</a>…</p>
     </>
   );
 }

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -9,13 +9,13 @@ import { useEffect } from 'react';
 export default function IndexRedirect() {
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      window.location.replace('/generated/patterns/index');
+      window.location.replace('./generated/patterns/index');
     }
   }, []);
 
   return (
     <>
-      <p>Redirecting to <a href="/generated/patterns/index">Pattern Catalog</a>…</p>
+      <p>Redirecting to <a href="./generated/patterns/index">Pattern Catalog</a>…</p>
     </>
   );
 }


### PR DESCRIPTION
## What

Fixes the homepage redirect to use a relative path instead of an absolute path, so it works correctly with the `/fpf-memory/` base path on GitHub Pages.

## Why

After the base path fix in #20, static assets (CSS/JS) load correctly, but the homepage redirect in `docs/index.mdx` was still hardcoded to `/generated/patterns/index`. This caused the browser to navigate to `venikman.github.io/generated/patterns/index` (404) instead of `venikman.github.io/fpf-memory/generated/patterns/index`.

## Type

- [ ] `feat` — new capability
- [x] `fix` — bug fix
- [ ] `refactor` — code restructuring
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance (deps, CI, cleanup)

## Changes

- Changed `window.location.replace('/generated/patterns/index')` → `window.location.replace('./generated/patterns/index')` in `docs/index.mdx`
- Changed the fallback `<a href>` to use the same relative path

## Validation

- [x] `bun run lint` passes locally
- [x] `bun run check` passes locally
- [ ] `bun run test` passes locally
- [x] No new warnings introduced
- [ ] `bun run build` succeeds (if runtime/server code touched)
- [x] `bun run docs:build` succeeds (if docs touched)
- [ ] Relevant docs updated (README, docs/, inline JSDoc if applicable)

## Boundary check

- [x] Runtime source set is `FPF-spec.md` only — no additional corpora added
- [x] No vector database or remote indexing introduced
- [x] No Python code added
- [x] MCP tool contracts stay in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
|---------|-------|
| Agent   | Devin |
| Session | https://app.devin.ai/sessions/f29391a9d614483ba76558826caa98fd |
| Prompt  | fix broken CSS / navigation on deployed docs |

Requested by: @venikman
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the client-side redirect and the Pattern Catalog link target so both point to the updated location, restoring expected navigation and ensuring users are taken to the correct catalog page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->