### PR TITLE
ci: bound MCP deploy runtime

### DIFF
--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -66,6 +66,7 @@ jobs:
   deploy:
     needs: guard
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Automatic deploys only run after the `CI` workflow succeeds on a
     # push to `main`. `workflow_dispatch` remains available as an explicit
     # maintainer override.
@@ -116,6 +117,7 @@ jobs:
             > .mastra-project.json
 
       - name: Deploy to Mastra Cloud
+        timeout-minutes: 8
         env:
           # The Mastra CLI reads `MASTRA_API_TOKEN` in headless mode.
           # The existing repo secret is `MASTRA_KEY` — remap at the


### PR DESCRIPTION
Summary
- Adds a 15-minute timeout to the MCP deploy job.
- Adds an 8-minute timeout to the Mastra Cloud deploy step so a hung CLI cannot block newer deploys indefinitely.

Why
- Earlier today a stale Mastra deploy stayed in the deploy step for over 40 minutes and blocked the next deploy lane until cancellation. The workflow already declares newer deploys supersede older ones; these timeouts make that promise enforceable.

Validation
- ruby -e "require 'psych'; Psych.parse_file('.github/workflows/deploy-mcp.yml'); puts 'workflow yaml parsed'"
- git diff --check
- bun run test -- tests/deploy-staging.test.ts
- bun run build:mcp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change, but an overly aggressive timeout could cause legitimate Mastra deployments to fail and require reruns.
> 
> **Overview**
> Prevents stalled MCP deploys from monopolizing the deploy lane by adding a **15-minute timeout** to the `deploy` job and an **8-minute timeout** specifically around the `Deploy to Mastra Cloud` step in `.github/workflows/deploy-mcp.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b04e08828dcf5d4b59f892c6e5422c139ffef56. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->