### PR TITLE
docs: add FPF demo video adoption page

### DIFF
--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -20,6 +20,7 @@ Use this page to choose the first doorway, then move into the reference only whe
 | Unpack an API, contract, or promise | [Boundary burden route](/generated/routes/route_boundary-burden) | Atomic claims, boundary duties, evidence needs |
 | Compare options | [Lawful comparison route](/generated/routes/route_lawful-comparison-or-portfolio-selection) | Governed shortlist or set result |
 | Use FPF inside an agent conversation | [MCP recipes](/mcp-recipes) | Compact cited context instead of a full-spec paste |
+| Show FPF to someone else | [Demo videos](/use-case-videos) | CSS-rendered walkthrough of one practical use case |
 
 ## Operating rule
 
@@ -32,8 +33,8 @@ Do not ask people to read all FPF before they can benefit from it. Ask for the w
 3. Capture the current claim, role, method, promise, evidence, and risk in ordinary language.
 4. Add exact FPF IDs only where they change the decision or the acceptance checks.
 5. Keep the full catalog available as the canonical reference, not as the first screen.
+6. Record a short use-case video when the path should be reusable by someone else.
 
 ## When to use the full catalog
 
 Use [Patterns](/generated/patterns/index) when the doorway is not enough, when an exact pattern clause matters, or when a reader needs to audit the source.
-

--- a/docs/use-case-videos.md
+++ b/docs/use-case-videos.md
@@ -1,0 +1,48 @@
+---
+title: "Demo Videos"
+description: "Product-level FPF use case recordings for adoption, work use, and promotion."
+outline: false
+---
+
+# Demo Videos
+
+Use videos to show FPF as a working surface, not only as a reference document. Each recording should show a concrete job, the smallest FPF route or tool call needed, and the useful outcome.
+
+## Record the current set
+
+```bash
+bun run videos:use-cases
+```
+
+For a quicker local check:
+
+```bash
+bun run videos:use-cases -- --skip-build --duration-ms 3000
+```
+
+Artifacts are written under `.runtime/use-case-videos/<timestamp>-fpf-product-use-cases/`. That folder includes a `README.md`, `manifest.json`, one `.webm` per scenario, and transcript pages for command and MCP recordings.
+
+## Scenario set
+
+| Surface | Video | Shows |
+| --- | --- | --- |
+| Docs wiki | Pick the right doorway | Start from the adoption page, choose a work doorway, then open the matching route or packet. |
+| Docs wiki | Audit exact source | Move from a route to the exact generated pattern page when wording matters. |
+| MCP runtime | Bounded agent context | Retrieve a compact project-alignment packet through MCP instead of pasting all FPF. |
+| MCP runtime | Retrieval provenance | Use the full local MCP surface when trace evidence matters. |
+| CLI runtime | Ask from terminal | Get a grounded FPF answer in a shell workflow. |
+| CLI runtime | Follow-up session | Reuse bounded session context across related questions. |
+| Work evaluator | Review working tree | Turn local work evidence into an FPF-grounded review surface. |
+| Work evaluator | CI-readable gate | Produce a compact gate report for maintainers and agents. |
+
+## Quality bar
+
+- The recording must load real CSS; unstyled pages are not acceptable.
+- The opening frame should show the product surface, not a blank or generic terminal.
+- The narration should name the problem, the tool or route, the action, and the outcome.
+- The output should be useful as adoption material for a new person and as a reminder for experienced users.
+- Keep each scenario narrow enough that the viewer can copy the move into their own work.
+
+## When to make a new video
+
+Create a new recording when FPF gains a new practical use path: a new work packet, MCP recipe, CLI workflow, evaluator report, or live wiki doorway. Do not wait until the whole framework is explained. Show one repeatable job.

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -60,6 +60,10 @@ export default defineConfig({
         link: '/mcp-recipes',
       },
       {
+        text: 'Demo Videos',
+        link: '/use-case-videos',
+      },
+      {
         text: 'Patterns',
         link: '/generated/patterns/index',
       },

--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -262,9 +262,9 @@ function buildPatternIndexPage(snapshot: Snapshot): GeneratedDocPage {
 /**
  * The site home. Intentionally short: one-sentence framing, a manifest
  * block so readers can tell which FPF snapshot this build is projected
- * from, a pointer to the hosted MCP endpoint, and links to the four
- * navigable surfaces (Patterns, Routes, Glossary, Change log). The
- * pattern catalog itself still lives at `/generated/patterns/index`.
+ * from, a pointer to the hosted MCP endpoint, and links to adoption,
+ * demonstration, and reference surfaces. The pattern catalog itself
+ * still lives at `/generated/patterns/index`.
  */
 function buildRootIndexPage(
   snapshot: Snapshot,
@@ -305,6 +305,7 @@ function renderHomeMarkdown(
     '- [Adoption guide](/start-here) — choose the first FPF path for a person, team, or agent.',
     '- [Work packets](/work-packets) — use FPF in project review, PR review, specification work, role/promise/capability analysis, and agent workflows.',
     '- [MCP recipes](/mcp-recipes) — retrieve compact grounded slices from the hosted or local MCP server.',
+    '- [Demo videos](/use-case-videos) — record CSS-rendered walkthroughs that show how people and agents use FPF without a full-spec paste.',
     '',
     '## Navigate',
     '',

--- a/tests/docs-projection.test.ts
+++ b/tests/docs-projection.test.ts
@@ -201,6 +201,7 @@ describe('docs projection', () => {
       expect(rootIndex).toContain('[Adoption guide](/start-here)');
       expect(rootIndex).toContain('[Work packets](/work-packets)');
       expect(rootIndex).toContain('[MCP recipes](/mcp-recipes)');
+      expect(rootIndex).toContain('[Demo videos](/use-case-videos)');
       expect(rootIndex).toContain('## Navigate');
       expect(rootIndex).toContain('[Patterns](/generated/patterns/index)');
       expect(rootIndex).toContain('[Routes](/generated/routes/index)');
@@ -263,6 +264,9 @@ describe('docs projection', () => {
       );
       expect(await readFile(resolve(outDir, 'mcp-recipes.html'), 'utf8')).toContain(
         'Use MCP instead of pasted context',
+      );
+      expect(await readFile(resolve(outDir, 'use-case-videos.html'), 'utf8')).toContain(
+        'Product-level FPF use case recordings',
       );
     } finally {
       await rm(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Add a Demo Videos wiki page for product-level FPF use case recordings
- Link the page from the adoption-first home, Start Here doorway table, and top nav
- Extend docs projection tests so the generated home and static build include the page

## Validation
- bun run lint
- bun run check
- bun run test -- tests/docs-projection.test.ts
- bun run docs:build
- Playwright CSS/video smoke for /use-case-videos: /Users/stas-studio/Developer/fpf-memory/.runtime/use-case-videos/2026-05-02T13-57-44-612Z-demo-videos-page/demo-videos-page.webm

changed | demo video adoption surface added
validated | local checks above
uncertain | CI pending
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only additions plus navigation/test updates; main risk is broken links or doc build expectations if the new route path changes.
> 
> **Overview**
> Adds a new docs page, `docs/use-case-videos.md`, describing how to record and curate product-level FPF demo videos (scenarios, commands, and quality bar).
> 
> Links this new “Demo Videos” surface from the adoption funnel: the `Start Here` doorway table, the generated home page (`src/core/documents.ts`), and the top nav (`rspress.config.ts`). Updates `tests/docs-projection.test.ts` to assert the page is included in both generated markdown and the rspress static build output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c43411bbe0d3b371f4cf392e1eb5136c898da497. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->