### PR TITLE
fix(mastra): restore new Mastra({...}) pattern in CLI entry file

### DIFF
--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -1,6 +1,15 @@
+import { Mastra } from '@mastra/core/mastra';
+
 import {
   createMastraRuntime,
+  resolveMastraRuntimeOptions,
 } from '../compat/mastra/runtime.js';
 
 export { createMastraRuntime };
-export const mastra = createMastraRuntime();
+
+// NOTE: The Mastra CLI statically scans this file for the literal pattern
+// `export const mastra = new Mastra({ ... })`. Do NOT refactor this expression
+// into a helper call — the CLI parses the AST and will not follow indirection.
+// Runtime composition still lives in `createMastraRuntime` /
+// `resolveMastraRuntimeOptions` in `../compat/mastra/runtime.ts`.
+export const mastra = new Mastra({ ...resolveMastraRuntimeOptions() });


### PR DESCRIPTION
## Summary

- The Mastra CLI statically scans `src/mastra/index.ts` for a top-level `export const mastra = new Mastra({...})` with an object-literal argument. Commit `a34408a` moved that call behind `createMastraRuntime()` in the compat layer, so the scanner could no longer see it and emitted `Invalid Mastra config`, producing a broken virtual entry (`\x00virtual:#entry/package.json`) that crashed `bunx mastra build` in deploy-validation CI and the deploy pipeline.
- Re-instated the literal `export const mastra = new Mastra({ ...resolveMastraRuntimeOptions() })` at the top of the entry while keeping all option composition in `src/compat/mastra/runtime.ts`. The `createMastraRuntime` re-export is preserved for `tests/mcp-server.test.ts`. An inline comment documents the static-scan constraint to prevent future refactors from silently reintroducing the regression.

## Test plan

- [ ] `bunx mastra build` → `Build successful`, no `Invalid Mastra config` warning, and `.mastra/output/{index.mjs, package.json, node_modules}` are produced (the exact artifacts asserted in `.github/workflows/deploy-validation.yml:52-58`).
- [x] `bun run check` (tsc) → clean.
- [x] `bun run lint` (rslint, 96 files) → 0 errors, 0 warnings.
- [x] `bun run check:boundaries` → passed (entry's new `@mastra/core/mastra` import is already allowed — the compat layer imports it too).
- [x] `rstest tests/mcp-server.test.ts` → the `initializes the Mastra runtime` test (which calls `createMastraRuntime()`) passes. The unrelated `serves status, query, and ask surfaces...` failure reproduces on `main` without this change, so it is pre-existing and not a regression from this PR.
- [ ] Deploy validation CI (`bunx mastra build`) goes green on this PR.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low code complexity, but it changes the `src/mastra/index.ts` entry pattern relied on by the Mastra CLI’s static scanner, so regressions would directly break `mastra build`/deploy validation.
> 
> **Overview**
> Replaces the entrypoint’s `export const mastra = createMastraRuntime()` with a literal `export const mastra = new Mastra({ ...resolveMastraRuntimeOptions() })` so the Mastra CLI’s static scan can recognize the config again.
> 
> Keeps `createMastraRuntime` exported for consumers/tests, and adds an inline warning comment to prevent refactors that would reintroduce the scanner regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23cc80bc73f09920b5890e50d9feeee4b5908ce5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->