### PR TITLE
feat: record FPF use case demo videos

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "validate:published": "bun scripts/validate-published-current.ts",
     "evaluate:work": "bun src/cli.ts evaluate-work --target current-pr --base origin/main --format markdown",
     "e2e:report": "bun scripts/e2e-report.ts",
+    "videos:use-cases": "bun scripts/record-use-case-videos.ts",
     "stage:from-published": "bun scripts/stage-from-published.ts",
     "mastra:build": "bun scripts/mastra-build.ts",
     "build": "bun run build:runtime && bun run build:mcp",

--- a/scripts/e2e-report.ts
+++ b/scripts/e2e-report.ts
@@ -70,6 +70,7 @@ export interface E2EReportResult {
 const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_VIDEO_DURATION_MS = 5_000;
 const VIDEO_VIEWPORT = { width: 1280, height: 720 };
+export const DOCS_BASE_PATH = '/fpf-memory';
 
 export const E2E_PRESETS = {
   cli: {
@@ -505,8 +506,13 @@ async function recordReportVideo(input: {
     const video = page.video();
 
     if (input.recordTarget === 'docs') {
-      staticServer = await startStaticServer(resolve(input.cwd, 'doc_build'));
-      await page.goto(staticServer.url, { waitUntil: 'networkidle', timeout: 30_000 });
+      staticServer = await startStaticServer(resolve(input.cwd, 'doc_build'), {
+        basePath: DOCS_BASE_PATH,
+      });
+      await page.goto(new URL(`${DOCS_BASE_PATH}/`, staticServer.url).href, {
+        waitUntil: 'networkidle',
+        timeout: 30_000,
+      });
       await page.waitForTimeout(700);
       await page.evaluate(() => window.scrollTo({ top: document.body.scrollHeight / 2 }));
       await page.waitForTimeout(700);
@@ -542,7 +548,10 @@ interface StaticServer {
   close: () => Promise<void>;
 }
 
-async function startStaticServer(rootDir: string): Promise<StaticServer> {
+export async function startStaticServer(
+  rootDir: string,
+  options: { basePath?: string } = {},
+): Promise<StaticServer> {
   if (!existsSync(resolve(rootDir, 'index.html'))) {
     throw new Error(`docs recording target missing at ${rootDir}; run the docs E2E command first.`);
   }
@@ -550,7 +559,7 @@ async function startStaticServer(rootDir: string): Promise<StaticServer> {
   const server = createServer(async (request, response) => {
     try {
       const requestUrl = new URL(request.url ?? '/', 'http://127.0.0.1');
-      const filePath = resolveStaticPath(rootDir, requestUrl.pathname);
+      const filePath = resolveStaticPath(rootDir, requestUrl.pathname, options.basePath);
       response.setHeader('Content-Type', contentTypeFor(filePath));
       response.end(await readFile(filePath));
     } catch (error) {
@@ -573,8 +582,20 @@ async function startStaticServer(rootDir: string): Promise<StaticServer> {
   };
 }
 
-function resolveStaticPath(rootDir: string, pathname: string): string {
-  const decoded = decodeURIComponent(pathname);
+export function resolveStaticPath(
+  rootDir: string,
+  pathname: string,
+  basePath = '',
+): string {
+  let decoded = decodeURIComponent(pathname);
+  const normalizedBasePath = normalizeBasePath(basePath);
+  if (normalizedBasePath) {
+    if (decoded === normalizedBasePath) {
+      decoded = '/';
+    } else if (decoded.startsWith(`${normalizedBasePath}/`)) {
+      decoded = decoded.slice(normalizedBasePath.length);
+    }
+  }
   const safePath = decoded === '/' ? '/index.html' : decoded;
   let candidate = resolve(rootDir, `.${safePath}`);
   const normalizedRoot = rootDir.endsWith(sep) ? rootDir : `${rootDir}${sep}`;
@@ -591,6 +612,14 @@ function resolveStaticPath(rootDir: string, pathname: string): string {
     throw new Error(`Static file not found: ${relative(rootDir, candidate)}`);
   }
   return candidate;
+}
+
+function normalizeBasePath(basePath: string): string {
+  const trimmed = basePath.trim().replace(/\/+$/u, '');
+  if (!trimmed || trimmed === '/') {
+    return '';
+  }
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
 }
 
 function closeServer(server: Server): Promise<void> {

--- a/scripts/record-use-case-videos.ts
+++ b/scripts/record-use-case-videos.ts
@@ -1,0 +1,406 @@
+import { spawn } from 'node:child_process';
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { chromium, type Browser, type Page } from 'playwright';
+
+import { DOCS_BASE_PATH, startStaticServer } from './e2e-report.js';
+
+interface UseCaseVideo {
+  slug: string;
+  title: string;
+  description: string;
+  path: string;
+  heading: string;
+}
+
+interface ParsedArgs {
+  skipBuild: boolean;
+  artifactRoot: string;
+  durationMs: number;
+}
+
+interface RecordedUseCase {
+  slug: string;
+  title: string;
+  description: string;
+  url: string;
+  videoPath: string;
+}
+
+const VIEWPORT = { width: 1440, height: 900 };
+const DEFAULT_DURATION_MS = 8_000;
+const DEFAULT_ARTIFACT_ROOT = '.runtime/use-case-videos';
+
+const USE_CASES: UseCaseVideo[] = [
+  {
+    slug: 'start-here-doorways',
+    title: 'Start with a doorway',
+    description: 'Choose a route before asking people or agents to read the full FPF.',
+    path: '/start-here',
+    heading: 'Pick a doorway',
+  },
+  {
+    slug: 'project-review-packet',
+    title: 'Project review packet',
+    description: 'Turn a messy project into context, roles, next owner, and acceptance evidence.',
+    path: '/work-packets#project-review-packet',
+    heading: 'Project review packet',
+  },
+  {
+    slug: 'pr-code-review-packet',
+    title: 'PR and code review packet',
+    description: 'Review for behavioral risk, missing evidence, and semantic drift.',
+    path: '/work-packets#pr-or-code-review-packet',
+    heading: 'PR or code review packet',
+  },
+  {
+    slug: 'spec-writing-packet',
+    title: 'Specification writing packet',
+    description: 'Write specs with scope, norms, checks, and an explicit change record.',
+    path: '/work-packets#specification-writing-packet',
+    heading: 'Specification writing packet',
+  },
+  {
+    slug: 'role-promise-capability',
+    title: 'Role, promise, capability analysis',
+    description: 'Separate ability, promise, responsibility, performance, and evidence.',
+    path: '/work-packets#role-promise-and-capability-analysis-packet',
+    heading: 'Role, promise, and capability analysis packet',
+  },
+  {
+    slug: 'agent-workflow-packet',
+    title: 'Agent workflow packet',
+    description: 'Let an agent retrieve only the grounded FPF slice needed for the work.',
+    path: '/work-packets#agent-workflow-use-packet',
+    heading: 'Agent workflow use packet',
+  },
+  {
+    slug: 'mcp-bounded-context',
+    title: 'MCP instead of pasted context',
+    description: 'Use the MCP server as the context boundary instead of pasting the whole FPF.',
+    path: '/mcp-recipes#keep-context-bounded',
+    heading: 'Keep context bounded',
+  },
+];
+
+export function parseRecordUseCaseVideoArgs(args: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    skipBuild: false,
+    artifactRoot: DEFAULT_ARTIFACT_ROOT,
+    durationMs: DEFAULT_DURATION_MS,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    switch (arg) {
+      case '--skip-build':
+        parsed.skipBuild = true;
+        break;
+      case '--artifact-root':
+        parsed.artifactRoot = readOptionValue(args, index, arg);
+        index += 1;
+        break;
+      case '--duration-ms':
+        parsed.durationMs = readPositiveInteger(args, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown record-use-case-videos option: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+export function buildUseCaseVideoArtifactDirName(now: Date): string {
+  return `${now.toISOString().replace(/[:.]/gu, '-')}-fpf-use-cases`;
+}
+
+export async function recordUseCaseVideos(
+  args: ParsedArgs,
+  options: { cwd?: string; now?: Date } = {},
+): Promise<{
+  artifactDir: string;
+  manifestPath: string;
+  readmePath: string;
+  videos: RecordedUseCase[];
+}> {
+  const cwd = options.cwd ?? process.cwd();
+  if (!args.skipBuild) {
+    await runCommand('bun', ['run', 'docs:build'], cwd);
+  }
+
+  const artifactDir = resolve(
+    cwd,
+    args.artifactRoot,
+    buildUseCaseVideoArtifactDirName(options.now ?? new Date()),
+  );
+  await mkdir(artifactDir, { recursive: true });
+
+  const staticServer = await startStaticServer(resolve(cwd, 'doc_build'), {
+    basePath: DOCS_BASE_PATH,
+  });
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const videos: RecordedUseCase[] = [];
+    for (const useCase of USE_CASES) {
+      videos.push(
+        await recordOneUseCase({
+          browser,
+          artifactDir,
+          baseUrl: staticServer.url,
+          useCase,
+          durationMs: args.durationMs,
+        }),
+      );
+    }
+
+    const manifestPath = resolve(artifactDir, 'manifest.json');
+    const readmePath = resolve(artifactDir, 'README.md');
+    await writeFile(
+      manifestPath,
+      `${JSON.stringify(
+        {
+          generatedAt: new Date().toISOString(),
+          basePath: DOCS_BASE_PATH,
+          viewport: VIEWPORT,
+          videos,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await writeFile(readmePath, renderReadme(videos));
+
+    return {
+      artifactDir,
+      manifestPath,
+      readmePath,
+      videos,
+    };
+  } finally {
+    await browser.close();
+    await staticServer.close();
+  }
+}
+
+async function recordOneUseCase(input: {
+  browser: Browser;
+  artifactDir: string;
+  baseUrl: string;
+  useCase: UseCaseVideo;
+  durationMs: number;
+}): Promise<RecordedUseCase> {
+  const context = await input.browser.newContext({
+    viewport: VIEWPORT,
+    colorScheme: 'light',
+    recordVideo: {
+      dir: input.artifactDir,
+      size: VIEWPORT,
+    },
+  });
+  const page = await context.newPage();
+  const video = page.video();
+  const url = new URL(`${DOCS_BASE_PATH}${input.useCase.path}`, input.baseUrl).href;
+
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 30_000 });
+  await assertCssAssetsLoaded(page);
+  await installPromoOverlay(page, input.useCase);
+  await focusHeading(page, input.useCase.heading);
+  await page.waitForTimeout(700);
+  await page.evaluate(() => window.scrollBy({ top: 260, behavior: 'smooth' }));
+  await page.waitForTimeout(Math.max(1_000, Math.floor(input.durationMs / 3)));
+  await page.evaluate(() => window.scrollBy({ top: 340, behavior: 'smooth' }));
+  await page.waitForTimeout(Math.max(1_000, Math.floor(input.durationMs / 3)));
+  await focusHeading(page, input.useCase.heading);
+  await page.waitForTimeout(Math.max(1_000, input.durationMs - Math.floor((input.durationMs * 2) / 3)));
+
+  await context.close();
+  const rawVideoPath = await video?.path();
+  if (!rawVideoPath) {
+    throw new Error(`Playwright did not produce a video for ${input.useCase.slug}.`);
+  }
+  const videoPath = resolve(input.artifactDir, `${input.useCase.slug}.webm`);
+  await rename(rawVideoPath, videoPath);
+
+  return {
+    slug: input.useCase.slug,
+    title: input.useCase.title,
+    description: input.useCase.description,
+    url,
+    videoPath,
+  };
+}
+
+async function assertCssAssetsLoaded(page: Page): Promise<void> {
+  const checks = await page.evaluate(async () => {
+    const links = Array.from(document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]'));
+    return Promise.all(
+      links.map(async (link) => {
+        const response = await fetch(link.href);
+        return {
+          href: link.href,
+          ok: response.ok,
+          byteLength: (await response.text()).length,
+        };
+      }),
+    );
+  });
+
+  const failed = checks.filter((check) => !check.ok || check.byteLength < 1_000);
+  if (checks.length === 0 || failed.length > 0) {
+    throw new Error(`CSS assets did not load for video recording: ${JSON.stringify(failed)}`);
+  }
+}
+
+async function installPromoOverlay(page: Page, useCase: UseCaseVideo): Promise<void> {
+  await page.addStyleTag({
+    content: `
+      .fpf-video-overlay {
+        position: fixed;
+        right: 24px;
+        bottom: 24px;
+        z-index: 9999;
+        width: 420px;
+        max-width: calc(100vw - 48px);
+        padding: 18px 20px;
+        border: 1px solid rgba(20, 75, 61, 0.22);
+        border-radius: 10px;
+        background: rgba(255, 255, 255, 0.94);
+        box-shadow: 0 16px 40px rgba(0, 0, 0, 0.16);
+        color: #18241d;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .fpf-video-overlay__eyebrow {
+        margin: 0 0 6px;
+        color: #0b6b4f;
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0;
+        text-transform: uppercase;
+      }
+      .fpf-video-overlay__title {
+        margin: 0;
+        font-size: 22px;
+        line-height: 1.18;
+        font-weight: 750;
+      }
+      .fpf-video-overlay__description {
+        margin: 8px 0 0;
+        color: #4d5f53;
+        font-size: 14px;
+        line-height: 1.45;
+      }
+      .fpf-video-heading-highlight {
+        outline: 3px solid rgba(11, 107, 79, 0.48);
+        outline-offset: 8px;
+        border-radius: 6px;
+      }
+    `,
+  });
+  await page.evaluate((overlay) => {
+    document.querySelector('.fpf-video-overlay')?.remove();
+    const node = document.createElement('aside');
+    node.className = 'fpf-video-overlay';
+    node.innerHTML = `
+      <p class="fpf-video-overlay__eyebrow">FPF use case</p>
+      <h2 class="fpf-video-overlay__title"></h2>
+      <p class="fpf-video-overlay__description"></p>
+    `;
+    node.querySelector('.fpf-video-overlay__title')!.textContent = overlay.title;
+    node.querySelector('.fpf-video-overlay__description')!.textContent = overlay.description;
+    document.body.append(node);
+  }, useCase);
+}
+
+async function focusHeading(page: Page, heading: string): Promise<void> {
+  const found = await page.evaluate((headingText) => {
+    document
+      .querySelectorAll('.fpf-video-heading-highlight')
+      .forEach((node) => node.classList.remove('fpf-video-heading-highlight'));
+    const candidate = Array.from(document.querySelectorAll('h1,h2,h3')).find((node) =>
+      node.textContent?.includes(headingText),
+    );
+    if (!candidate) {
+      return false;
+    }
+    candidate.classList.add('fpf-video-heading-highlight');
+    candidate.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    return true;
+  }, heading);
+
+  if (!found) {
+    throw new Error(`Unable to find heading for video recording: ${heading}`);
+  }
+}
+
+function renderReadme(videos: RecordedUseCase[]): string {
+  return [
+    '# FPF Use Case Videos',
+    '',
+    'CSS-rendered Playwright recordings for adoption and work-use demos.',
+    '',
+    '| Use case | Video |',
+    '| --- | --- |',
+    ...videos.map((video) => `| ${video.title} | \`${video.videoPath}\` |`),
+    '',
+  ].join('\n');
+}
+
+function runCommand(command: string, args: string[], cwd: string): Promise<void> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: process.env,
+      stdio: 'inherit',
+    });
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolvePromise();
+        return;
+      }
+      reject(new Error(`${command} ${args.join(' ')} failed with ${signal ?? `exit code ${code}`}.`));
+    });
+  });
+}
+
+function readOptionValue(args: string[], index: number, optionName: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${optionName} requires a value.`);
+  }
+  return value;
+}
+
+function readPositiveInteger(args: string[], index: number, optionName: string): number {
+  const value = Number(readOptionValue(args, index, optionName));
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${optionName} must be a positive integer.`);
+  }
+  return value;
+}
+
+async function main(): Promise<void> {
+  const result = await recordUseCaseVideos(parseRecordUseCaseVideoArgs(process.argv.slice(2)));
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        artifactDir: result.artifactDir,
+        manifest: result.manifestPath,
+        readme: result.readmePath,
+        videos: result.videos.map((video) => video.videoPath),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  });
+}

--- a/tests/e2e-report.test.ts
+++ b/tests/e2e-report.test.ts
@@ -1,3 +1,7 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
 import { describe, expect, it } from '@rstest/core';
 
 import {
@@ -6,8 +10,13 @@ import {
   renderE2EReportHtml,
   renderE2EReportMarkdown,
   resolveE2EReportConfig,
+  resolveStaticPath,
   type CommandRunResult,
 } from '../scripts/e2e-report.js';
+import {
+  buildUseCaseVideoArtifactDirName,
+  parseRecordUseCaseVideoArgs,
+} from '../scripts/record-use-case-videos.js';
 
 describe('E2E report tooling', () => {
   it('defaults to the CLI smoke preset', () => {
@@ -55,6 +64,39 @@ describe('E2E report tooling', () => {
   it('builds stable artifact directory names', () => {
     expect(buildE2EArtifactDirName(new Date('2026-04-30T16:00:01.123Z'), 'PR Review')).toBe(
       '2026-04-30T16-00-01-123Z-pr-review',
+    );
+  });
+
+  it('resolves Rspress base-path assets for local docs recordings', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'fpf-static-'));
+    await mkdir(join(root, 'static/css'), { recursive: true });
+    await writeFile(join(root, 'static/css/styles.css'), 'body{}');
+    await writeFile(join(root, 'start-here.html'), '<html></html>');
+
+    expect(resolveStaticPath(root, '/fpf-memory/static/css/styles.css', '/fpf-memory')).toBe(
+      join(root, 'static/css/styles.css'),
+    );
+    expect(resolveStaticPath(root, '/fpf-memory/start-here', '/fpf-memory')).toBe(
+      join(root, 'start-here.html'),
+    );
+  });
+
+  it('parses use-case video recording options', () => {
+    const args = parseRecordUseCaseVideoArgs([
+      '--skip-build',
+      '--artifact-root',
+      '.runtime/demo-videos',
+      '--duration-ms',
+      '2000',
+    ]);
+
+    expect(args).toEqual({
+      skipBuild: true,
+      artifactRoot: '.runtime/demo-videos',
+      durationMs: 2_000,
+    });
+    expect(buildUseCaseVideoArtifactDirName(new Date('2026-05-02T12:00:00.000Z'))).toBe(
+      '2026-05-02T12-00-00-000Z-fpf-use-cases',
     );
   });
 


### PR DESCRIPTION
## Summary\n- fix docs E2E static serving so GitHub Pages base-path CSS assets load in local recordings\n- add a Playwright use-case video recorder for the adoption/work-packet/MCP recipe flows\n- cover base-path resolution and recorder argument parsing in tests\n\n## Validation\n- bun run lint\n- bun run check\n- bun run test -- tests/e2e-report.test.ts\n- bun run test\n- bun run videos:use-cases -- --skip-build\n- bun run e2e:report docs --video-duration-ms 3000\n\nGenerated local video artifact set:\n/Users/stas-studio/Developer/fpf-memory/.runtime/use-case-videos/2026-05-02T12-43-41-289Z-fpf-use-cases\n\nCSS verification: recorder fetch-checks stylesheet assets before recording; inspected start-here preview frame at .runtime/use-case-videos/2026-05-02T12-43-41-289Z-fpf-use-cases/start-here-doorways-preview.png
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer tooling/scripts and associated tests, mainly affecting Playwright-based recording and local static serving for docs previews.
> 
> **Overview**
> Adds a new `videos:use-cases` script that builds the docs (optional), serves `doc_build`, and uses Playwright to record a set of curated docs flows into timestamped `.webm` artifacts with a generated `manifest.json` and `README.md`.
> 
> Fixes docs E2E recordings when the site is built under a GitHub Pages base path by introducing `DOCS_BASE_PATH` and teaching `startStaticServer`/`resolveStaticPath` to strip an optional `basePath` before resolving assets (so CSS loads correctly). Updates tests to cover base-path resolution and the new recorder CLI arg parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93931b793b2d007a3a47ada601165e5f7352d9be. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->