### PR TITLE
chore: add required measurable impact verification to issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -71,6 +71,21 @@ body:
       required: false
 
   - type: textarea
+    id: impact
+    attributes:
+      label: Measurable impact verification
+      description: |
+        How will we verify the fix works and measure its impact? Provide a table with concrete metrics.
+        Every metric must be quantifiable — no vague criteria like "works better" or "improved".
+      placeholder: |
+        | Metric | Before (broken) | After (target) | How to measure |
+        |--------|-----------------|----------------|----------------|
+        | Error on query X | throws TypeError | returns valid answer | `bun run cli -- query --question "X"` |
+        | Test pass rate | 38/39 (1 failure) | 39/39 | `bun run test` |
+    validations:
+      required: true
+
+  - type: textarea
     id: context
     attributes:
       label: Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -51,8 +51,8 @@ body:
       placeholder: |
         | Metric | Before | After (target) | How to measure |
         |--------|--------|----------------|----------------|
-        | New MCP tools available | 0 | 2 | `grep -c createTool src/mcp/tools.ts` |
-        | Test coverage for feature | 0 tests | ≥5 tests | `bun run test` |
+        | Total MCP tool definitions | 10 | 12 | `grep -c createTool src/mcp/tools.ts` |
+        | Feature test cases added | 0 | ≥5 | `grep -Ec '\b(it|test)\(' tests/feature.test.ts` |
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -42,6 +42,21 @@ body:
       required: true
 
   - type: textarea
+    id: impact
+    attributes:
+      label: Measurable impact verification
+      description: |
+        How will we verify the feature works and measure its impact? Provide a table with concrete metrics.
+        Every metric must be quantifiable — no vague criteria like "works better" or "improved".
+      placeholder: |
+        | Metric | Before | After (target) | How to measure |
+        |--------|--------|----------------|----------------|
+        | New MCP tools available | 0 | 2 | `grep -c createTool src/mcp/tools.ts` |
+        | Test coverage for feature | 0 tests | ≥5 tests | `bun run test` |
+    validations:
+      required: true
+
+  - type: textarea
     id: alternatives
     attributes:
       label: Alternatives considered

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -59,6 +59,21 @@ body:
     validations:
       required: false
 
+  - type: textarea
+    id: impact
+    attributes:
+      label: Measurable impact verification
+      description: |
+        How will we verify the task is complete and measure its impact? Provide a table with concrete metrics.
+        Every metric must be quantifiable — no vague criteria like "works better" or "improved".
+      placeholder: |
+        | Metric | Before | After (target) | How to measure |
+        |--------|--------|----------------|----------------|
+        | LOC in target file | 1614 | ≤400 | `wc -l src/runtime/target.ts` |
+        | Existing test pass rate | all pass | all pass | `bun run test` |
+    validations:
+      required: true
+
   - type: dropdown
     id: agent_delegable
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,15 @@
 
 <!-- Key changes, one bullet per logical unit -->
 
+## Measurable impact verification
+
+<!-- Required. Provide a table showing before/after metrics that prove this PR's impact.
+     Every metric must be quantifiable — no vague criteria like "works better" or "improved". -->
+
+| Metric | Before | After (target) | How to measure |
+|--------|--------|----------------|----------------|
+| <!-- e.g. LOC in target file --> | <!-- e.g. 1614 --> | <!-- e.g. ≤400 --> | <!-- e.g. `wc -l src/runtime/target.ts` --> |
+
 ## Validation
 
 - [ ] `bun run lint` passes locally


### PR DESCRIPTION
## What

Adds a required "Measurable impact verification" field to all three issue templates (bug report, feature request, task) and adds a corresponding section to the PR template. Also fixes incorrect measurement commands in 4 existing open issues (#2, #4, #5, #15).

## Why

Every issue and PR should have quantifiable, verifiable impact metrics — no vague criteria like "works better" or "improved". This enforces a before/after table with concrete metrics and runnable measurement commands.

## Type

- [ ] `feat` — new capability
- [ ] `fix` — bug fix
- [ ] `refactor` — code restructuring
- [ ] `docs` — documentation only
- [x] `chore` — maintenance (deps, CI, cleanup)

## Changes

- **`bug_report.yml`**: Added required `Measurable impact verification` textarea with before/after table placeholder
- **`feature_request.yml`**: Added required `Measurable impact verification` textarea with before/after table placeholder
- **`task.yml`**: Added required `Measurable impact verification` textarea (placed before Agent-delegable dropdown)
- **`pull_request_template.md`**: Added `Measurable impact verification` section between Changes and Validation

**Issue body fixes (via `gh issue edit`):**
- **#2**: Updated "Typed stage interfaces" Before from 0→3 (reflects post-compiler-split state); fixed grep to aggregate per-file counts
- **#4**: Fixed grep patterns — source uses single quotes (`'C.17'`), not double quotes; old commands returned 0 false negatives
- **#5**: Fixed `relationGraph.filter` grep (code uses `for...of`, not `.filter()`)
- **#15**: Fixed `grep -Ec 'browse|search'` (matched `searchableText` false positive) → now uses exact schema names

## Measurable impact verification

| Metric | Before | After (target) | How to measure |
|--------|--------|----------------|----------------|
| Issue templates with required impact field | 0/3 | 3/3 | `grep -c 'required: true' .github/ISSUE_TEMPLATE/*.yml` (impact fields only) |
| PR template has impact section | No | Yes | `grep -c 'Measurable impact verification' .github/pull_request_template.md` |
| Issue #4 hard-coded ID grep returns correct Before value | 0 (wrong) | 6 (correct) | `grep -Ec "'C\.[0-9]\|'A\.[0-9]\|'B\.[0-9]\|'F\.[0-9]" src/runtime/query-engine.ts` |
| Issue #5 relationGraph grep returns correct Before value | 0 (wrong) | 1 (correct) | `grep -c 'for.*of.*\.relationGraph' src/runtime/query-engine.ts` |

## Validation

- [x] `bun run lint` passes locally
- [x] `bun run check` passes locally
- [x] `bun run test` passes locally
- [x] No new warnings introduced
- [ ] `bun run build` succeeds (if runtime/server code touched)
- [ ] `bun run docs:build` succeeds (if docs touched)
- [x] Relevant docs updated (README, docs/, inline JSDoc if applicable)

## Boundary check

- [x] Runtime source set is `FPF-spec.md` only — no additional corpora added
- [x] No vector database or remote indexing introduced
- [x] No Python code added
- [x] MCP tool contracts stay in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
|---------|-------|
| Agent   | Devin |
| Session | https://app.devin.ai/sessions/f9b77396c94f4a03971ac0c8cbe5f8b7 |
| Prompt  | Update issue templates with required measurable impact verification; fix incorrect measurement commands in open issues |

Requested by: @venikman
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added required "Measurable impact verification" sections to contribution templates, requiring contributors to include quantifiable before/after metrics and how to measure them for bug reports, feature requests, tasks, and pull requests.

* **Documentation**
  * Standardized instructions and example table to guide submission of measurable impact details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->