### PR TITLE
Parse plain-text catalog dependency cells into typed relation edges

### DIFF
--- a/src/runtime/compiler.ts
+++ b/src/runtime/compiler.ts
@@ -1191,24 +1191,53 @@ function parseLabeledRelations(
   sourceCitation: string,
 ): RelationEdge[] {
   const relationEdges: RelationEdge[] = [];
-  const relationRegex =
+
+  // Bold markdown format: **Builds on:** A.1, A.2.
+  const boldRegex =
     /\*\*([^:*]+):\*\*\s*([\s\S]*?)(?=(?:\n\s*[*-]\s*\*\*[^:*]+:\*\*|\s+\*\*[^:*]+:\*\*|$))/g;
-  for (const match of text.matchAll(relationRegex)) {
-    const label = normalizeForLookup(match[1] ?? '');
-    const relation = RELATION_LABELS[label];
-    if (!relation) {
-      continue;
-    }
-    for (const target of extractIds(match[2] ?? '')) {
-      relationEdges.push({
-        from: sourceId,
-        relation,
-        to: target,
-        source: sourceCitation,
-      });
+  for (const match of text.matchAll(boldRegex)) {
+    pushRelationEdges(relationEdges, sourceId, match[1] ?? '', match[2] ?? '', sourceCitation);
+  }
+
+  // Plain-text catalog format: Builds on: A.1, A.2. Constrains: B.3.
+  // Uses lookahead to split on the next known label or end-of-string.
+  if (relationEdges.length === 0) {
+    const escapedLabels = Object.keys(RELATION_LABELS).map(
+      (label) => label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+    );
+    const labelAlternation = escapedLabels.join('|');
+    const plainRegex = new RegExp(
+      `(${labelAlternation}):\\s*(.*?)(?=(?:${labelAlternation}):|$)`,
+      'gis',
+    );
+    for (const match of text.matchAll(plainRegex)) {
+      pushRelationEdges(relationEdges, sourceId, match[1] ?? '', match[2] ?? '', sourceCitation);
     }
   }
+
   return relationEdges;
+}
+
+function pushRelationEdges(
+  edges: RelationEdge[],
+  sourceId: string,
+  rawLabel: string,
+  rawTargets: string,
+  sourceCitation: string,
+): void {
+  const label = normalizeForLookup(rawLabel);
+  const relation = RELATION_LABELS[label];
+  if (!relation) {
+    return;
+  }
+  for (const target of extractIds(rawTargets)) {
+    edges.push({
+      from: sourceId,
+      relation,
+      to: target,
+      source: sourceCitation,
+    });
+  }
 }
 
 function parseKeywords(cell: string): string[] {


### PR DESCRIPTION
## Summary

- Add plain-text fallback parser to `parseLabeledRelations` in `compiler.ts` for catalog dependency cells that use `Builds on: A.1` format instead of `**Builds on:** A.1`
- Extract `pushRelationEdges` helper to deduplicate edge-creation logic between bold and plain-text parsers
- Fallback only activates when the bold-markdown regex finds zero matches, preventing double-counting

## Impact

| Relation type | Before | After | Change |
|---|---|---|---|
| `builds_on` | 353 | 1,132 | +221% |
| `coordinates_with` | 167 | 583 | +249% |
| `prerequisite_for` | 37 | 68 | +84% |
| `used_by` | 32 | 122 | +281% |
| **Total edges** | 14,006 | 15,402 | **+1,396** |

218 of 224 patterns with dependency text now have parsed typed relations (was 76 before). The remaining 6 reference non-standard IDs (`P-4`, `CHR-CAL`, `Part C (CHR)`) that `extractIds` cannot parse.

## Test plan

- [x] All 38 existing tests pass (`npx rstest run`)
- [x] Force-rebuilt index via `refresh_fpf_index` MCP tool
- [x] Verified A.0 now has `builds_on` and `coordinates_with` edges (was only `explicit_reference`)
- [x] Verified G.9 and G.13 typed relations populated correctly
- [x] End-to-end MCP client validation: `ask_fpf`, `query_fpf_spec`, `inspect_fpf_node`, `trace_fpf_path` all return correct results against the improved index

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced relation label parsing with improved fallback logic: now attempts bold-markdown format first, then falls back to plain-text format if needed.
  * Strengthened target extraction and label normalization for more robust parsing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->