### PR TITLE
docs: add product-role feedback packet

### DIFF
--- a/docs/mcp-recipes.md
+++ b/docs/mcp-recipes.md
@@ -66,6 +66,23 @@ Prompt:
 Use only the fpf_memory MCP server. Build an FPF work packet for <task>. Include goal, relevant route or IDs, operating questions, constraints, acceptance checks, risks, and one next move. Do not paste the whole FPF.
 ```
 
+## Dogfood a product role
+
+Prompt:
+
+```txt
+Use only bounded FPF retrieval plus direct product evidence. Act as <persona> trying to complete <job> with fpf-memory. Return Context | Persona/job | Surface | FPF IDs used | Evidence | Friction | Proposed improvement | Severity | Validation path. Keep the answer discussion-ready and do not paste the full FPF.
+```
+
+Good personas to rotate:
+
+- new adopter
+- project lead
+- PR/code reviewer
+- spec writer
+- agent integrator
+- product maintainer
+
 ## Review work with FPF
 
 Prompt:

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -24,6 +24,7 @@ Name the work shape first, pick the smallest matching doorway, and keep exact FP
 | --- | --- | --- |
 | Align a project or team | [Project alignment route](/generated/routes/route_project-alignment) | Shared context, role/method/work split, first work surface |
 | Review a PR or design change | [Writing or reviewing patterns](/generated/routes/route_writing-or-reviewing-patterns) | Findings tied to IDs, constraints, risks, and tests |
+| Dogfood a product as a user role | [Product-role feedback packet](/work-packets#product-role-feedback-packet) | Replayable job, friction evidence, proposed improvement, discussion-ready feedback |
 | Write a specification | [E.8](/generated/patterns/E.8) + [E.19](/generated/patterns/E.19) | Clear pattern order, semantic change record, acceptance harness |
 | Unpack an API, contract, or promise | [Boundary burden route](/generated/routes/route_boundary-burden) | Atomic claims, boundary duties, evidence needs |
 | Compare options | [Lawful comparison route](/generated/routes/route_lawful-comparison-or-portfolio-selection) | Governed shortlist or set result |
@@ -36,7 +37,7 @@ Do not ask people to read all FPF before they can benefit from it. Ask for the w
 
 ## Fast adoption path
 
-1. Name the work: project alignment, review, specification, boundary unpacking, comparison, or agent use.
+1. Name the work: project alignment, review, product-role feedback, specification, boundary unpacking, comparison, or agent use.
 2. Open the matching route or work packet.
 3. Capture the current claim, role, method, promise, evidence, and risk in ordinary language.
 4. Add exact FPF IDs only where they change the decision or the acceptance checks.

--- a/docs/use-case-videos.md
+++ b/docs/use-case-videos.md
@@ -28,6 +28,12 @@ For a quicker local check:
 bun run videos:use-cases -- --skip-build --duration-ms 3000
 ```
 
+For one new adoption path:
+
+```bash
+bun run videos:use-cases -- --scenario docs-product-role-feedback --duration-ms 5000
+```
+
 Artifacts are written under `.runtime/use-case-videos/<timestamp>-fpf-product-use-cases/`. That folder includes a `README.md`, `manifest.json`, one `.webm` per scenario, and transcript pages for command and MCP recordings.
 
 ## Scenario set
@@ -35,6 +41,7 @@ Artifacts are written under `.runtime/use-case-videos/<timestamp>-fpf-product-us
 | Surface | Video | Shows |
 | --- | --- | --- |
 | Docs wiki | Pick the right doorway | Start from the adoption page, choose a work doorway, then open the matching route or packet. |
+| Docs wiki | Dogfood product-role feedback | Act as one product user role, capture friction, and turn it into discussion-ready evidence. |
 | Docs wiki | Audit exact source | Move from a route to the exact generated pattern page when wording matters. |
 | MCP runtime | Bounded agent context | Retrieve a compact project-alignment packet through MCP instead of pasting all FPF. |
 | MCP runtime | Retrieval provenance | Use the full local MCP surface when trace evidence matters. |

--- a/docs/work-packets.md
+++ b/docs/work-packets.md
@@ -1,6 +1,6 @@
 ---
 title: "Work Packets"
-description: "Task-sized FPF packets for project review, PR review, specs, role/promise analysis, and agent workflows."
+description: "Task-sized FPF packets for project review, PR review, product-role feedback, specs, role/promise analysis, and agent workflows."
 outline: false
 ---
 
@@ -10,7 +10,7 @@ A work packet is a small grounded slice of FPF for doing one job. It is not a re
 
 ## What this page is
 
-This is the task-sized operating surface for using FPF in real work. It turns the framework into bounded packets for project review, PR review, spec writing, role analysis, and agent workflows.
+This is the task-sized operating surface for using FPF in real work. It turns the framework into bounded packets for project review, PR review, product-role feedback, spec writing, role analysis, and agent workflows.
 
 ## Methodology
 
@@ -58,6 +58,30 @@ Packet:
 - Verdict: merge, fix first, or split scope.
 
 Done when: every finding points at a concrete behavior, file, or missing check.
+
+## Product-role feedback packet
+
+Goal: act as one concrete user role and turn product friction into evidence-backed adoption feedback.
+
+Use:
+
+- [E.12 Human Feedback Loop](/generated/patterns/E.12)
+- [route:project-alignment](/generated/routes/route_project-alignment)
+- [A.1.1 U.BoundedContext](/generated/patterns/A.1.1)
+- [A.15 Role / Method / Work stratification](/generated/patterns/A.15)
+- [A.2.2 U.Capability](/generated/patterns/A.2.2)
+- [A.2.3 U.PromiseContent](/generated/patterns/A.2.3)
+
+Packet:
+
+- Persona: which role is trying the product, and what job do they need done?
+- Surface: docs wiki, hosted MCP, CLI, evaluator, deploy evidence, or automation feedback.
+- Job: what concrete task should be possible without pasting the full FPF?
+- Friction: what explanation, route, affordance, evidence, or compact context was missing?
+- Evidence: URL, command, MCP call, screenshot, video, issue, discussion, or log path.
+- Feedback: one proposed improvement, severity, and validation path.
+
+Done when: the role/job can be replayed by another person, the feedback points at exact evidence, and the output is either a focused PR, issue, GitHub Discussion, or no-new-feedback checkpoint.
 
 ## Specification writing packet
 

--- a/scripts/record-use-case-videos.ts
+++ b/scripts/record-use-case-videos.ts
@@ -80,6 +80,7 @@ export interface ParsedRecordUseCaseVideoArgs {
   skipBuild: boolean;
   artifactRoot: string;
   durationMs: number;
+  scenarioSlugs: string[];
 }
 
 export interface RecordedUseCase {
@@ -202,6 +203,41 @@ export const USE_CASE_SCENARIOS: UseCaseVideoScenario[] = [
         heading: 'Relations',
         stage: 'Useful outcome',
         message: 'The reviewer can inspect relation context before accepting or challenging the citation.',
+      },
+    ],
+  },
+  {
+    kind: 'docs',
+    slug: 'docs-product-role-feedback',
+    product: 'Docs/wiki',
+    title: 'Dogfood product-role feedback',
+    initialState: 'A product maintainer wants real adoption feedback, not a generic opinion.',
+    problem: 'Feedback must come from one role doing one job with bounded FPF context and visible evidence.',
+    tools: ['/start-here', '/work-packets#product-role-feedback-packet', '/mcp-recipes#dogfood-a-product-role'],
+    outcome: 'The maintainer gets a replayable job, friction evidence, a proposed improvement, and a validation path.',
+    recordingSteps: [
+      'Open Start Here and select the product-role feedback doorway.',
+      'Open the product-role feedback packet and show the evidence fields.',
+      'Open the MCP recipe that turns the run into discussion-ready feedback.',
+    ],
+    docsSteps: [
+      {
+        path: '/start-here',
+        heading: 'Dogfood a product as a user role',
+        stage: 'Initial state',
+        message: 'The doorway frames feedback as one role doing one concrete product job.',
+      },
+      {
+        path: '/work-packets#product-role-feedback-packet',
+        heading: 'Product-role feedback packet',
+        stage: 'Tool in action',
+        message: 'The packet separates persona, surface, job, friction, evidence, and proposed improvement.',
+      },
+      {
+        path: '/mcp-recipes#dogfood-a-product-role',
+        heading: 'Dogfood a product role',
+        stage: 'Useful outcome',
+        message: 'The recipe produces discussion-ready feedback without loading the full FPF.',
       },
     ],
   },
@@ -447,11 +483,14 @@ export function parseRecordUseCaseVideoArgs(args: string[]): ParsedRecordUseCase
     skipBuild: false,
     artifactRoot: DEFAULT_ARTIFACT_ROOT,
     durationMs: DEFAULT_DURATION_MS,
+    scenarioSlugs: [],
   };
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index]!;
     switch (arg) {
+      case '--':
+        break;
       case '--skip-build':
         parsed.skipBuild = true;
         break;
@@ -463,12 +502,34 @@ export function parseRecordUseCaseVideoArgs(args: string[]): ParsedRecordUseCase
         parsed.durationMs = readPositiveInteger(args, index, arg);
         index += 1;
         break;
+      case '--scenario':
+        parsed.scenarioSlugs.push(readOptionValue(args, index, arg));
+        index += 1;
+        break;
       default:
         throw new Error(`Unknown record-use-case-videos option: ${arg}`);
     }
   }
 
   return parsed;
+}
+
+export function selectUseCaseScenarios(scenarioSlugs: string[]): UseCaseVideoScenario[] {
+  if (scenarioSlugs.length === 0) {
+    return USE_CASE_SCENARIOS;
+  }
+
+  const selected = scenarioSlugs.map((slug) => {
+    const scenario = USE_CASE_SCENARIOS.find((candidate) => candidate.slug === slug);
+    if (!scenario) {
+      throw new Error(
+        `Unknown use-case video scenario "${slug}". Expected one of: ${USE_CASE_SCENARIOS.map((candidate) => candidate.slug).join(', ')}`,
+      );
+    }
+    return scenario;
+  });
+
+  return selected;
 }
 
 export function buildUseCaseVideoArtifactDirName(now: Date): string {
@@ -542,7 +603,8 @@ export async function recordUseCaseVideos(
   const browser = await chromium.launch({ headless: true });
   try {
     const videos: RecordedUseCase[] = [];
-    for (const scenario of USE_CASE_SCENARIOS) {
+    const scenarios = selectUseCaseScenarios(args.scenarioSlugs);
+    for (const scenario of scenarios) {
       if (scenario.kind === 'docs') {
         videos.push(
           await recordDocsUseCase({

--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -319,7 +319,7 @@ function renderHomeMarkdown(
     '## Start here',
     '',
     '- [Adoption guide](/start-here) — choose the first FPF path for a person, team, or agent.',
-    '- [Work packets](/work-packets) — use FPF in project review, PR review, specification work, role/promise/capability analysis, and agent workflows.',
+    '- [Work packets](/work-packets) — use FPF in project review, PR review, product-role feedback, specification work, role/promise/capability analysis, and agent workflows.',
     '- [MCP recipes](/mcp-recipes) — retrieve compact grounded slices from the hosted or local MCP server.',
     '- [Demo videos](/use-case-videos) — record CSS-rendered walkthroughs that show how people and agents use FPF without a full-spec paste.',
     '',

--- a/tests/docs-projection.test.ts
+++ b/tests/docs-projection.test.ts
@@ -223,6 +223,7 @@ describe('docs projection', () => {
       expect(rootIndex).toContain('## Start here');
       expect(rootIndex).toContain('[Adoption guide](/start-here)');
       expect(rootIndex).toContain('[Work packets](/work-packets)');
+      expect(rootIndex).toContain('product-role feedback');
       expect(rootIndex).toContain('[MCP recipes](/mcp-recipes)');
       expect(rootIndex).toContain('[Demo videos](/use-case-videos)');
       expect(rootIndex).toContain('## Navigate');
@@ -298,11 +299,17 @@ describe('docs projection', () => {
       expect(await readFile(resolve(outDir, 'work-packets.html'), 'utf8')).toContain(
         'This is the task-sized operating surface',
       );
+      expect(await readFile(resolve(outDir, 'work-packets.html'), 'utf8')).toContain(
+        'Product-role feedback packet',
+      );
       expect(await readFile(resolve(outDir, 'mcp-recipes.html'), 'utf8')).toContain(
         'Use MCP instead of pasted context',
       );
       expect(await readFile(resolve(outDir, 'mcp-recipes.html'), 'utf8')).toContain(
         'This is the agent and tool-use guide for fpf-memory',
+      );
+      expect(await readFile(resolve(outDir, 'mcp-recipes.html'), 'utf8')).toContain(
+        'Dogfood a product role',
       );
       expect(await readFile(resolve(outDir, 'use-case-videos.html'), 'utf8')).toContain(
         'Product-level FPF use case recordings',

--- a/tests/e2e-report.test.ts
+++ b/tests/e2e-report.test.ts
@@ -19,6 +19,7 @@ import {
   parseRecordUseCaseVideoArgs,
   PRODUCT_SURFACES,
   renderUseCaseVideoReadme,
+  selectUseCaseScenarios,
   USE_CASE_SCENARIOS,
   type RecordedUseCase,
 } from '../scripts/record-use-case-videos.js';
@@ -93,6 +94,7 @@ describe('E2E report tooling', () => {
 
   it('parses use-case video recording options', () => {
     const args = parseRecordUseCaseVideoArgs([
+      '--',
       '--skip-build',
       '--artifact-root',
       '.runtime/demo-videos',
@@ -104,13 +106,26 @@ describe('E2E report tooling', () => {
       skipBuild: true,
       artifactRoot: '.runtime/demo-videos',
       durationMs: 2_000,
+      scenarioSlugs: [],
     });
     expect(buildUseCaseVideoArtifactDirName(new Date('2026-05-02T12:00:00.000Z'))).toBe(
       '2026-05-02T12-00-00-000Z-fpf-product-use-cases',
     );
   });
 
-  it('defines two use-case video scenarios for each product surface', () => {
+  it('selects individual use-case video scenarios for incremental recordings', () => {
+    const args = parseRecordUseCaseVideoArgs(['--scenario', 'docs-product-role-feedback']);
+
+    expect(args.scenarioSlugs).toEqual(['docs-product-role-feedback']);
+    expect(selectUseCaseScenarios(args.scenarioSlugs).map((scenario) => scenario.slug)).toEqual([
+      'docs-product-role-feedback',
+    ]);
+    expect(() => selectUseCaseScenarios(['missing-scenario'])).toThrow(
+      /Unknown use-case video scenario/u,
+    );
+  });
+
+  it('defines at least two use-case video scenarios for each product surface', () => {
     const grouped = groupUseCaseScenariosByProduct(USE_CASE_SCENARIOS);
 
     expect(PRODUCT_SURFACES).toEqual([
@@ -120,8 +135,11 @@ describe('E2E report tooling', () => {
       'Work evaluator',
     ]);
     for (const product of PRODUCT_SURFACES) {
-      expect(grouped[product].map((scenario) => scenario.slug)).toHaveLength(2);
+      expect(grouped[product].map((scenario) => scenario.slug).length).toBeGreaterThanOrEqual(2);
     }
+    expect(grouped['Docs/wiki'].map((scenario) => scenario.slug)).toContain(
+      'docs-product-role-feedback',
+    );
   });
 
   it('keeps each use-case scenario narration complete', () => {


### PR DESCRIPTION
## Summary
- add a product-role feedback packet for replayable adoption dogfooding
- add an MCP recipe for bounded role feedback outputs
- add a docs use-case video scenario and --scenario filtering for incremental recordings

## Validation
- git diff --check
- bun run test -- tests/e2e-report.test.ts
- bun run test -- tests/docs-projection.test.ts
- bun run check
- bun run videos:use-cases -- --scenario docs-product-role-feedback --duration-ms 5000
- bun run e2e:report -- docs --video-duration-ms 3000
- bun run lint
- bun run check:boundaries
- bun run test
- bun run build

## Artifacts
- Product-role demo video: /Users/stas-studio/Developer/fpf-memory/.runtime/use-case-videos/2026-05-02T16-36-57-108Z-fpf-product-use-cases/docs-product-role-feedback.webm
- Docs E2E report: /Users/stas-studio/Developer/fpf-memory/.runtime/e2e-recordings/2026-05-02T16-37-13-087Z-docs-preview/report.md
- Docs E2E video: /Users/stas-studio/Developer/fpf-memory/.runtime/e2e-recordings/2026-05-02T16-37-13-087Z-docs-preview/e2e-report.webm
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly documentation additions, but it also changes the Playwright use-case video recorder to accept `--scenario` filtering, which could affect CI/adoption video tooling if argument parsing or selection logic regresses.
> 
> **Overview**
> Adds a new **product-role dogfooding** adoption path: a `Product-role feedback packet` in `work-packets`, a matching doorway entry in `start-here`, and an MCP prompt recipe for producing discussion-ready role feedback.
> 
> Extends the demo-video workflow with a new docs scenario (`docs-product-role-feedback`) and updates the recorder script to support incremental recordings via `--scenario` (including scenario validation/selection). Tests are updated to assert the new docs content and the new scenario-selection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 878eca985dae3f0a10e634418d4905e8ab550c9a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->