### PR TITLE
feat: add public browse/search MCP discovery layer for Codex-facing workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Public tools (deployed MCP surface):
 - `ask_fpf` for markdown-first answers
 - `query_fpf_spec` for structured answer envelopes
 - `read_fpf_doc` for exact generated markdown pages
+- `get_fpf_index_status` for runtime freshness checks
 
 Expert tools (local full-surface runtime only, via `FPF_MCP_SURFACE=full bun run mcp`):
 
@@ -17,5 +18,4 @@ Expert tools (local full-surface runtime only, via `FPF_MCP_SURFACE=full bun run
 
 Admin tools (index management):
 
-- `get_fpf_index_status` for runtime freshness checks
 - `refresh_fpf_index` to rebuild the local artifact set

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,18 @@ Use the `fpf_memory` MCP server whenever the task requires grounded answers, exa
 
 Public tools (deployed MCP surface):
 
+- `browse_fpf_catalog` for task-oriented discovery by part, status, or kind
+- `search_fpf` for full-text search across compiled nodes
 - `ask_fpf` for markdown-first answers
 - `query_fpf_spec` for structured answer envelopes
-- `get_fpf_index_status` for runtime freshness checks
+- `read_fpf_doc` for exact generated markdown pages
 
 Expert tools (local full-surface runtime only, via `FPF_MCP_SURFACE=full bun run mcp`):
 
-- `read_fpf_doc` for exact generated markdown pages
-- `trace_fpf_path` for retrieval evidence and provenance
 - `inspect_fpf_node`, `inspect_fpf_anchor`, `expand_fpf_citations` for deep inspection
+- `trace_fpf_path` for retrieval evidence and provenance
+
+Admin tools (index management):
+
+- `get_fpf_index_status` for runtime freshness checks
 - `refresh_fpf_index` to rebuild the local artifact set

--- a/src/mastra/mcp/server.ts
+++ b/src/mastra/mcp/server.ts
@@ -12,6 +12,6 @@ export const fpfMemory = new MCPServer({
 export const fpfMemoryPublic = new MCPServer({
   name: 'fpf_memory',
   version: '1.0.0',
-  description: 'FPF-spec query runtime with public tool surface (ask, query, status).',
+  description: 'FPF-spec query runtime with public discovery surface (browse, search, ask, query, read).',
   tools: fpfPublicTools,
 });

--- a/src/mastra/mcp/server.ts
+++ b/src/mastra/mcp/server.ts
@@ -12,6 +12,6 @@ export const fpfMemory = new MCPServer({
 export const fpfMemoryPublic = new MCPServer({
   name: 'fpf_memory',
   version: '1.0.0',
-  description: 'FPF-spec query runtime with public discovery surface (browse, search, ask, query, read).',
+  description: 'FPF-spec query runtime with public discovery surface (browse, search, ask, query, read, status).',
   tools: fpfPublicTools,
 });

--- a/src/mcp/tool-contracts.ts
+++ b/src/mcp/tool-contracts.ts
@@ -507,6 +507,7 @@ export const browseFpfCatalogInputSchema = z
     part: z.string().optional(),
     status: z.string().optional(),
     kind: nodeKindSchema.optional(),
+    limit: z.number().int().min(1).max(500).optional(),
     forceRefresh: z.boolean().optional(),
   })
   .strict();

--- a/src/mcp/tool-contracts.ts
+++ b/src/mcp/tool-contracts.ts
@@ -485,3 +485,86 @@ export type ReadFpfDocInput = z.infer<typeof readFpfDocInputSchema>;
 export type InspectFpfAnchorInput = z.infer<typeof inspectFpfAnchorInputSchema>;
 export type ExpandFpfCitationsInput = z.infer<typeof expandFpfCitationsInputSchema>;
 export type TraceFpfPathInput = z.infer<typeof traceFpfPathInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Discovery layer schemas (browse / search)
+// ---------------------------------------------------------------------------
+
+export const catalogEntrySchema = z
+  .object({
+    id: z.string(),
+    kind: nodeKindSchema,
+    title: z.string(),
+    status: z.string().optional(),
+    part: z.string().optional(),
+    cluster: z.string().optional(),
+    description: z.string(),
+  })
+  .strict();
+
+export const browseFpfCatalogInputSchema = z
+  .object({
+    part: z.string().optional(),
+    status: z.string().optional(),
+    kind: nodeKindSchema.optional(),
+    forceRefresh: z.boolean().optional(),
+  })
+  .strict();
+
+export const browseFpfCatalogResultSchema = z
+  .object({
+    entries: z.array(catalogEntrySchema),
+    total: z.number(),
+    filters: z
+      .object({
+        part: z.string().optional(),
+        status: z.string().optional(),
+        kind: nodeKindSchema.optional(),
+      })
+      .strict(),
+    snapshot: z
+      .object({
+        sourceHash: z.string(),
+        builtAt: z.string(),
+      })
+      .strict(),
+  })
+  .strict();
+
+export const searchHitSchema = z
+  .object({
+    id: z.string(),
+    kind: nodeKindSchema,
+    title: z.string(),
+    status: z.string().optional(),
+    part: z.string().optional(),
+    score: z.number(),
+    snippet: z.string(),
+  })
+  .strict();
+
+export const searchFpfInputSchema = z
+  .object({
+    query: z.string().min(1),
+    kind: nodeKindSchema.optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+    forceRefresh: z.boolean().optional(),
+  })
+  .strict();
+
+export const searchFpfResultSchema = z
+  .object({
+    query: z.string(),
+    hits: z.array(searchHitSchema),
+    total: z.number(),
+    snapshot: z
+      .object({
+        sourceHash: z.string(),
+        builtAt: z.string(),
+      })
+      .strict(),
+  })
+  .strict();
+
+export type BrowseFpfCatalogInput = z.infer<typeof browseFpfCatalogInputSchema>;
+export type SearchFpfInput = z.infer<typeof searchFpfInputSchema>;

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -162,6 +162,7 @@ export const fpfPublicTools = {
   ask_fpf: askFpfTool,
   query_fpf_spec: queryFpfSpecTool,
   read_fpf_doc: readFpfDocTool,
+  get_fpf_index_status: getFpfIndexStatusTool,
 } as const;
 
 /** Expert/debug tools — full-surface runtime only. */
@@ -174,7 +175,6 @@ export const fpfExpertTools = {
 
 /** Admin tools — index management. */
 export const fpfAdminTools = {
-  get_fpf_index_status: getFpfIndexStatusTool,
   refresh_fpf_index: refreshFpfIndexTool,
 } as const;
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -131,11 +131,12 @@ export const browseFpfCatalogTool = createTool({
     'Browse the FPF catalog of compiled patterns, routes, and lexicon entries. Filter by part, status, or kind to discover relevant material before drilling into individual nodes.',
   inputSchema: browseFpfCatalogInputSchema,
   outputSchema: browseFpfCatalogResultSchema,
-  execute: async ({ part, status, kind, forceRefresh }) =>
+  execute: async ({ part, status, kind, limit, forceRefresh }) =>
     runtime.browse({
       part,
       status,
       kind: kind as NodeKind | undefined,
+      limit,
       forceRefresh: forceRefresh ?? false,
     }),
 });

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,10 +1,12 @@
 import { createTool } from '@mastra/core/tools';
 
 import { FpfRuntime } from '../runtime/runtime.js';
-import type { AnswerMode, AskFpfResult, QueryResult } from '../runtime/types.js';
+import type { AnswerMode, AskFpfResult, NodeKind, QueryResult } from '../runtime/types.js';
 import {
   askFpfInputSchema,
   askFpfResultSchema,
+  browseFpfCatalogInputSchema,
+  browseFpfCatalogResultSchema,
   expandCitationsResultSchema,
   expandFpfCitationsInputSchema,
   getFpfIndexStatusInputSchema,
@@ -19,6 +21,8 @@ import {
   refreshFpfIndexInputSchema,
   runtimeStatusSchema,
   buildAuditSchema,
+  searchFpfInputSchema,
+  searchFpfResultSchema,
   traceFpfPathInputSchema,
   traceResultSchema,
 } from './tool-contracts.js';
@@ -121,27 +125,63 @@ export const traceFpfPathTool = createTool({
     runtime.trace(question, mode ?? 'compact', forceRefresh ?? false, sessionId),
 });
 
+export const browseFpfCatalogTool = createTool({
+  id: 'browse_fpf_catalog',
+  description:
+    'Browse the FPF catalog of compiled patterns, routes, and lexicon entries. Filter by part, status, or kind to discover relevant material before drilling into individual nodes.',
+  inputSchema: browseFpfCatalogInputSchema,
+  outputSchema: browseFpfCatalogResultSchema,
+  execute: async ({ part, status, kind, forceRefresh }) =>
+    runtime.browse({
+      part,
+      status,
+      kind: kind as NodeKind | undefined,
+      forceRefresh: forceRefresh ?? false,
+    }),
+});
+
+export const searchFpfTool = createTool({
+  id: 'search_fpf',
+  description:
+    'Full-text search across all compiled FPF nodes. Returns ranked hits with contextual snippets. Use this to find patterns, routes, or lexicon entries by keyword or concept.',
+  inputSchema: searchFpfInputSchema,
+  outputSchema: searchFpfResultSchema,
+  execute: async ({ query, kind, limit, forceRefresh }) =>
+    runtime.search(query, {
+      kind: kind as NodeKind | undefined,
+      limit,
+      forceRefresh: forceRefresh ?? false,
+    }),
+});
+
 /** Public tools — safe for deployed MCP surface. */
 export const fpfPublicTools = {
+  browse_fpf_catalog: browseFpfCatalogTool,
+  search_fpf: searchFpfTool,
   ask_fpf: askFpfTool,
   query_fpf_spec: queryFpfSpecTool,
-  get_fpf_index_status: getFpfIndexStatusTool,
+  read_fpf_doc: readFpfDocTool,
 } as const;
 
 /** Expert/debug tools — full-surface runtime only. */
 export const fpfExpertTools = {
-  refresh_fpf_index: refreshFpfIndexTool,
-  trace_fpf_path: traceFpfPathTool,
   inspect_fpf_node: inspectFpfNodeTool,
-  read_fpf_doc: readFpfDocTool,
   inspect_fpf_anchor: inspectFpfAnchorTool,
   expand_fpf_citations: expandFpfCitationsTool,
+  trace_fpf_path: traceFpfPathTool,
+} as const;
+
+/** Admin tools — index management. */
+export const fpfAdminTools = {
+  get_fpf_index_status: getFpfIndexStatusTool,
+  refresh_fpf_index: refreshFpfIndexTool,
 } as const;
 
 /** All tools — used by the full-surface MCP runtime. */
 export const fpfMcpTools = {
   ...fpfPublicTools,
   ...fpfExpertTools,
+  ...fpfAdminTools,
 } as const;
 
 export function resolveDefaultQueryMode(env: NodeJS.ProcessEnv = process.env): AnswerMode {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -519,9 +519,12 @@ function interleaveBrowseEntries(entries: CatalogEntry[], limit: number): Catalo
     if (!added) break;
   }
 
+  // Enforce the limit — the first pass may overshoot when limit < kindCount.
+  const capped = result.slice(0, limit);
+
   // Sort the interleaved result by ID for stable output.
-  result.sort((a, b) => a.id.localeCompare(b.id));
-  return result;
+  capped.sort((a, b) => a.id.localeCompare(b.id));
+  return capped;
 }
 
 function nodeToCatalogEntry(

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -265,31 +265,29 @@ export class FpfRuntime {
   }
 
   async browse(
-    options: { part?: string; status?: string; kind?: NodeKind; forceRefresh?: boolean } = {},
+    options: { part?: string; status?: string; kind?: NodeKind; limit?: number; forceRefresh?: boolean } = {},
   ): Promise<BrowseCatalogResult> {
     await this.refresh(options.forceRefresh ?? false);
     const snapshot = await this.requireSnapshot();
 
-    let entries: CatalogEntry[] = Object.values(snapshot.compiledNodes).map((node) =>
-      nodeToCatalogEntry(node, snapshot),
-    );
+    const partLower = options.part?.toLowerCase();
+    const statusLower = options.status?.toLowerCase();
+    const limit = Math.min(options.limit ?? 200, 500);
 
-    if (options.kind) {
-      entries = entries.filter((e) => e.kind === options.kind);
-    }
-    if (options.part) {
-      const partLower = options.part.toLowerCase();
-      entries = entries.filter((e) => e.part?.toLowerCase() === partLower);
-    }
-    if (options.status) {
-      const statusLower = options.status.toLowerCase();
-      entries = entries.filter((e) => e.status?.toLowerCase() === statusLower);
-    }
+    const entries = Object.values(snapshot.compiledNodes)
+      .filter((node) => {
+        if (options.kind && node.kind !== options.kind) return false;
+        if (partLower && node.part?.toLowerCase() !== partLower) return false;
+        if (statusLower && node.status?.toLowerCase() !== statusLower) return false;
+        return true;
+      })
+      .map((node) => nodeToCatalogEntry(node, snapshot));
 
     entries.sort((a, b) => a.id.localeCompare(b.id));
+    const trimmed = entries.slice(0, limit);
 
     return {
-      entries,
+      entries: trimmed,
       total: entries.length,
       filters: {
         part: options.part,
@@ -493,21 +491,63 @@ function nodeToCatalogEntry(
 
 const SNIPPET_RADIUS = 80;
 
+function findTokenPosition(
+  searchableText: string,
+  lower: string,
+  token: string,
+): { pos: number; len: number } | undefined {
+  // Try literal substring match first.
+  const literalPos = lower.indexOf(token);
+  if (literalPos !== -1) {
+    return { pos: literalPos, len: token.length };
+  }
+
+  // For collapsed tokens (e.g. "a23" from "A.2.3"), try matching with
+  // optional non-alphanumeric separators between each character.
+  if (token.length > 0) {
+    const escaped = Array.from(token).map((c) =>
+      c.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+    );
+    const pattern = new RegExp(escaped.join('[^a-z0-9]*'), 'i');
+    const match = pattern.exec(searchableText);
+    if (match && match.index !== undefined) {
+      return { pos: match.index, len: match[0].length };
+    }
+  }
+
+  return undefined;
+}
+
 function extractSnippet(searchableText: string, queryTokens: string[]): string {
   const lower = searchableText.toLowerCase();
   let bestPos = 0;
   let bestLen = 0;
 
   for (const token of queryTokens) {
-    const pos = lower.indexOf(token);
-    if (pos !== -1 && token.length > bestLen) {
-      bestPos = pos;
-      bestLen = token.length;
+    const hit = findTokenPosition(searchableText, lower, token);
+    if (hit && token.length > bestLen) {
+      bestPos = hit.pos;
+      bestLen = hit.len;
     }
   }
 
-  const start = Math.max(0, bestPos - SNIPPET_RADIUS);
-  const end = Math.min(searchableText.length, bestPos + bestLen + SNIPPET_RADIUS);
+  let start = Math.max(0, bestPos - SNIPPET_RADIUS);
+  let end = Math.min(searchableText.length, bestPos + bestLen + SNIPPET_RADIUS);
+
+  // Snap to word boundaries to avoid cutting words in half.
+  if (start > 0) {
+    const nextSpace = searchableText.indexOf(' ', start);
+    if (nextSpace !== -1 && nextSpace < bestPos) {
+      start = nextSpace + 1;
+    }
+  }
+  if (end < searchableText.length) {
+    const prevSpace = searchableText.lastIndexOf(' ', end);
+    if (prevSpace > bestPos + bestLen) {
+      end = prevSpace;
+    }
+  }
+
   let snippet = searchableText.slice(start, end).replace(/\s+/g, ' ').trim();
   if (start > 0) {
     snippet = `…${snippet}`;

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -36,7 +36,7 @@ import type {
   Snapshot,
   TraceResult,
 } from './types.js';
-import { tokenize, scoreOverlap } from './text.js';
+import { normalizeForLookup, tokenize, scoreOverlap } from './text.js';
 import { getRuntimeObservabilitySummary } from '../observability/runtime-observability.js';
 
 export interface FpfRuntimeOptions {
@@ -284,7 +284,13 @@ export class FpfRuntime {
       .map((node) => nodeToCatalogEntry(node, snapshot));
 
     entries.sort((a, b) => a.id.localeCompare(b.id));
-    const trimmed = entries.slice(0, limit);
+
+    // When no kind filter is active, interleave kinds so the default page
+    // shows a representative mix of patterns, routes, and lexemes instead
+    // of burying routes/lexemes past the limit cutoff.
+    const trimmed = options.kind
+      ? entries.slice(0, limit)
+      : interleaveBrowseEntries(entries, limit);
 
     return {
       entries: trimmed,
@@ -330,6 +336,17 @@ export class FpfRuntime {
         score,
         snippet: extractSnippet(node.searchableText, queryTokens),
       });
+    }
+
+    // Boost exact ID and exact title matches so precise selector queries
+    // rank the target node first, ahead of broader prefix matches.
+    const normalizedQuery = normalizeForLookup(query);
+    for (const hit of hits) {
+      if (hit.id === query || normalizeForLookup(hit.id) === normalizedQuery) {
+        hit.score += 200;
+      } else if (normalizeForLookup(hit.title) === normalizedQuery) {
+        hit.score += 150;
+      }
     }
 
     hits.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
@@ -460,6 +477,51 @@ function snapshotNeedsRebuild(snapshot: Snapshot): boolean {
       typeof node.metadata.role !== 'string' ||
       typeof node.metadata.routeBearing !== 'boolean',
   );
+}
+
+/**
+ * Interleave entries by kind so the default browse page shows a
+ * representative mix of patterns, routes, and lexemes.  Each kind
+ * gets a fair share of the limit, and leftover slots are filled by
+ * whichever kinds have entries remaining.
+ */
+function interleaveBrowseEntries(entries: CatalogEntry[], limit: number): CatalogEntry[] {
+  const byKind = new Map<string, CatalogEntry[]>();
+  for (const entry of entries) {
+    const bucket = byKind.get(entry.kind) ?? [];
+    bucket.push(entry);
+    byKind.set(entry.kind, bucket);
+  }
+
+  const kinds = [...byKind.keys()].sort();
+  const perKind = Math.max(1, Math.floor(limit / kinds.length));
+  const result: CatalogEntry[] = [];
+
+  // First pass: take up to perKind from each bucket.
+  for (const kind of kinds) {
+    const bucket = byKind.get(kind)!;
+    result.push(...bucket.splice(0, perKind));
+  }
+
+  // Second pass: fill remaining slots round-robin.
+  let remaining = limit - result.length;
+  while (remaining > 0) {
+    let added = false;
+    for (const kind of kinds) {
+      if (remaining <= 0) break;
+      const bucket = byKind.get(kind)!;
+      if (bucket.length > 0) {
+        result.push(bucket.shift()!);
+        remaining -= 1;
+        added = true;
+      }
+    }
+    if (!added) break;
+  }
+
+  // Sort the interleaved result by ID for stable output.
+  result.sort((a, b) => a.id.localeCompare(b.id));
+  return result;
 }
 
 function nodeToCatalogEntry(

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -19,18 +19,24 @@ import {
 } from './session-cache.js';
 import type {
   AnswerMode,
+  BrowseCatalogResult,
   BuildAudit,
+  CatalogEntry,
   ExpandCitationsResult,
   IndexingView,
   InspectAnchorResult,
   InspectResult,
   LocalAnswerSynthesizer,
+  NodeKind,
   QueryResult,
   ReadDocResult,
   RuntimeStatus,
+  SearchHit,
+  SearchResult,
   Snapshot,
   TraceResult,
 } from './types.js';
+import { normalizeForLookup, tokenize, scoreOverlap } from './text.js';
 import { getRuntimeObservabilitySummary } from '../observability/runtime-observability.js';
 
 export interface FpfRuntimeOptions {
@@ -258,6 +264,86 @@ export class FpfRuntime {
     };
   }
 
+  async browse(
+    options: { part?: string; status?: string; kind?: NodeKind; forceRefresh?: boolean } = {},
+  ): Promise<BrowseCatalogResult> {
+    await this.refresh(options.forceRefresh ?? false);
+    const snapshot = await this.requireSnapshot();
+
+    let entries: CatalogEntry[] = Object.values(snapshot.compiledNodes).map((node) =>
+      nodeToCatalogEntry(node, snapshot),
+    );
+
+    if (options.kind) {
+      entries = entries.filter((e) => e.kind === options.kind);
+    }
+    if (options.part) {
+      const partLower = options.part.toLowerCase();
+      entries = entries.filter((e) => e.part?.toLowerCase() === partLower);
+    }
+    if (options.status) {
+      const statusLower = options.status.toLowerCase();
+      entries = entries.filter((e) => e.status?.toLowerCase() === statusLower);
+    }
+
+    entries.sort((a, b) => a.id.localeCompare(b.id));
+
+    return {
+      entries,
+      total: entries.length,
+      filters: {
+        part: options.part,
+        status: options.status,
+        kind: options.kind,
+      },
+      snapshot: { sourceHash: snapshot.sourceHash, builtAt: snapshot.builtAt },
+    };
+  }
+
+  async search(
+    query: string,
+    options: { kind?: NodeKind; limit?: number; forceRefresh?: boolean } = {},
+  ): Promise<SearchResult> {
+    await this.refresh(options.forceRefresh ?? false);
+    const snapshot = await this.requireSnapshot();
+
+    const normalizedQuery = normalizeForLookup(query);
+    const queryTokens = tokenize(normalizedQuery);
+    const limit = Math.min(options.limit ?? 20, 100);
+
+    const hits: SearchHit[] = [];
+    for (const node of Object.values(snapshot.compiledNodes)) {
+      if (options.kind && node.kind !== options.kind) {
+        continue;
+      }
+
+      const score = scoreOverlap(queryTokens, node.searchableText);
+      if (score <= 0) {
+        continue;
+      }
+
+      hits.push({
+        id: node.id,
+        kind: node.kind,
+        title: node.title,
+        status: node.status,
+        part: node.part,
+        score,
+        snippet: extractSnippet(node.searchableText, queryTokens),
+      });
+    }
+
+    hits.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+    const trimmed = hits.slice(0, limit);
+
+    return {
+      query,
+      hits: trimmed,
+      total: hits.length,
+      snapshot: { sourceHash: snapshot.sourceHash, builtAt: snapshot.builtAt },
+    };
+  }
+
   private persistSession(sessionId: string | undefined, trace: TraceResult): void {
     if (!sessionId) {
       return;
@@ -375,4 +461,59 @@ function snapshotNeedsRebuild(snapshot: Snapshot): boolean {
       typeof node.metadata.role !== 'string' ||
       typeof node.metadata.routeBearing !== 'boolean',
   );
+}
+
+function nodeToCatalogEntry(
+  node: import('./types.js').CompiledNode,
+  snapshot: Snapshot,
+): CatalogEntry {
+  let description = '';
+  if (node.kind === 'pattern') {
+    const pattern = snapshot.patternGraph.nodes[node.id];
+    description = pattern?.description ?? node.title;
+  } else if (node.kind === 'route') {
+    const route = snapshot.routeGraph.nodes[node.id];
+    description = route?.description ?? node.title;
+  } else if (node.kind === 'lexeme') {
+    const entry = snapshot.lexicon[node.id];
+    description = entry
+      ? `Lexicon: ${entry.canonical}${entry.aliases.length > 0 ? ` (${entry.aliases.join(', ')})` : ''}`
+      : node.title;
+  }
+  return {
+    id: node.id,
+    kind: node.kind,
+    title: node.title,
+    status: node.status,
+    part: node.part,
+    cluster: node.cluster,
+    description,
+  };
+}
+
+const SNIPPET_RADIUS = 80;
+
+function extractSnippet(searchableText: string, queryTokens: string[]): string {
+  const lower = searchableText.toLowerCase();
+  let bestPos = 0;
+  let bestLen = 0;
+
+  for (const token of queryTokens) {
+    const pos = lower.indexOf(token);
+    if (pos !== -1 && token.length > bestLen) {
+      bestPos = pos;
+      bestLen = token.length;
+    }
+  }
+
+  const start = Math.max(0, bestPos - SNIPPET_RADIUS);
+  const end = Math.min(searchableText.length, bestPos + bestLen + SNIPPET_RADIUS);
+  let snippet = searchableText.slice(start, end).replace(/\s+/g, ' ').trim();
+  if (start > 0) {
+    snippet = `…${snippet}`;
+  }
+  if (end < searchableText.length) {
+    snippet = `${snippet}…`;
+  }
+  return snippet;
 }

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -36,7 +36,7 @@ import type {
   Snapshot,
   TraceResult,
 } from './types.js';
-import { normalizeForLookup, tokenize, scoreOverlap } from './text.js';
+import { tokenize, scoreOverlap } from './text.js';
 import { getRuntimeObservabilitySummary } from '../observability/runtime-observability.js';
 
 export interface FpfRuntimeOptions {
@@ -305,8 +305,9 @@ export class FpfRuntime {
     await this.refresh(options.forceRefresh ?? false);
     const snapshot = await this.requireSnapshot();
 
-    const normalizedQuery = normalizeForLookup(query);
-    const queryTokens = tokenize(normalizedQuery);
+    // Tokenize the raw query first so camelCase splits (e.g. BoundedContext →
+    // bounded + context) are preserved; tokenize() handles lowercasing internally.
+    const queryTokens = tokenize(query);
     const limit = Math.min(options.limit ?? 20, 100);
 
     const hits: SearchHit[] = [];
@@ -522,12 +523,14 @@ function extractSnippet(searchableText: string, queryTokens: string[]): string {
   const lower = searchableText.toLowerCase();
   let bestPos = 0;
   let bestLen = 0;
+  let bestTokenLen = 0;
 
   for (const token of queryTokens) {
     const hit = findTokenPosition(searchableText, lower, token);
-    if (hit && token.length > bestLen) {
+    if (hit && token.length > bestTokenLen) {
       bestPos = hit.pos;
       bestLen = hit.len;
+      bestTokenLen = token.length;
     }
   }
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -545,3 +545,51 @@ export interface LocalAnswerSynthesizer {
   ): Promise<AnswerSynthesizerOutput> | AnswerSynthesizerOutput;
   describe?(): LocalAnswerSynthesizerInfo;
 }
+
+// ---------------------------------------------------------------------------
+// Discovery layer types (browse / search)
+// ---------------------------------------------------------------------------
+
+export interface CatalogEntry {
+  id: string;
+  kind: NodeKind;
+  title: string;
+  status?: string;
+  part?: string;
+  cluster?: string;
+  description: string;
+}
+
+export interface BrowseCatalogResult {
+  entries: CatalogEntry[];
+  total: number;
+  filters: {
+    part?: string;
+    status?: string;
+    kind?: NodeKind;
+  };
+  snapshot: {
+    sourceHash: string;
+    builtAt: string;
+  };
+}
+
+export interface SearchHit {
+  id: string;
+  kind: NodeKind;
+  title: string;
+  status?: string;
+  part?: string;
+  score: number;
+  snippet: string;
+}
+
+export interface SearchResult {
+  query: string;
+  hits: SearchHit[];
+  total: number;
+  snapshot: {
+    sourceHash: string;
+    builtAt: string;
+  };
+}

--- a/tests/discovery-layer.test.ts
+++ b/tests/discovery-layer.test.ts
@@ -1,0 +1,156 @@
+import { copyFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from '@rstest/core';
+
+import { FpfRuntime } from '../src/runtime/runtime.js';
+
+/**
+ * Tests for the browse / search discovery layer.
+ *
+ * Verifies filtering, ordering, limits, search scoring, snippet output,
+ * and snapshot metadata for the two new public tools.
+ */
+
+describe('Discovery layer', () => {
+  const canonicalSourcePath = resolve(process.cwd(), 'FPF-spec.md');
+  let tempRoot: string;
+  let sourcePath: string;
+  let artifactDir: string;
+  let runtime: FpfRuntime;
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(resolve(tmpdir(), 'fpf-discovery-'));
+    artifactDir = resolve(tempRoot, 'artifacts');
+    sourcePath = resolve(tempRoot, 'FPF-spec.md');
+    await copyFile(canonicalSourcePath, sourcePath);
+    runtime = new FpfRuntime({ sourcePath, artifactDir });
+  });
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  // -----------------------------------------------------------------------
+  // browse()
+  // -----------------------------------------------------------------------
+
+  describe('browse()', () => {
+    it('returns entries when no filters are applied', async () => {
+      const result = await runtime.browse();
+      expect(result.entries.length).toBeGreaterThan(0);
+      // total reflects all matching entries; entries may be capped by default limit
+      expect(result.total).toBeGreaterThanOrEqual(result.entries.length);
+      expect(result.snapshot.sourceHash).toBeTruthy();
+      expect(result.snapshot.builtAt).toBeTruthy();
+    });
+
+    it('returns entries sorted by id', async () => {
+      const result = await runtime.browse();
+      const ids = result.entries.map((e) => e.id);
+      const sorted = [...ids].sort((a, b) => a.localeCompare(b));
+      expect(ids).toEqual(sorted);
+    });
+
+    it('filters by kind', async () => {
+      const patterns = await runtime.browse({ kind: 'pattern' });
+      const routes = await runtime.browse({ kind: 'route' });
+
+      expect(patterns.entries.length).toBeGreaterThan(0);
+      expect(routes.entries.length).toBeGreaterThan(0);
+      expect(patterns.entries.every((e) => e.kind === 'pattern')).toBe(true);
+      expect(routes.entries.every((e) => e.kind === 'route')).toBe(true);
+      expect(patterns.filters.kind).toBe('pattern');
+    });
+
+    it('filters by part (case-insensitive)', async () => {
+      // First discover an actual part value from the data.
+      const all = await runtime.browse({ limit: 500 });
+      const withPart = all.entries.find((e) => e.part);
+      expect(withPart).toBeDefined();
+
+      const partValue = withPart!.part!;
+      const filtered = await runtime.browse({ part: partValue, limit: 500 });
+      const filteredLower = await runtime.browse({ part: partValue.toLowerCase(), limit: 500 });
+
+      expect(filtered.entries.length).toBeGreaterThan(0);
+      expect(filtered.total).toBeLessThan(all.total);
+      expect(filtered.entries.every((e) => e.part?.toLowerCase() === partValue.toLowerCase())).toBe(true);
+      expect(filtered.entries.length).toBe(filteredLower.entries.length);
+    });
+
+    it('respects the limit parameter', async () => {
+      const limited = await runtime.browse({ limit: 3 });
+      expect(limited.entries.length).toBe(3);
+      expect(limited.total).toBeGreaterThan(3);
+    });
+
+    it('includes description for each entry', async () => {
+      const result = await runtime.browse({ limit: 10 });
+      for (const entry of result.entries) {
+        expect(typeof entry.description).toBe('string');
+        expect(entry.description.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // search()
+  // -----------------------------------------------------------------------
+
+  describe('search()', () => {
+    it('returns ranked hits for a known term', async () => {
+      const result = await runtime.search('bounded context');
+      expect(result.hits.length).toBeGreaterThan(0);
+      expect(result.query).toBe('bounded context');
+      expect(result.snapshot.sourceHash).toBeTruthy();
+    });
+
+    it('returns hits sorted by descending score', async () => {
+      const result = await runtime.search('pattern');
+      const scores = result.hits.map((h) => h.score);
+      for (let i = 1; i < scores.length; i++) {
+        expect(scores[i]).toBeLessThanOrEqual(scores[i - 1]);
+      }
+    });
+
+    it('includes non-empty snippets in hits', async () => {
+      const result = await runtime.search('holon');
+      expect(result.hits.length).toBeGreaterThan(0);
+      for (const hit of result.hits) {
+        expect(typeof hit.snippet).toBe('string');
+        expect(hit.snippet.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('filters search results by kind', async () => {
+      const all = await runtime.search('pattern');
+      const routesOnly = await runtime.search('pattern', { kind: 'route' });
+
+      expect(routesOnly.hits.every((h) => h.kind === 'route')).toBe(true);
+      expect(all.total).toBeGreaterThanOrEqual(routesOnly.total);
+    });
+
+    it('respects the limit parameter', async () => {
+      const result = await runtime.search('pattern', { limit: 2 });
+      expect(result.hits.length).toBeLessThanOrEqual(2);
+    });
+
+    it('returns zero hits for nonsense query', async () => {
+      const result = await runtime.search('xyzzy_nonexistent_term_12345');
+      expect(result.hits.length).toBe(0);
+      expect(result.total).toBe(0);
+    });
+
+    it('centers snippet on matched term for dotted IDs', async () => {
+      const result = await runtime.search('A.1.1');
+      const hit = result.hits.find((h) => h.id === 'A.1.1');
+      if (hit) {
+        // The snippet should contain the ID or related text, not default
+        // to the beginning of the node.
+        expect(hit.snippet.toLowerCase()).toMatch(/a\.1\.1|boundedcontext|semantic/i);
+      }
+    });
+  });
+});

--- a/tests/discovery-layer.test.ts
+++ b/tests/discovery-layer.test.ts
@@ -138,7 +138,7 @@ describe('Discovery layer', () => {
     });
 
     it('returns zero hits for nonsense query', async () => {
-      const result = await runtime.search('xyzzy_nonexistent_term_12345');
+      const result = await runtime.search('zqqxvwjkf');
       expect(result.hits.length).toBe(0);
       expect(result.total).toBe(0);
     });

--- a/tests/discovery-layer.test.ts
+++ b/tests/discovery-layer.test.ts
@@ -86,6 +86,15 @@ describe('Discovery layer', () => {
       expect(limited.total).toBeGreaterThan(3);
     });
 
+    it('includes all kinds in default unfiltered page', async () => {
+      const result = await runtime.browse();
+      const kinds = new Set(result.entries.map((e) => e.kind));
+      // Default browse page must include routes and lexemes, not just patterns.
+      expect(kinds.has('pattern')).toBe(true);
+      expect(kinds.has('route')).toBe(true);
+      expect(kinds.has('lexeme')).toBe(true);
+    });
+
     it('includes description for each entry', async () => {
       const result = await runtime.browse({ limit: 10 });
       for (const entry of result.entries) {
@@ -151,6 +160,12 @@ describe('Discovery layer', () => {
         // to the beginning of the node.
         expect(hit.snippet.toLowerCase()).toMatch(/a\.1\.1|boundedcontext|semantic/i);
       }
+    });
+
+    it('ranks exact ID match first when searching by node ID', async () => {
+      const result = await runtime.search('A.1.1');
+      expect(result.hits.length).toBeGreaterThan(0);
+      expect(result.hits[0]!.id).toBe('A.1.1');
     });
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -195,11 +195,11 @@ describe('Mastra MCP server', () => {
       'ask_fpf',
       'query_fpf_spec',
       'read_fpf_doc',
+      'get_fpf_index_status',
       'inspect_fpf_node',
       'inspect_fpf_anchor',
       'expand_fpf_citations',
       'trace_fpf_path',
-      'get_fpf_index_status',
       'refresh_fpf_index',
     ]);
 
@@ -284,6 +284,7 @@ describe('Mastra MCP server', () => {
       'ask_fpf',
       'query_fpf_spec',
       'read_fpf_doc',
+      'get_fpf_index_status',
     ]);
   });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -190,15 +190,17 @@ describe('Mastra MCP server', () => {
     }>;
 
     expect(tools.map((tool) => tool.name)).toEqual([
+      'browse_fpf_catalog',
+      'search_fpf',
       'ask_fpf',
       'query_fpf_spec',
-      'get_fpf_index_status',
-      'refresh_fpf_index',
-      'trace_fpf_path',
-      'inspect_fpf_node',
       'read_fpf_doc',
+      'inspect_fpf_node',
       'inspect_fpf_anchor',
       'expand_fpf_citations',
+      'trace_fpf_path',
+      'get_fpf_index_status',
+      'refresh_fpf_index',
     ]);
 
     for (const tool of tools) {
@@ -277,9 +279,11 @@ describe('Mastra MCP server', () => {
     const toolsList = await harness.request('tools/list');
     const tools = (toolsList.result?.tools ?? []) as Array<{ name: string }>;
     expect(tools.map((tool) => tool.name)).toEqual([
+      'browse_fpf_catalog',
+      'search_fpf',
       'ask_fpf',
       'query_fpf_spec',
-      'get_fpf_index_status',
+      'read_fpf_doc',
     ]);
   });
 


### PR DESCRIPTION
## What

Add a public MCP discovery layer with `browse_fpf_catalog` and `search_fpf` tools, giving agent operators a task-oriented entry path to the spec before drilling into individual nodes.

Closes #15

## Why

The current MCP surface is strong on answers, tracing, and raw evidence but lacks first-pass discovery for agent operators. Today the default interaction is selector- and debug-oriented. Per issue #15 and FPF grounding (E.14, A.2.3, E.10.D2, A.6.3), agents need an obvious entry path → task-shaped discovery → source opening workflow, with debug/tracing separated from default use.

## Type

- [x] `feat` — new capability
- [x] `fix` — bug fix
- [ ] `refactor` — code restructuring
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance (deps, CI, cleanup)

## Changes

- **`src/runtime/types.ts`** — Add `CatalogEntry`, `BrowseCatalogResult`, `SearchHit`, `SearchResult` interfaces for the discovery layer
- **`src/runtime/runtime.ts`** — Add `browse()` and `search()` methods to `FpfRuntime`:
  - `browse()`: Lists compiled nodes with optional `part`/`status`/`kind` filters, sorted by ID
  - **[NEW]** Default browse page now **interleaves kinds** (patterns/routes/lexemes) so all kinds are visible within the 200-entry cap, instead of burying routes/lexemes past the limit
  - `search()`: Full-text search using existing `scoreOverlap`/`tokenize` infrastructure, returns ranked hits with contextual snippets
  - **[NEW]** Exact ID matches get +200 boost, exact title matches get +150, so `search('A.1.1')` returns `A.1.1` first (not `A.1`)
  - Helper functions: `nodeToCatalogEntry()`, `extractSnippet()`, `interleaveBrowseEntries()`
- **`src/mcp/tool-contracts.ts`** — Add Zod schemas for browse/search inputs and results
- **`src/mcp/tools.ts`** — Add `browseFpfCatalogTool` and `searchFpfTool` definitions; reorganize tool families:
  - **Public**: `browse_fpf_catalog`, `search_fpf`, `ask_fpf`, `query_fpf_spec`, `read_fpf_doc`, `get_fpf_index_status`
  - **Expert**: `inspect_fpf_node`, `inspect_fpf_anchor`, `expand_fpf_citations`, `trace_fpf_path`
  - **Admin**: `refresh_fpf_index`
- **`src/mastra/mcp/server.ts`** — Update public surface description
- **`tests/mcp-server.test.ts`** — Update tool list expectations
- **`tests/discovery-layer.test.ts`** — Discovery layer tests + two new tests:
  - `'includes all kinds in default unfiltered page'` — asserts patterns, routes, and lexemes all present
  - `'ranks exact ID match first when searching by node ID'` — asserts A.1.1 is top hit

## Validation

- [x] `bun run lint` passes locally
- [x] `bun run check` passes locally
- [x] `bun run test` passes locally
- [x] No new warnings introduced
- [x] `bun run build` succeeds (if runtime/server code touched)
- [ ] `bun run docs:build` succeeds (if docs touched)
- [ ] Relevant docs updated (README, docs/, inline JSDoc if applicable)

## Boundary check

- [x] Runtime source set is `FPF-spec.md` only — no additional corpora added
- [x] No vector database or remote indexing introduced
- [x] No Python code added
- [x] MCP tool contracts stay in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
|---------|-------|
| Agent   | Devin |
| Session | https://app.devin.ai/sessions/8fa4d238c77d45b2bfa931f5547007bc |
| Prompt  | Merger: address venikman's P2 findings on #33 (browse kind interleaving + exact-ID search boost) |

Requested by: @venikman