### PR TITLE
docs: explain FPF page surfaces

### DIFF
--- a/docs/mcp-recipes.md
+++ b/docs/mcp-recipes.md
@@ -8,6 +8,14 @@ outline: false
 
 Use MCP instead of pasted context when the work needs grounded FPF context, exact IDs, or deterministic retrieval provenance.
 
+## What this page is
+
+This is the agent and tool-use guide for fpf-memory's MCP surface. It explains how to retrieve compact grounded FPF context instead of pasting the full specification into a conversation.
+
+## Methodology
+
+Check runtime health first, find the right doorway with search or query tools, read exact generated docs only when wording matters, and keep answers cited to route or pattern IDs. Hosted MCP exposes the public work surface; local full mode is for deeper inspection and provenance.
+
 Hosted endpoint:
 
 ```txt

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -10,6 +10,14 @@ FPF is meant to stay whole. Adoption should be small.
 
 Use this page to choose the first doorway, then move into the reference only when the work needs exact pattern text.
 
+## What this page is
+
+This is the adoption entry surface for fpf-memory's FPF wiki. It helps a person, team, or agent choose a first practical path; it is not the full FPF specification and it is not a product changelog.
+
+## Methodology
+
+Name the work shape first, pick the smallest matching doorway, and keep exact FPF IDs visible only where they change the work. The full catalog stays available for audit, but it should not be the first mental model.
+
 ## Pick a doorway
 
 | Work | Start with | Good output |

--- a/docs/use-case-videos.md
+++ b/docs/use-case-videos.md
@@ -8,6 +8,14 @@ outline: false
 
 Use videos to show FPF as a working surface, not only as a reference document. Each recording should show a concrete job, the smallest FPF route or tool call needed, and the useful outcome.
 
+## What this page is
+
+This is the promotion and adoption evidence page for fpf-memory. It tracks recordings that show concrete FPF use cases for people and agents; it is not a general video library or a generated FPF reference page.
+
+## Methodology
+
+Record one repeatable job at a time. The video must show the initial problem, the FPF route, packet, MCP call, or CLI command used, and the outcome someone can copy into their own work.
+
 ## Record the current set
 
 ```bash

--- a/docs/work-packets.md
+++ b/docs/work-packets.md
@@ -8,6 +8,14 @@ outline: false
 
 A work packet is a small grounded slice of FPF for doing one job. It is not a replacement for the full specification.
 
+## What this page is
+
+This is the task-sized operating surface for using FPF in real work. It turns the framework into bounded packets for project review, PR review, spec writing, role analysis, and agent workflows.
+
+## Methodology
+
+Each packet keeps five things separate: the goal, the relevant route or pattern IDs, the operating questions, the constraints, and the acceptance checks. Start with the packet, retrieve exact source only when needed, and stop when the done condition is satisfied.
+
 ## Project review packet
 
 Goal: make a project legible enough to decide the next work move.

--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -232,6 +232,14 @@ function renderPatternCatalogMarkdown(
     }),
     `# ${options.heading ?? options.title}`,
     '',
+    '## What this page is',
+    '',
+    'This is the full generated catalog of FPF pattern IDs from the published FPF snapshot. It is not the first adoption path and it is not a fpf-memory product feature list.',
+    '',
+    '## Methodology',
+    '',
+    'Start with [Start Here](/start-here), a route, or a work packet when the job is active. Use this catalog when you need to audit the full FPF reference, open an exact ID, or compare neighboring patterns by Part.',
+    '',
     `Generated pages: ${Object.keys(snapshot.patternGraph.nodes).length}`,
   ];
 
@@ -300,6 +308,14 @@ function renderHomeMarkdown(
     '',
     'Use the full First Principles Framework through small, grounded entry points instead of pasting the whole specification into every conversation.',
     '',
+    '## What this page is',
+    '',
+    'This is the fpf-memory adoption landing page for the published FPF reference. It explains how to enter FPF through small working surfaces; it is not the full specification, and it is not a product release page.',
+    '',
+    '## Methodology',
+    '',
+    'Name the work first, choose the smallest matching route or packet, then open generated pattern pages only when exact wording matters. Keep the full FPF intact as the canonical source while retrieving only the slice needed for the task.',
+    '',
     '## Start here',
     '',
     '- [Adoption guide](/start-here) — choose the first FPF path for a person, team, or agent.',
@@ -309,10 +325,10 @@ function renderHomeMarkdown(
     '',
     '## Navigate',
     '',
-    `- [Patterns](/generated/patterns/index) — ${patternCount} patterns across parts A–K`,
-    `- [Routes](/generated/routes/index) — ${routeCount} routes`,
-    '- [Glossary](/generated/patterns/H.1)',
-    '- [Change log](/generated/patterns/I.3)',
+    `- [Patterns](/generated/patterns/index) — full generated FPF pattern catalog with ${patternCount} patterns across parts A-K.`,
+    `- [Routes](/generated/routes/index) — ${routeCount} generated FPF working paths through pattern IDs, not website routes.`,
+    '- [Glossary](/generated/patterns/H.1) — FPF term glossary from the published source, not fpf-memory UI vocabulary.',
+    '- [Change log](/generated/patterns/I.3) — FPF specification change log from the published source, not fpf-memory product release notes.',
     '',
     '## MCP endpoint',
     '',
@@ -347,6 +363,14 @@ function buildRouteIndexPage(snapshot: Snapshot): GeneratedDocPage {
       outline: false,
     }),
     '# Route Catalog',
+    '',
+    '## What this page is',
+    '',
+    'Routes are generated FPF working paths through pattern IDs. They are not website routes, app routes, or navigation implementation details.',
+    '',
+    '## Methodology',
+    '',
+    'Use a route when the work shape is known but the exact patterns are not. Follow ordered steps first, use optional and landing points only when the task needs them, then open individual pattern pages for exact wording or audit evidence.',
     '',
     `Generated pages: ${routes.length}`,
   ];
@@ -395,6 +419,14 @@ function buildPrefaceIndexPage(snapshot: Snapshot): GeneratedDocPage {
       outline: false,
     }),
     '# Preface Catalog',
+    '',
+    '## What this page is',
+    '',
+    'This catalog lists generated reference pages from FPF preface and supporting sections. These pages explain how to read the specification; they are not fpf-memory product documentation.',
+    '',
+    '## Methodology',
+    '',
+    'Use these pages when you need interpretation guidance before applying a route or pattern. For active work, return to Start Here, a route, or a work packet after the reading burden is clear.',
   ];
 
   for (const [group, items] of groups.entries()) {
@@ -449,6 +481,8 @@ function renderPatternPage(snapshot: Snapshot, pattern: PatternRecord): string {
     lines.push(`> ${pattern.cluster}`);
   }
 
+  appendPatternContext(lines, pattern);
+
   if (introText) {
     lines.push('', introText);
   }
@@ -490,6 +524,47 @@ function renderPatternPage(snapshot: Snapshot, pattern: PatternRecord): string {
   }
 
   return `${lines.join('\n')}\n`;
+}
+
+function appendPatternContext(lines: string[], pattern: PatternRecord): void {
+  const context = patternPageContext(pattern);
+  lines.push(
+    '',
+    '## What this page is',
+    '',
+    context.what,
+    '',
+    '## Methodology',
+    '',
+    context.methodology,
+  );
+}
+
+function patternPageContext(pattern: PatternRecord): { what: string; methodology: string } {
+  if (pattern.id === 'H.1') {
+    return {
+      what:
+        'This is the FPF glossary generated from the published FPF source. It defines framework terms; it is not a glossary of fpf-memory UI, repository, or deployment terms.',
+      methodology:
+        'Use it to normalize terms before route or pattern work. When a term changes a decision, follow its linked or cited pattern ID instead of treating the glossary entry as a whole-task answer.',
+    };
+  }
+
+  if (pattern.id === 'I.3') {
+    return {
+      what:
+        'This is the FPF specification change log generated from the published FPF source. It is not the fpf-memory product changelog, product release notes, or GitHub history.',
+      methodology:
+        'Use it to understand semantic changes inside FPF itself. Use repository PRs, commits, or releases for product changes, and cite I.3 only when the specification evolution matters to the work.',
+    };
+  }
+
+  return {
+    what:
+      'This is a generated FPF pattern page projected from the published FPF source. It is canonical FPF content for this ID; it is not a fpf-memory product feature page.',
+    methodology:
+      'Read the ID, status, type, and normativity first. Use the content for exact wording, the relations for adjacent concepts, and citations to keep active work grounded without pasting the whole specification.',
+  };
 }
 
 function normalizedCatalogReminder(
@@ -534,6 +609,14 @@ function renderRoutePage(snapshot: Snapshot, route: RouteRecord): string {
     '',
     `# ${route.name}`,
     `> Route ${inlineCode(route.id)}`,
+    '',
+    '## What this page is',
+    '',
+    'This is an FPF route: a curated working path through pattern IDs. It is not a website route or application navigation route.',
+    '',
+    '## Methodology',
+    '',
+    'Use the ordered steps as the first path through the framework. Treat optional steps, landing points, route surfaces, and reroutes as controls for scope, ownership, and common wrong turns. Open exact pattern pages only when the work depends on their wording.',
   ];
 
   if (route.firstHonestBurden) {
@@ -581,6 +664,14 @@ function renderPrefacePage(snapshot: Snapshot, sectionId: string): string {
     '',
     `# ${section.title}`,
     `> Preface node ${inlineCode(sectionId)}`,
+    '',
+    '## What this page is',
+    '',
+    'This is generated FPF reference text from the specification preface or supporting sections. It helps interpret FPF; it is not fpf-memory product documentation.',
+    '',
+    '## Methodology',
+    '',
+    'Use it to understand how the specification wants to be read, then return to a route, pattern, or work packet for active work. Cite generated IDs only when the wording changes the task decision.',
   ];
 
   if (anchor.text.trim() || section.childIds.length > 0) {

--- a/tests/docs-projection.test.ts
+++ b/tests/docs-projection.test.ts
@@ -89,10 +89,33 @@ describe('docs projection', () => {
     const patternPage =
       projection.pagesByMarkdownPath['docs/generated/patterns/A.2.md']?.markdown ?? '';
 
+    expect(patternPage).toContain('## What this page is');
+    expect(patternPage).toContain('This is a generated FPF pattern page');
+    expect(patternPage).toContain('## Methodology');
     expect(patternPage).toContain('## Problem frame');
     expect(patternPage).not.toContain('## A.2:1 - Problem frame');
     expect(patternPage).toContain('> Pattern <span class="fpf-pid fpf-pid--a">A.2</span>');
     expect(patternPage).not.toContain('- **ID:** `A.2`');
+  });
+
+  it('explains generated glossary, changelog, and route pages by source and method', () => {
+    const projection = buildDocsProjection(snapshot);
+    const glossaryPage =
+      projection.pagesByMarkdownPath['docs/generated/patterns/H.1.md']?.markdown ?? '';
+    const changeLogPage =
+      projection.pagesByMarkdownPath['docs/generated/patterns/I.3.md']?.markdown ?? '';
+    const routeIndex =
+      projection.pagesByMarkdownPath['docs/generated/routes/index.md']?.markdown ?? '';
+    const routePage =
+      projection.pagesByMarkdownPath['docs/generated/routes/route_project-alignment.md']
+        ?.markdown ?? '';
+
+    expect(glossaryPage).toContain('This is the FPF glossary');
+    expect(glossaryPage).toContain('not a glossary of fpf-memory UI');
+    expect(changeLogPage).toContain('This is the FPF specification change log');
+    expect(changeLogPage).toContain('not the fpf-memory product changelog');
+    expect(routeIndex).toContain('They are not website routes');
+    expect(routePage).toContain('It is not a website route or application navigation route');
   });
 
   it('keeps hyphenated cluster names intact in breadcrumbs', () => {
@@ -207,6 +230,7 @@ describe('docs projection', () => {
       expect(rootIndex).toContain('[Routes](/generated/routes/index)');
       expect(rootIndex).toContain('[Glossary](/generated/patterns/H.1)');
       expect(rootIndex).toContain('[Change log](/generated/patterns/I.3)');
+      expect(rootIndex).toContain('FPF specification change log from the published source');
       expect(rootIndex).toContain('## MCP endpoint');
       expect(rootIndex).toContain('fpf-memory.server.mastra.cloud');
       expect(rootIndex).toContain('https://github.com/venikman/fpf-memory#run-and-test-mcp');
@@ -256,17 +280,35 @@ describe('docs projection', () => {
       expect(
         await readFile(resolve(outDir, 'generated/routes/route_project-alignment.html'), 'utf8'),
       ).toContain('project alignment');
+      expect(
+        await readFile(resolve(outDir, 'generated/patterns/I.3.html'), 'utf8'),
+      ).toContain('This is the FPF specification change log');
+      expect(
+        await readFile(resolve(outDir, 'generated/routes/index.html'), 'utf8'),
+      ).toContain('They are not website routes');
       expect(await readFile(resolve(outDir, 'start-here.html'), 'utf8')).toContain(
         'Pick a doorway',
+      );
+      expect(await readFile(resolve(outDir, 'start-here.html'), 'utf8')).toContain(
+        'This is the adoption entry surface',
       );
       expect(await readFile(resolve(outDir, 'work-packets.html'), 'utf8')).toContain(
         'Project review packet',
       );
+      expect(await readFile(resolve(outDir, 'work-packets.html'), 'utf8')).toContain(
+        'This is the task-sized operating surface',
+      );
       expect(await readFile(resolve(outDir, 'mcp-recipes.html'), 'utf8')).toContain(
         'Use MCP instead of pasted context',
       );
+      expect(await readFile(resolve(outDir, 'mcp-recipes.html'), 'utf8')).toContain(
+        'This is the agent and tool-use guide for fpf-memory',
+      );
       expect(await readFile(resolve(outDir, 'use-case-videos.html'), 'utf8')).toContain(
         'Product-level FPF use case recordings',
+      );
+      expect(await readFile(resolve(outDir, 'use-case-videos.html'), 'utf8')).toContain(
+        'This is the promotion and adoption evidence page',
       );
     } finally {
       await rm(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
Summary
- Adds What this page is and Methodology context to top-level wiki pages.
- Adds generated-page context for pattern, route, preface, and catalog pages.
- Clarifies that Change log is the FPF specification change log, not fpf-memory product release notes, and that Routes are FPF work paths, not website routes.

Validation
- bun run docs:generate
- bun run lint
- bun run check
- bun run check:boundaries
- bun run test -- tests/docs-projection.test.ts
- bun run test
- bun run docs:build
- bun run e2e:report -- docs --video-duration-ms 4000
- bun run build
- Playwright CSS-loaded page-context video recorded locally.

Artifacts
- E2E report: /Users/stas-studio/Developer/fpf-memory/.runtime/e2e-recordings/2026-05-02T14-37-11-041Z-docs-preview/report.md
- E2E video: /Users/stas-studio/Developer/fpf-memory/.runtime/e2e-recordings/2026-05-02T14-37-11-041Z-docs-preview/e2e-report.webm
- Page-context video: /Users/stas-studio/Developer/fpf-memory/.runtime/use-case-videos/2026-05-02T14-38-20-117Z-page-context-explanations/page-context-explanations.webm
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily additional explanatory copy in markdown generators and top-level docs, with tests updated to assert the new text; minimal impact beyond docs output formatting.
> 
> **Overview**
> Adds consistent **“What this page is”** and **“Methodology”** sections to the top-level wiki pages (`start-here`, `work-packets`, `mcp-recipes`, `use-case-videos`) to better frame each surface and how to use it.
> 
> Updates the docs generator (`src/core/documents.ts`) to inject the same context into generated pattern, route, preface, and catalog pages, including special-case wording for `H.1` (glossary) and `I.3` (FPF spec change log) and clearer navigation labels distinguishing FPF artifacts from fpf-memory product docs.
> 
> Extends docs projection/build tests to assert the presence of the new explanatory sections in both generated markdown and built HTML output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a955e8db753af97c3ea0a3c79a16f0e3d46ca6ae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->