### PR TITLE
feat: persist session cache across process restarts

### DIFF
--- a/src/mcp/tool-contracts.ts
+++ b/src/mcp/tool-contracts.ts
@@ -221,6 +221,7 @@ export const runtimeStatusSchema = z
         enabled: z.boolean(),
         maxSessions: z.number(),
         activeSessions: z.number(),
+        persistent: z.boolean(),
       })
       .strict(),
   })

--- a/src/runtime/constants.ts
+++ b/src/runtime/constants.ts
@@ -9,6 +9,7 @@ export const ARTIFACT_FILENAMES = {
   routeGraph: 'route-graph.json',
   lexicon: 'lexicon.json',
   anchorMap: 'anchor-map.json',
+  sessionCache: 'session-cache.json',
 } as const;
 
 export const PREFACE_MARKER = '# **Preface** (non-normative)';

--- a/src/runtime/constants.ts
+++ b/src/runtime/constants.ts
@@ -9,8 +9,9 @@ export const ARTIFACT_FILENAMES = {
   routeGraph: 'route-graph.json',
   lexicon: 'lexicon.json',
   anchorMap: 'anchor-map.json',
-  sessionCache: 'session-cache.json',
 } as const;
+
+export const SESSION_CACHE_FILENAME = 'session-cache.json';
 
 export const PREFACE_MARKER = '# **Preface** (non-normative)';
 export const PREFACE_ROUTE_CITATION = 'Preface/Where to start';

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -6,6 +6,7 @@ import {
   ARTIFACT_FILENAMES,
   DEFAULT_ARTIFACT_DIR,
   DEFAULT_SOURCE_PATH,
+  SESSION_CACHE_FILENAME,
 } from './constants.js';
 import { compileFpfSource } from './compiler.js';
 import { createSynthesizerFromEnv } from './lm-studio-synthesizer.js';
@@ -64,7 +65,9 @@ export class FpfRuntime {
       options.persistSessionCache ?? process.env.FPF_PERSIST_SESSION_CACHE === 'true';
     this.sessionCache = new SessionCache({
       maxSessions: options.maxSessions ?? 50,
-      persistPath: persistSession ? this.artifactPaths.sessionCache : undefined,
+      persistPath: persistSession
+        ? resolve(this.artifactDir, SESSION_CACHE_FILENAME)
+        : undefined,
     });
   }
 

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -34,6 +34,7 @@ export interface FpfRuntimeOptions {
   artifactDir?: string;
   synthesizer?: LocalAnswerSynthesizer;
   maxSessions?: number;
+  persistSessionCache?: boolean;
 }
 
 export class FpfRuntime {
@@ -59,12 +60,18 @@ export class FpfRuntime {
       ]),
     ) as Record<keyof typeof ARTIFACT_FILENAMES, string>;
     this.synthesizer = options.synthesizer ?? createSynthesizerFromEnv();
-    this.sessionCache = new SessionCache(options.maxSessions ?? 50);
+    const persistSession =
+      options.persistSessionCache ?? process.env.FPF_PERSIST_SESSION_CACHE === 'true';
+    this.sessionCache = new SessionCache({
+      maxSessions: options.maxSessions ?? 50,
+      persistPath: persistSession ? this.artifactPaths.sessionCache : undefined,
+    });
   }
 
   async refresh(force = false): Promise<BuildAudit> {
     await mkdir(this.artifactDir, { recursive: true });
     const currentSourceHash = await hashFile(this.sourcePath);
+    await this.sessionCache.load(currentSourceHash);
     const existingSnapshot = await this.loadSnapshot();
     const compatibleSnapshot = existingSnapshot && !snapshotNeedsRebuild(existingSnapshot);
 

--- a/src/runtime/session-cache.ts
+++ b/src/runtime/session-cache.ts
@@ -11,7 +11,7 @@ export interface RetrievalSessionState {
 
 interface PersistedSessionCache {
   sourceHash: string;
-  entries: Record<string, RetrievalSessionState>;
+  entries: Array<[string, RetrievalSessionState]>;
 }
 
 export interface SessionCacheOptions {
@@ -51,11 +51,11 @@ export class SessionCache {
         return;
       }
       this.entries.clear();
-      const keys = Object.keys(data.entries);
-      const start = Math.max(0, keys.length - this.maxSessions);
-      for (let i = start; i < keys.length; i++) {
-        const key = keys[i];
-        this.entries.set(key, data.entries[key]);
+      const tuples = data.entries;
+      const start = Math.max(0, tuples.length - this.maxSessions);
+      for (let i = start; i < tuples.length; i++) {
+        const [key, value] = tuples[i];
+        this.entries.set(key, value);
       }
     } catch {
       // File missing or corrupt — start fresh
@@ -103,7 +103,7 @@ export class SessionCache {
     const path = this.persistPath;
     const data: PersistedSessionCache = {
       sourceHash: this.sourceHash,
-      entries: Object.fromEntries(this.entries),
+      entries: Array.from(this.entries.entries()),
     };
     const json = JSON.stringify(data);
     this.flushPromise = (this.flushPromise ?? Promise.resolve())

--- a/src/runtime/session-cache.ts
+++ b/src/runtime/session-cache.ts
@@ -1,5 +1,5 @@
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { readFile, writeFile, mkdir, rename } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 
 export interface RetrievalSessionState {
   lastNormalizedQuestion: string;
@@ -17,25 +17,36 @@ interface PersistedSessionCache {
 export interface SessionCacheOptions {
   maxSessions?: number;
   persistPath?: string;
+  /** Debounce delay in ms before flushing to disk (default 500). */
+  flushDelayMs?: number;
 }
 
 export class SessionCache {
   private readonly entries = new Map<string, RetrievalSessionState>();
   private readonly maxSessions: number;
   private readonly persistPath?: string;
+  private readonly flushDelayMs: number;
   private sourceHash?: string;
   private flushPromise?: Promise<void>;
   private loadPromise?: Promise<void>;
+  private flushTimer?: ReturnType<typeof setTimeout>;
+  private hasLoggedWriteError = false;
 
   constructor(options: SessionCacheOptions = {}) {
     this.maxSessions = options.maxSessions ?? 50;
     this.persistPath = options.persistPath;
+    this.flushDelayMs = options.flushDelayMs ?? 500;
   }
 
   async load(sourceHash: string): Promise<void> {
     if (this.sourceHash === sourceHash) {
       await this.loadPromise;
       return;
+    }
+
+    // Await any in-flight load before reassigning to avoid race conditions
+    if (this.loadPromise) {
+      await this.loadPromise;
     }
 
     if (this.sourceHash !== undefined) {
@@ -46,18 +57,22 @@ export class SessionCache {
     if (!this.persistPath) {
       return;
     }
-    this.loadPromise = this.readFromDisk(sourceHash);
+    this.loadPromise = this.readFromDisk(this.persistPath, sourceHash);
     await this.loadPromise;
   }
 
-  private async readFromDisk(sourceHash: string): Promise<void> {
+  /** Read persisted entries from disk. Path is passed explicitly to avoid non-null assertions. */
+  private async readFromDisk(path: string, sourceHash: string): Promise<void> {
     try {
-      const raw = await readFile(this.persistPath!, 'utf8');
+      const raw = await readFile(path, 'utf8');
       const data: PersistedSessionCache = JSON.parse(raw);
       if (data.sourceHash !== sourceHash || this.sourceHash !== sourceHash) {
         return;
       }
       const tuples = data.entries;
+      if (!Array.isArray(tuples)) {
+        return;
+      }
       const start = Math.max(0, tuples.length - this.maxSessions);
       for (let i = start; i < tuples.length; i++) {
         const [key, value] = tuples[i];
@@ -104,7 +119,22 @@ export class SessionCache {
     };
   }
 
+  /** Debounced flush — batches rapid set() calls into a single disk write. */
   private scheduleFlush(): void {
+    if (!this.persistPath || !this.sourceHash) {
+      return;
+    }
+    // Clear any pending debounce timer so we only write once after the last set()
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+    }
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = undefined;
+      this.doFlush();
+    }, this.flushDelayMs);
+  }
+
+  private doFlush(): void {
     if (!this.persistPath || !this.sourceHash) {
       return;
     }
@@ -117,10 +147,17 @@ export class SessionCache {
     this.flushPromise = (this.flushPromise ?? Promise.resolve())
       .then(async () => {
         await mkdir(dirname(path), { recursive: true });
-        await writeFile(path, json, 'utf8');
+        // Atomic write: write to temp file then rename to avoid corruption on crash
+        const tmpPath = join(dirname(path), `.session-cache.tmp.${Date.now()}`);
+        await writeFile(tmpPath, json, 'utf8');
+        await rename(tmpPath, path);
       })
-      .catch(() => {
-        // Best-effort persistence — don't crash on write failure
+      .catch((err: unknown) => {
+        // Log the first write failure so silent disk issues are visible
+        if (!this.hasLoggedWriteError) {
+          this.hasLoggedWriteError = true;
+          console.error('[SessionCache] disk write failed:', err);
+        }
       });
   }
 }

--- a/src/runtime/session-cache.ts
+++ b/src/runtime/session-cache.ts
@@ -32,7 +32,15 @@ export class SessionCache {
   }
 
   async load(sourceHash: string): Promise<void> {
+    if (this.sourceHash === sourceHash) {
+      return;
+    }
+
+    if (this.sourceHash !== undefined) {
+      this.entries.clear();
+    }
     this.sourceHash = sourceHash;
+
     if (!this.persistPath) {
       return;
     }
@@ -97,7 +105,7 @@ export class SessionCache {
       sourceHash: this.sourceHash,
       entries: Object.fromEntries(this.entries),
     };
-    const json = JSON.stringify(data, null, 2);
+    const json = JSON.stringify(data);
     this.flushPromise = (this.flushPromise ?? Promise.resolve())
       .then(async () => {
         await mkdir(dirname(path), { recursive: true });

--- a/src/runtime/session-cache.ts
+++ b/src/runtime/session-cache.ts
@@ -54,7 +54,7 @@ export class SessionCache {
     try {
       const raw = await readFile(this.persistPath!, 'utf8');
       const data: PersistedSessionCache = JSON.parse(raw);
-      if (data.sourceHash !== sourceHash) {
+      if (data.sourceHash !== sourceHash || this.sourceHash !== sourceHash) {
         return;
       }
       const tuples = data.entries;

--- a/src/runtime/session-cache.ts
+++ b/src/runtime/session-cache.ts
@@ -25,6 +25,7 @@ export class SessionCache {
   private readonly persistPath?: string;
   private sourceHash?: string;
   private flushPromise?: Promise<void>;
+  private loadPromise?: Promise<void>;
 
   constructor(options: SessionCacheOptions = {}) {
     this.maxSessions = options.maxSessions ?? 50;
@@ -33,6 +34,7 @@ export class SessionCache {
 
   async load(sourceHash: string): Promise<void> {
     if (this.sourceHash === sourceHash) {
+      await this.loadPromise;
       return;
     }
 
@@ -44,18 +46,24 @@ export class SessionCache {
     if (!this.persistPath) {
       return;
     }
+    this.loadPromise = this.readFromDisk(sourceHash);
+    await this.loadPromise;
+  }
+
+  private async readFromDisk(sourceHash: string): Promise<void> {
     try {
-      const raw = await readFile(this.persistPath, 'utf8');
+      const raw = await readFile(this.persistPath!, 'utf8');
       const data: PersistedSessionCache = JSON.parse(raw);
       if (data.sourceHash !== sourceHash) {
         return;
       }
-      this.entries.clear();
       const tuples = data.entries;
       const start = Math.max(0, tuples.length - this.maxSessions);
       for (let i = start; i < tuples.length; i++) {
         const [key, value] = tuples[i];
-        this.entries.set(key, value);
+        if (!this.entries.has(key)) {
+          this.entries.set(key, value);
+        }
       }
     } catch {
       // File missing or corrupt — start fresh

--- a/src/runtime/session-cache.ts
+++ b/src/runtime/session-cache.ts
@@ -50,6 +50,12 @@ export class SessionCache {
     }
 
     if (this.sourceHash !== undefined) {
+      // Cancel any pending flush — entries are about to be cleared so writing them
+      // under the new sourceHash would persist stale session context.
+      if (this.flushTimer) {
+        clearTimeout(this.flushTimer);
+        this.flushTimer = undefined;
+      }
       this.entries.clear();
     }
     this.sourceHash = sourceHash;
@@ -139,13 +145,21 @@ export class SessionCache {
       return;
     }
     const path = this.persistPath;
+    // Capture the hash at flush time so we can verify it hasn't changed
+    // between scheduling and the async write completing.
+    const hashAtFlush = this.sourceHash;
     const data: PersistedSessionCache = {
-      sourceHash: this.sourceHash,
+      sourceHash: hashAtFlush,
       entries: Array.from(this.entries.entries()),
     };
     const json = JSON.stringify(data);
     this.flushPromise = (this.flushPromise ?? Promise.resolve())
       .then(async () => {
+        // If the sourceHash changed while we were waiting, skip this write —
+        // the entries were captured under a potentially stale hash.
+        if (this.sourceHash !== hashAtFlush) {
+          return;
+        }
         await mkdir(dirname(path), { recursive: true });
         // Atomic write: write to temp file then rename to avoid corruption on crash
         const tmpPath = join(dirname(path), `.session-cache.tmp.${Date.now()}`);

--- a/src/runtime/session-cache.ts
+++ b/src/runtime/session-cache.ts
@@ -1,3 +1,6 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
 export interface RetrievalSessionState {
   lastNormalizedQuestion: string;
   lastSelectedNodeIds: string[];
@@ -6,10 +9,50 @@ export interface RetrievalSessionState {
   updatedAt: string;
 }
 
+interface PersistedSessionCache {
+  sourceHash: string;
+  entries: Record<string, RetrievalSessionState>;
+}
+
+export interface SessionCacheOptions {
+  maxSessions?: number;
+  persistPath?: string;
+}
+
 export class SessionCache {
   private readonly entries = new Map<string, RetrievalSessionState>();
+  private readonly maxSessions: number;
+  private readonly persistPath?: string;
+  private sourceHash?: string;
+  private flushPromise?: Promise<void>;
 
-  constructor(private readonly maxSessions = 50) {}
+  constructor(options: SessionCacheOptions = {}) {
+    this.maxSessions = options.maxSessions ?? 50;
+    this.persistPath = options.persistPath;
+  }
+
+  async load(sourceHash: string): Promise<void> {
+    this.sourceHash = sourceHash;
+    if (!this.persistPath) {
+      return;
+    }
+    try {
+      const raw = await readFile(this.persistPath, 'utf8');
+      const data: PersistedSessionCache = JSON.parse(raw);
+      if (data.sourceHash !== sourceHash) {
+        return;
+      }
+      this.entries.clear();
+      const keys = Object.keys(data.entries);
+      const start = Math.max(0, keys.length - this.maxSessions);
+      for (let i = start; i < keys.length; i++) {
+        const key = keys[i];
+        this.entries.set(key, data.entries[key]);
+      }
+    } catch {
+      // File missing or corrupt — start fresh
+    }
+  }
 
   get(sessionId: string): RetrievalSessionState | undefined {
     const value = this.entries.get(sessionId);
@@ -33,13 +76,35 @@ export class SessionCache {
       }
       this.entries.delete(oldest);
     }
+    this.scheduleFlush();
   }
 
-  summary(): { enabled: boolean; maxSessions: number; activeSessions: number } {
+  summary(): { enabled: boolean; maxSessions: number; activeSessions: number; persistent: boolean } {
     return {
       enabled: true,
       maxSessions: this.maxSessions,
       activeSessions: this.entries.size,
+      persistent: this.persistPath != null,
     };
+  }
+
+  private scheduleFlush(): void {
+    if (!this.persistPath || !this.sourceHash) {
+      return;
+    }
+    const path = this.persistPath;
+    const data: PersistedSessionCache = {
+      sourceHash: this.sourceHash,
+      entries: Object.fromEntries(this.entries),
+    };
+    const json = JSON.stringify(data, null, 2);
+    this.flushPromise = (this.flushPromise ?? Promise.resolve())
+      .then(async () => {
+        await mkdir(dirname(path), { recursive: true });
+        await writeFile(path, json, 'utf8');
+      })
+      .catch(() => {
+        // Best-effort persistence — don't crash on write failure
+      });
   }
 }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -421,6 +421,7 @@ export interface RuntimeStatus {
     enabled: boolean;
     maxSessions: number;
     activeSessions: number;
+    persistent: boolean;
   };
 }
 


### PR DESCRIPTION
## What

Add optional file-backed persistence to `SessionCache` so session context survives MCP server restarts. The in-memory LRU Map remains the hot path; persistence is write-through with debounced async flush to `<artifactDir>/session-cache.json`.

## Why

Closes #9 — The MCP stdio server is long-running and is the primary integration surface. Losing session context on restart silently degrades follow-up query quality. CLI users are unaffected (persistence defaults to off).

## Type

- [x] `feat` — new capability

## Changes

- **`src/runtime/session-cache.ts`**: Rewrote `SessionCache` to accept `SessionCacheOptions` with optional `persistPath`. Added idempotent `load(sourceHash)` that restores sessions from disk only when the snapshot edition matches — stale sessions are discarded. Write-through flush is debounced (500ms), serialized via promise chain, and uses atomic temp+rename. First disk error is logged. Concurrent load() calls are guarded via `loadPromise`. Entries persisted as ordered tuples to preserve LRU order.
- **`src/runtime/runtime.ts`**: Added `persistSessionCache` option to `FpfRuntimeOptions`. Also reads `FPF_PERSIST_SESSION_CACHE=true` env var as fallback. Calls `sessionCache.load(currentSourceHash)` at the start of `refresh()`.
- **`src/runtime/constants.ts`**: Added `SESSION_CACHE_FILENAME` constant (separate from `ARTIFACT_FILENAMES` since session cache is an optional runtime file, not a built artifact).
- **`src/runtime/types.ts`**: Added `persistent: boolean` field to `RuntimeStatus.sessionCache`.
- **`src/mcp/tool-contracts.ts`**: Updated `runtimeStatusSchema` Zod schema to include `persistent` field.

## Validation

- [x] `bun run lint` passes locally
- [x] `bun run check` passes locally
- [x] `bun run test` passes locally (pre-existing timeouts unrelated)
- [x] No new warnings introduced
- [x] Merges cleanly onto current main (post #25, #30, #35)

## Boundary check

- [x] Runtime source set is `FPF-spec.md` only — no additional corpora added
- [x] No vector database or remote indexing introduced
- [x] No Python code added
- [x] MCP tool contracts stay in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
|---------|-------|
| Agent   | Devin |
| Session | https://app.devin.ai/sessions/8fa4d238c77d45b2bfa931f5547007bc |
| Prompt  | Merger role — review PR #27, address all review comments, get merge-ready |

Requested by: @venikman
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
