### PR TITLE
ci: cap rstest workers on CI

### DIFF
--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -6,4 +6,10 @@ export default defineConfig({
   clearMocks: true,
   restoreMocks: true,
   testTimeout: 20_000,
+  pool: {
+    type: 'forks',
+    // The suite compiles and serves the full FPF surface in multiple files.
+    // Keep CI below the GitHub runner memory cliff while preserving local speed.
+    maxWorkers: process.env.CI ? 1 : '50%',
+  },
 });


### PR DESCRIPTION
## Summary
- cap Rstest workers to 1 on CI so full-spec runtime and MCP subprocess tests run serially on GitHub runners
- keep local runs parallel at 50% worker capacity
- document why the cap exists in rstest.config.ts

## Validation
- git diff --check
- bun run test -- tests/mcp-session-roundtrip.test.ts tests/runtime-path-resolution.test.ts
- bun run check
- bun run lint
- bun run check:boundaries
- bun run e2e:report -- --name ci-rstest-serial --command "CI=true bun run test" --timeout-ms 480000 --video-duration-ms 3000

## Artifacts
- E2E report: /Users/stas-studio/Developer/fpf-memory/.runtime/e2e-recordings/2026-05-02T17-42-45-786Z-ci-rstest-serial/report.md
- E2E video: /Users/stas-studio/Developer/fpf-memory/.runtime/e2e-recordings/2026-05-02T17-42-45-786Z-ci-rstest-serial/e2e-report.webm