### PR TITLE
Simplify runtime refresh and sync MCP docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ Recommended Codex tasks:
 
 - answer a question: `Use only the fpf_memory MCP server. Call ask_fpf with question: "What is U.PromiseContent?"`
 - structured query: `Use only the fpf_memory MCP server. Call query_fpf_spec with question: "What is an FPF pattern?"`
+- read a generated page: `Use only the fpf_memory MCP server. Call read_fpf_doc with selector: "A.1.1"`
 - check runtime freshness: `Use only the fpf_memory MCP server. Call get_fpf_index_status`
 
 Expert tasks (local full-surface runtime only):
 
-- read a generated page: `Use only the fpf_memory MCP server. Call read_fpf_doc with selector: "A.1.1"`
 - inspect retrieval evidence: `Use only the fpf_memory MCP server. Call trace_fpf_path with question: "How do U.RoleAssignment and U.BoundedContext connect?"`
 - rebuild the local index: `Use only the fpf_memory MCP server. Call refresh_fpf_index`
 
@@ -181,7 +181,7 @@ The verification script also checks the direct stdio launcher (same entry as `bu
 FPF_MCP_SURFACE=full bun src/mastra/stdio.ts
 ```
 
-This starts a long-running stdio server; for a manual smoke check, stop it with `Ctrl+C` after startup confirmation. Omit `FPF_MCP_SURFACE=full` if you only want the public 3-tool surface.
+This starts a long-running stdio server; for a manual smoke check, stop it with `Ctrl+C` after startup confirmation. Omit `FPF_MCP_SURFACE=full` if you only want the public surface.
 
 If this repo is registered as a Codex MCP server, restart Codex after changes and then test with a forced tool-use prompt such as:
 
@@ -241,20 +241,11 @@ Call trace_fpf_path with:
 
 ### Public tools (default surface)
 
-- `ask_fpf`: return the grounded answer as markdown with IDs, citations, constraints, gaps, and snapshot metadata
-- `query_fpf_spec`: return the answer envelope with IDs, citations, constraints, and freshness metadata
-- `get_fpf_index_status`: inspect runtime freshness, artifact presence, and runtime configuration
+`browse_fpf_catalog`, `search_fpf`, `ask_fpf`, `query_fpf_spec`, `read_fpf_doc`, and `get_fpf_index_status`.
 
-### Expert tools (local full-surface runtime only)
+### Full-surface-only tools
 
-Set `FPF_MCP_SURFACE=full` on local stdio or local HTTP runtimes to expose these tools. The deployed server stays on the public 3-tool surface.
-
-- `refresh_fpf_index`: rebuild the local artifact set
-- `trace_fpf_path`: return deterministic retrieval evidence only
-- `inspect_fpf_node`: expand one node into its anchors, neighboring relations, and stable doc references
-- `read_fpf_doc`: return the canonical generated markdown page plus stable markdown/static paths
-- `inspect_fpf_anchor`: expand one anchor into raw anchor text plus owning node context
-- `expand_fpf_citations`: expand multiple citations into raw anchor text plus owning node context
+Set `FPF_MCP_SURFACE=full` on local stdio or local HTTP runtimes to expose `inspect_fpf_node`, `inspect_fpf_anchor`, `expand_fpf_citations`, `trace_fpf_path`, and `refresh_fpf_index`.
 
 Only `query_fpf_spec` and `ask_fpf` can use the optional synthesizer. All other MCP tools stay deterministic. Set `FPF_MCP_SURFACE=public` on the deployed server to restrict it to public tools only.
 

--- a/docs/mcp-interface.md
+++ b/docs/mcp-interface.md
@@ -26,7 +26,7 @@ The runtime itself is compiler-backed and local to `FPF-spec.md`:
 - server name: `fpf_memory`
 - protocol version: `2024-11-05`
 
-The hosted server exposes only the 3 public tools. Local stdio and local HTTP default to the same public surface; set `FPF_MCP_SURFACE=full` to expose all 9 tools for local expert work.
+The hosted server exposes only the public tool surface. Local stdio and local HTTP default to the same public surface; set `FPF_MCP_SURFACE=full` to expose the full tool set for local expert work.
 
 ## Codex Setup
 
@@ -45,43 +45,11 @@ For temporary local expert work, point a client at `src/mastra/stdio.ts` and set
 
 ### Public tools (hosted default surface)
 
-#### `ask_fpf`
+`browse_fpf_catalog`, `search_fpf`, `ask_fpf`, `query_fpf_spec`, `read_fpf_doc`, and `get_fpf_index_status`.
 
-Return a markdown-first grounded answer envelope over the same runtime.
+### Full-surface-only tools
 
-#### `query_fpf_spec`
-
-Answer a question with deterministic grounding, citations, constraints, and freshness metadata.
-
-#### `get_fpf_index_status`
-
-Report whether the current runtime index exists, whether it is fresh against the current source hash, and which artifacts are present.
-
-### Expert tools (local full-surface runtime only)
-
-#### `refresh_fpf_index`
-
-Build or rebuild the compiler-backed vectorless index from `FPF-spec.md` and persist the runtime artifact set under `.runtime/fpf-index/`.
-
-#### `trace_fpf_path`
-
-Return the retrieval trace used for a question, including candidate scores, graph expansion, and selected anchors.
-
-#### `inspect_fpf_node`
-
-Inspect one pattern, route, or lexeme and return anchors, neighboring relations, and stable document references.
-
-#### `read_fpf_doc`
-
-Resolve a pattern, route, or lexeme to the canonical generated markdown page and return the selected document node, stable paths, and exact generated markdown text.
-
-#### `inspect_fpf_anchor`
-
-Inspect one exact anchor ID and return raw anchor text plus owning-node context.
-
-#### `expand_fpf_citations`
-
-Expand multiple citation IDs into raw anchor text plus owning-node context without adding new semantics.
+`inspect_fpf_node`, `inspect_fpf_anchor`, `expand_fpf_citations`, `trace_fpf_path`, and `refresh_fpf_index`.
 
 ## Direct Document Contract
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   ],
   "scripts": {
     "dev": "bun --watch src/server.ts",
-    "build": "bun build ./src/cli.ts ./src/server.ts --outdir dist --target bun",
-    "build:mcp": "tsup src/mastra/stdio.ts --format esm,cjs --out-dir dist --no-splitting && node -e \"const fs=require('node:fs');const path='dist/stdio.js';const data=fs.readFileSync(path,'utf8');const shebang='#!/usr/bin/env node';if(!data.startsWith(shebang))fs.writeFileSync(path, shebang + '\\\\n' + data);\" && chmod +x dist/stdio.js",
+    "build": "bun build ./src/cli.ts ./src/server.ts --outdir dist --target bun && bun run build:mcp",
+    "build:mcp": "tsup src/mastra/stdio.ts --format esm --out-dir dist --no-splitting && node -e \"const fs=require('node:fs');const path='dist/stdio.js';const data=fs.readFileSync(path,'utf8');const shebang='#!/usr/bin/env node';if(!data.startsWith(shebang))fs.writeFileSync(path, shebang + '\\\\n' + data);\" && chmod +x dist/stdio.js",
     "start": "bun src/server.ts",
     "predeploy": "bash scripts/prepare-deploy.sh",
     "deploy": "bun run predeploy && npx mastra build && npx mastra server deploy",

--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -23,6 +23,6 @@ export function createMastraRuntime(env: NodeJS.ProcessEnv = process.env) {
 
 /**
  * Direct Mastra instance export required by `mastra build` / `mastra deploy`.
- * Deployed server sets FPF_MCP_SURFACE=public to restrict to 3 public tools.
+ * Deployed server sets FPF_MCP_SURFACE=public to restrict to the public tool surface.
  */
 export const mastra = createMastraRuntime();

--- a/src/runtime/query-engine.ts
+++ b/src/runtime/query-engine.ts
@@ -232,50 +232,21 @@ export class QueryEngine {
   inspect(selector: string, kind: 'auto' | 'id' | 'route' | 'lexeme' = 'auto'): InspectResult {
     const resolvedId = this.resolveSelector(selector, kind);
     if (!resolvedId) {
-      return {
-        selector,
-        resolvedAs: 'not_found',
-        status: 'not_found',
-        anchors: [],
-        neighbors: [],
-        snapshot: {
-          sourceHash: this.snapshot.sourceHash,
-          builtAt: this.snapshot.builtAt,
-        },
-      };
+      return this.notFoundInspect(selector);
     }
 
     const node = this.snapshot.compiledNodes[resolvedId];
-    const anchors = (node.anchorIds ?? [])
-      .map((anchorId) => this.snapshot.anchorMap[anchorId])
-      .filter((anchor): anchor is Snapshot['anchorMap'][string] => Boolean(anchor));
-    const neighbors = node.neighborEdges
-      .map((edge): InspectNeighbor | undefined => {
-        const target = this.snapshot.compiledNodes[edge.to];
-        if (!target) {
-          return undefined;
-        }
-        return {
-          id: target.id,
-          kind: target.kind,
-          title: target.title,
-          relation: edge.relation,
-        };
-      })
-      .filter((neighbor): neighbor is InspectNeighbor => Boolean(neighbor));
-
     return {
       selector,
-      resolvedAs: node.kind === 'route' ? 'route' : node.kind === 'lexeme' ? 'lexeme' : 'id',
+      resolvedAs: this.resolvedAsForNode(node),
       status: 'ok',
       node,
-      anchors,
-      neighbors,
+      anchors: (node.anchorIds ?? [])
+        .map((anchorId) => this.snapshot.anchorMap[anchorId])
+        .filter((anchor): anchor is Snapshot['anchorMap'][string] => Boolean(anchor)),
+      neighbors: this.neighborsForNode(node),
       docRef: resolveDocTarget(this.snapshot, node.id)?.docRef,
-      snapshot: {
-        sourceHash: this.snapshot.sourceHash,
-        builtAt: this.snapshot.builtAt,
-      },
+      snapshot: this.snapshotRef(),
     };
   }
 
@@ -285,84 +256,32 @@ export class QueryEngine {
   ): ReadDocResult {
     const resolvedNodeId = this.resolveSelector(selector, kind);
     if (!resolvedNodeId) {
-      return {
-        selector,
-        resolvedAs: 'not_found',
-        status: 'not_found',
-        snapshot: {
-          sourceHash: this.snapshot.sourceHash,
-          builtAt: this.snapshot.builtAt,
-        },
-      };
+      return this.notFoundReadDoc(selector);
     }
 
     const resolvedNode = this.snapshot.compiledNodes[resolvedNodeId];
     if (!resolvedNode) {
-      return {
-        selector,
-        resolvedAs: 'not_found',
-        status: 'not_found',
-        snapshot: {
-          sourceHash: this.snapshot.sourceHash,
-          builtAt: this.snapshot.builtAt,
-        },
-      };
+      return this.notFoundReadDoc(selector);
     }
 
+    const resolvedAs = this.resolvedAsForNode(resolvedNode);
     const docTarget = resolveDocTarget(this.snapshot, resolvedNodeId);
-    if (!docTarget) {
-      return {
-        selector,
-        resolvedAs:
-          resolvedNode.kind === 'route'
-            ? 'route'
-            : resolvedNode.kind === 'lexeme'
-              ? 'lexeme'
-              : 'id',
-        status: 'not_found',
-        snapshot: {
-          sourceHash: this.snapshot.sourceHash,
-          builtAt: this.snapshot.builtAt,
-        },
-      };
-    }
-
-    const projection = buildDocsProjection(this.snapshot);
-    const page = projection.pagesByMarkdownPath[docTarget.docRef.markdownPath];
-    if (!page) {
-      return {
-        selector,
-        resolvedAs:
-          resolvedNode.kind === 'route'
-            ? 'route'
-            : resolvedNode.kind === 'lexeme'
-              ? 'lexeme'
-              : 'id',
-        status: 'not_found',
-        snapshot: {
-          sourceHash: this.snapshot.sourceHash,
-          builtAt: this.snapshot.builtAt,
-        },
-      };
+    const page = docTarget
+      ? buildDocsProjection(this.snapshot).pagesByMarkdownPath[docTarget.docRef.markdownPath]
+      : undefined;
+    if (!docTarget || !page) {
+      return this.notFoundReadDoc(selector, resolvedAs);
     }
 
     return {
       selector,
-      resolvedAs:
-        resolvedNode.kind === 'route'
-          ? 'route'
-          : resolvedNode.kind === 'lexeme'
-            ? 'lexeme'
-            : 'id',
+      resolvedAs,
       status: 'ok',
       nodeId: docTarget.nodeId,
       title: docTarget.title,
       docRef: docTarget.docRef,
       markdown: page.markdown,
-      snapshot: {
-        sourceHash: this.snapshot.sourceHash,
-        builtAt: this.snapshot.builtAt,
-      },
+      snapshot: this.snapshotRef(),
     };
   }
 
@@ -374,10 +293,7 @@ export class QueryEngine {
       anchor: expanded.anchor,
       ownerNode: expanded.ownerNode,
       neighbors: expanded.neighbors,
-      snapshot: {
-        sourceHash: this.snapshot.sourceHash,
-        builtAt: this.snapshot.builtAt,
-      },
+      snapshot: this.snapshotRef(),
     };
   }
 
@@ -385,10 +301,7 @@ export class QueryEngine {
     return {
       citationIds,
       items: citationIds.map((citationId) => this.expandCitation(citationId)),
-      snapshot: {
-        sourceHash: this.snapshot.sourceHash,
-        builtAt: this.snapshot.builtAt,
-      },
+      snapshot: this.snapshotRef(),
     };
   }
 
@@ -553,6 +466,40 @@ export class QueryEngine {
       .filter((neighbor): neighbor is InspectNeighbor => Boolean(neighbor));
   }
 
+  private snapshotRef(): { sourceHash: string; builtAt: string } {
+    return {
+      sourceHash: this.snapshot.sourceHash,
+      builtAt: this.snapshot.builtAt,
+    };
+  }
+
+  private resolvedAsForNode(node: CompiledNode): 'id' | 'route' | 'lexeme' {
+    return node.kind === 'route' ? 'route' : node.kind === 'lexeme' ? 'lexeme' : 'id';
+  }
+
+  private notFoundInspect(selector: string): InspectResult {
+    return {
+      selector,
+      resolvedAs: 'not_found',
+      status: 'not_found',
+      anchors: [],
+      neighbors: [],
+      snapshot: this.snapshotRef(),
+    };
+  }
+
+  private notFoundReadDoc(
+    selector: string,
+    resolvedAs: ReadDocResult['resolvedAs'] = 'not_found',
+  ): ReadDocResult {
+    return {
+      selector,
+      resolvedAs,
+      status: 'not_found',
+      snapshot: this.snapshotRef(),
+    };
+  }
+
   private result(
     question: string,
     mode: AnswerMode,
@@ -562,11 +509,7 @@ export class QueryEngine {
       ...payload,
       mode,
       question,
-      snapshot: {
-        sourceHash: this.snapshot.sourceHash,
-        builtAt: this.snapshot.builtAt,
-        rebuilt: this.rebuilt,
-      },
+      snapshot: { ...this.snapshotRef(), rebuilt: this.rebuilt },
     };
   }
 }

--- a/src/runtime/query-engine.ts
+++ b/src/runtime/query-engine.ts
@@ -64,11 +64,6 @@ export class QueryEngine {
     private readonly sessionState?: RetrievalSessionState,
   ) {}
 
-  async query(question: string, mode: AnswerMode = 'compact'): Promise<QueryResult> {
-    const trace = this.trace(question, mode);
-    return this.answerFromTrace(question, mode, trace);
-  }
-
   async answerFromTrace(
     question: string,
     mode: AnswerMode,
@@ -230,15 +225,15 @@ export class QueryEngine {
   }
 
   inspect(selector: string, kind: 'auto' | 'id' | 'route' | 'lexeme' = 'auto'): InspectResult {
-    const resolvedId = this.resolveSelector(selector, kind);
-    if (!resolvedId) {
+    const resolved = this.resolveNode(selector, kind);
+    if (!resolved) {
       return this.notFoundInspect(selector);
     }
 
-    const node = this.snapshot.compiledNodes[resolvedId];
+    const { node, resolvedAs } = resolved;
     return {
       selector,
-      resolvedAs: this.resolvedAsForNode(node),
+      resolvedAs,
       status: 'ok',
       node,
       anchors: (node.anchorIds ?? [])
@@ -254,18 +249,13 @@ export class QueryEngine {
     selector: string,
     kind: 'auto' | 'id' | 'route' | 'lexeme' = 'auto',
   ): ReadDocResult {
-    const resolvedNodeId = this.resolveSelector(selector, kind);
-    if (!resolvedNodeId) {
+    const resolved = this.resolveNode(selector, kind);
+    if (!resolved) {
       return this.notFoundReadDoc(selector);
     }
 
-    const resolvedNode = this.snapshot.compiledNodes[resolvedNodeId];
-    if (!resolvedNode) {
-      return this.notFoundReadDoc(selector);
-    }
-
-    const resolvedAs = this.resolvedAsForNode(resolvedNode);
-    const docTarget = resolveDocTarget(this.snapshot, resolvedNodeId);
+    const { node, resolvedAs } = resolved;
+    const docTarget = resolveDocTarget(this.snapshot, node.id);
     const page = docTarget
       ? buildDocsProjection(this.snapshot).pagesByMarkdownPath[docTarget.docRef.markdownPath]
       : undefined;
@@ -358,12 +348,8 @@ export class QueryEngine {
         nodeId: node.id,
         score: this.scoreLexemeSelectorMatch(normalizedSelector, node),
       }))
-      .sort((left, right) => {
-        if (right.score !== left.score) {
-          return right.score - left.score;
-        }
-        return left.nodeId.localeCompare(right.nodeId);
-      })[0]?.nodeId;
+      .sort((left, right) => right.score - left.score || left.nodeId.localeCompare(right.nodeId))[0]
+      ?.nodeId;
   }
 
   private scoreLexemeSelectorMatch(normalizedSelector: string, node: CompiledNode): number {
@@ -467,14 +453,20 @@ export class QueryEngine {
   }
 
   private snapshotRef(): { sourceHash: string; builtAt: string } {
-    return {
-      sourceHash: this.snapshot.sourceHash,
-      builtAt: this.snapshot.builtAt,
-    };
+    return { sourceHash: this.snapshot.sourceHash, builtAt: this.snapshot.builtAt };
+  }
+
+  private resolveNode(
+    selector: string,
+    kind: 'auto' | 'id' | 'route' | 'lexeme',
+  ): { node: CompiledNode; resolvedAs: 'id' | 'route' | 'lexeme' } | undefined {
+    const nodeId = this.resolveSelector(selector, kind);
+    const node = nodeId ? this.snapshot.compiledNodes[nodeId] : undefined;
+    return node ? { node, resolvedAs: this.resolvedAsForNode(node) } : undefined;
   }
 
   private resolvedAsForNode(node: CompiledNode): 'id' | 'route' | 'lexeme' {
-    return node.kind === 'route' ? 'route' : node.kind === 'lexeme' ? 'lexeme' : 'id';
+    return node.kind === 'pattern' ? 'id' : node.kind;
   }
 
   private notFoundInspect(selector: string): InspectResult {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -162,14 +162,7 @@ export class FpfRuntime {
     forceRefresh = false,
     sessionId?: string,
   ): Promise<QueryResult> {
-    const audit = await this.refresh(forceRefresh);
-    const snapshot = await this.requireSnapshot();
-    const engine = new QueryEngine(
-      snapshot,
-      audit.rebuilt,
-      this.synthesizer,
-      sessionId ? this.sessionCache.get(sessionId) : undefined,
-    );
+    const engine = await this.createEngine(forceRefresh, sessionId);
     const trace = engine.trace(question, mode);
     const result = await engine.answerFromTrace(question, mode, trace);
     this.persistSession(sessionId, trace);
@@ -182,14 +175,7 @@ export class FpfRuntime {
     forceRefresh = false,
     sessionId?: string,
   ): Promise<TraceResult> {
-    const audit = await this.refresh(forceRefresh);
-    const snapshot = await this.requireSnapshot();
-    const trace = new QueryEngine(
-      snapshot,
-      audit.rebuilt,
-      this.synthesizer,
-      sessionId ? this.sessionCache.get(sessionId) : undefined,
-    ).trace(question, mode);
+    const trace = (await this.createEngine(forceRefresh, sessionId)).trace(question, mode);
     this.persistSession(sessionId, trace);
     return trace;
   }
@@ -199,9 +185,7 @@ export class FpfRuntime {
     kind: 'auto' | 'id' | 'route' | 'lexeme' = 'auto',
     forceRefresh = false,
   ): Promise<InspectResult> {
-    await this.refresh(forceRefresh);
-    const snapshot = await this.requireSnapshot();
-    return new QueryEngine(snapshot, false, this.synthesizer).inspect(selector, kind);
+    return (await this.createEngine(forceRefresh)).inspect(selector, kind);
   }
 
   async readDoc(
@@ -209,24 +193,18 @@ export class FpfRuntime {
     kind: 'auto' | 'id' | 'route' | 'lexeme' = 'auto',
     forceRefresh = false,
   ): Promise<ReadDocResult> {
-    await this.refresh(forceRefresh);
-    const snapshot = await this.requireSnapshot();
-    return new QueryEngine(snapshot, false, this.synthesizer).readDoc(selector, kind);
+    return (await this.createEngine(forceRefresh)).readDoc(selector, kind);
   }
 
   async inspectAnchor(anchorId: string, forceRefresh = false): Promise<InspectAnchorResult> {
-    await this.refresh(forceRefresh);
-    const snapshot = await this.requireSnapshot();
-    return new QueryEngine(snapshot, false, this.synthesizer).inspectAnchor(anchorId);
+    return (await this.createEngine(forceRefresh)).inspectAnchor(anchorId);
   }
 
   async expandCitations(
     citationIds: string[],
     forceRefresh = false,
   ): Promise<ExpandCitationsResult> {
-    await this.refresh(forceRefresh);
-    const snapshot = await this.requireSnapshot();
-    return new QueryEngine(snapshot, false, this.synthesizer).expandCitations(citationIds);
+    return (await this.createEngine(forceRefresh)).expandCitations(citationIds);
   }
 
   async status(): Promise<RuntimeStatus> {
@@ -377,22 +355,22 @@ export class FpfRuntime {
     this.sessionCache.set(sessionId, nextState);
   }
 
-  private async loadSnapshot(): Promise<Snapshot | undefined> {
-    try {
-      const content = await readFile(this.artifactPaths.snapshot, 'utf8');
-      return JSON.parse(content) as Snapshot;
-    } catch {
-      return undefined;
-    }
+  private async createEngine(forceRefresh = false, sessionId?: string): Promise<QueryEngine> {
+    const audit = await this.refresh(forceRefresh);
+    return new QueryEngine(
+      await this.requireSnapshot(),
+      audit.rebuilt,
+      this.synthesizer,
+      sessionId ? this.sessionCache.get(sessionId) : undefined,
+    );
   }
 
-  private async loadIndexingView(): Promise<IndexingView | undefined> {
-    try {
-      const content = await readFile(this.artifactPaths.indexingView, 'utf8');
-      return JSON.parse(content) as IndexingView;
-    } catch {
-      return undefined;
-    }
+  private loadSnapshot(): Promise<Snapshot | undefined> {
+    return this.readJsonFile(this.artifactPaths.snapshot);
+  }
+
+  private loadIndexingView(): Promise<IndexingView | undefined> {
+    return this.readJsonFile(this.artifactPaths.indexingView);
   }
 
   private async requireSnapshot(): Promise<Snapshot> {
@@ -436,6 +414,14 @@ export class FpfRuntime {
   private async writeJson(path: string, value: unknown): Promise<void> {
     await mkdir(dirname(path), { recursive: true });
     await writeFile(path, JSON.stringify(value, null, 2));
+  }
+
+  private async readJsonFile<T>(path: string): Promise<T | undefined> {
+    try {
+      return JSON.parse(await readFile(path, 'utf8')) as T;
+    } catch {
+      return undefined;
+    }
   }
 
   private async pathExists(path: string): Promise<boolean> {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -106,12 +106,11 @@ export class FpfRuntime {
         compiler: buildCompilerSummary(existingSnapshot),
         artifacts: this.artifactPaths,
       };
-      await this.writeArtifacts(existingSnapshot);
       const existingView = await this.loadIndexingView();
       if (!existingView) {
-        const view = buildIndexingView(existingSnapshot);
-        await this.writeJson(this.artifactPaths.indexingView, view);
+        await this.writeJson(this.artifactPaths.indexingView, buildIndexingView(existingSnapshot));
       }
+      await this.writeArtifacts(existingSnapshot, true);
       await this.writeAudit(audit);
       return audit;
     }
@@ -404,10 +403,9 @@ export class FpfRuntime {
     return snapshot;
   }
 
-  private async writeArtifacts(snapshot: Snapshot): Promise<void> {
+  private async writeArtifacts(snapshot: Snapshot, onlyMissing = false): Promise<void> {
     const payloads = {
       snapshot,
-      buildAudit: undefined,
       indexMap: {
         roots: snapshot.indexRoots,
         nodes: snapshot.indexMap,
@@ -418,10 +416,16 @@ export class FpfRuntime {
       anchorMap: snapshot.anchorMap,
     } as const;
 
+    const entries = Object.entries(payloads) as Array<
+      [keyof typeof payloads, (typeof payloads)[keyof typeof payloads]]
+    >;
     await Promise.all(
-      Object.entries(payloads)
-        .filter((entry): entry is [keyof typeof payloads, Exclude<(typeof payloads)[keyof typeof payloads], undefined>] => entry[1] !== undefined)
-        .map(([key, value]) => this.writeJson(this.artifactPaths[key], value)),
+      entries.map(async ([key, value]) => {
+        if (onlyMissing && (await this.pathExists(this.artifactPaths[key]))) {
+          return;
+        }
+        await this.writeJson(this.artifactPaths[key], value);
+      }),
     );
   }
 
@@ -434,16 +438,18 @@ export class FpfRuntime {
     await writeFile(path, JSON.stringify(value, null, 2));
   }
 
+  private async pathExists(path: string): Promise<boolean> {
+    try {
+      await readFile(path, 'utf8');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   private async getArtifactPresence(): Promise<Record<string, boolean>> {
     const entries = await Promise.all(
-      Object.entries(this.artifactPaths).map(async ([key, path]) => {
-        try {
-          await readFile(path, 'utf8');
-          return [key, true] as const;
-        } catch {
-          return [key, false] as const;
-        }
-      }),
+      Object.entries(this.artifactPaths).map(async ([key, path]) => [key, await this.pathExists(path)] as const),
     );
     return Object.fromEntries(entries);
   }

--- a/tests/fpf-spec-runtime.test.ts
+++ b/tests/fpf-spec-runtime.test.ts
@@ -91,6 +91,13 @@ describe('FpfRuntime', () => {
     expect(second.rebuilt).toBe(false);
     expect(second.reason).toBe('snapshot_current');
 
+    await rm(resolve(artifactDir, ARTIFACT_FILENAMES.routeGraph), { force: true });
+    const backfilled = await runtime.refresh();
+    expect(backfilled.rebuilt).toBe(false);
+    expect(await readFile(resolve(artifactDir, ARTIFACT_FILENAMES.routeGraph), 'utf8')).toContain(
+      '"relations"',
+    );
+
     await writeFile(sourcePath, `${await readFile(sourcePath, 'utf8')}\n<!-- hash-shift -->\n`);
     const third = await runtime.refresh();
     expect(third.rebuilt).toBe(true);


### PR DESCRIPTION
## Summary

This PR is now a focused simplification pass.

Current net change on the branch vs `main`:
- **136 insertions**
- **243 deletions**

## What changed

- simplified `FpfRuntime.refresh()` so a current snapshot no longer rewrites every artifact
- kept artifact backfill behavior for missing files on snapshot reuse
- simplified `QueryEngine` selector / inspect / read-doc handling by removing repeated boilerplate
- simplified runtime engine setup by collapsing repeated `refresh + snapshot + QueryEngine` creation
- made `build` consistently produce the declared stdio `bin`
- removed the `build:mcp` CJS output that produced the `import.meta` warning
- shortened and corrected MCP docs to match the actual public/full surfaces
- added coverage for artifact backfill on snapshot reuse

## Verification

- `bun run check`
- `bun run lint`
- `bun run test`
- `bun run build`

## Notes

This version intentionally avoids adding new abstraction files unless they reduce total complexity.
