### PR TITLE
docs: add PR review demo path

### DIFF
--- a/docs/mcp-recipes.md
+++ b/docs/mcp-recipes.md
@@ -83,6 +83,21 @@ Good personas to rotate:
 - agent integrator
 - product maintainer
 
+## Review a PR without full-spec paste
+
+Prompt:
+
+```txt
+Use only the fpf_memory MCP server plus the PR diff, local files, and CI evidence. Review this PR through the PR or code review packet. Return Findings | FPF IDs | Evidence | Tests | Residual risk | Verdict. Lead with behavioral issues and cite exact files; do not paste the full FPF.
+```
+
+Good retrieval shape:
+
+- Start with `query_fpf_spec` for `route:writing-or-reviewing-patterns`.
+- Add `route:boundary-burden` only when the change touches an API, contract, workflow, protocol, CI gate, or deploy promise.
+- Read exact pattern pages only when a finding depends on the wording.
+- Keep the verdict tied to evidence: merge, fix first, or split scope.
+
 ## Review work with FPF
 
 Prompt:

--- a/docs/use-case-videos.md
+++ b/docs/use-case-videos.md
@@ -42,6 +42,7 @@ Artifacts are written under `.runtime/use-case-videos/<timestamp>-fpf-product-us
 | --- | --- | --- |
 | Docs wiki | Pick the right doorway | Start from the adoption page, choose a work doorway, then open the matching route or packet. |
 | Docs wiki | Dogfood product-role feedback | Act as one product user role, capture friction, and turn it into discussion-ready evidence. |
+| Docs wiki | Review a PR without full-spec paste | Start from the review doorway, open the PR review packet, then use a compact MCP recipe for findings and verdict. |
 | Docs wiki | Audit exact source | Move from a route to the exact generated pattern page when wording matters. |
 | MCP runtime | Bounded agent context | Retrieve a compact project-alignment packet through MCP instead of pasting all FPF. |
 | MCP runtime | Retrieval provenance | Use the full local MCP surface when trace evidence matters. |

--- a/scripts/record-use-case-videos.ts
+++ b/scripts/record-use-case-videos.ts
@@ -242,6 +242,41 @@ export const USE_CASE_SCENARIOS: UseCaseVideoScenario[] = [
     ],
   },
   {
+    kind: 'docs',
+    slug: 'docs-pr-review-without-full-spec',
+    product: 'Docs/wiki',
+    title: 'Review a PR without full-spec paste',
+    initialState: 'A reviewer has a PR or design change and needs FPF discipline.',
+    problem: 'A generic review can miss claims, boundaries, and evidence, while a full-spec paste wastes context.',
+    tools: ['/start-here', '/work-packets#pr-or-code-review-packet', '/mcp-recipes#review-a-pr-without-full-spec-paste'],
+    outcome: 'The reviewer gets findings tied to behavior, FPF IDs, evidence, tests, residual risk, and verdict.',
+    recordingSteps: [
+      'Open Start Here and select the PR or design review doorway.',
+      'Open the PR or code review packet and show the claim, boundary, evidence, risk, and verdict fields.',
+      'Open the MCP recipe that keeps review context bounded to the needed route and evidence.',
+    ],
+    docsSteps: [
+      {
+        path: '/start-here',
+        heading: 'Review a PR or design change',
+        stage: 'Initial state',
+        message: 'The doorway starts from the work shape: one PR or design change that needs review.',
+      },
+      {
+        path: '/work-packets#pr-or-code-review-packet',
+        heading: 'PR or code review packet',
+        stage: 'Tool in action',
+        message: 'The packet separates claim, boundary, evidence, risk, and verdict before reading more FPF.',
+      },
+      {
+        path: '/mcp-recipes#review-a-pr-without-full-spec-paste',
+        heading: 'Review a PR without full-spec paste',
+        stage: 'Useful outcome',
+        message: 'The recipe keeps the review grounded in compact FPF IDs, local evidence, tests, and residual risk.',
+      },
+    ],
+  },
+  {
     kind: 'mcp',
     slug: 'mcp-bounded-agent-context',
     product: 'MCP runtime',

--- a/tests/docs-projection.test.ts
+++ b/tests/docs-projection.test.ts
@@ -311,8 +311,14 @@ describe('docs projection', () => {
       expect(await readFile(resolve(outDir, 'mcp-recipes.html'), 'utf8')).toContain(
         'Dogfood a product role',
       );
+      expect(await readFile(resolve(outDir, 'mcp-recipes.html'), 'utf8')).toContain(
+        'Review a PR without full-spec paste',
+      );
       expect(await readFile(resolve(outDir, 'use-case-videos.html'), 'utf8')).toContain(
         'Product-level FPF use case recordings',
+      );
+      expect(await readFile(resolve(outDir, 'use-case-videos.html'), 'utf8')).toContain(
+        'Review a PR without full-spec paste',
       );
       expect(await readFile(resolve(outDir, 'use-case-videos.html'), 'utf8')).toContain(
         'This is the promotion and adoption evidence page',

--- a/tests/e2e-report.test.ts
+++ b/tests/e2e-report.test.ts
@@ -140,6 +140,9 @@ describe('E2E report tooling', () => {
     expect(grouped['Docs/wiki'].map((scenario) => scenario.slug)).toContain(
       'docs-product-role-feedback',
     );
+    expect(grouped['Docs/wiki'].map((scenario) => scenario.slug)).toContain(
+      'docs-pr-review-without-full-spec',
+    );
   });
 
   it('keeps each use-case scenario narration complete', () => {


### PR DESCRIPTION
Summary:\n- Add a compact MCP recipe for reviewing PRs without pasting the full FPF.\n- Add the PR review scenario to the demo-video catalog and Playwright recording registry.\n- Cover the new scenario in projection and E2E-report tests.\n\nValidation:\n- bun run test -- tests/e2e-report.test.ts\n- bun run test -- tests/docs-projection.test.ts\n- bun run videos:use-cases -- --skip-build --scenario docs-pr-review-without-full-spec --duration-ms 5000\n- bun run e2e:report -- docs --video-duration-ms 3000\n- bun run lint\n- bun run check\n- bun run check:boundaries\n- git diff --check\n- bun run test\n- bun run build
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation and demo-scenario registry updates with small test adjustments; no runtime/product logic changes beyond demo metadata.
> 
> **Overview**
> Adds a new MCP recipe for **reviewing PRs without pasting the full spec**, including a suggested retrieval sequence and a structured review output (findings, FPF IDs, evidence, tests, residual risk, verdict).
> 
> Extends the demo-video catalog and the Playwright use-case recording registry with a new Docs/wiki scenario (`docs-pr-review-without-full-spec`) that walks through the review doorway, PR review packet, and the new recipe.
> 
> Updates docs projection and e2e-report tests to assert the new recipe section and scenario are present in the built docs output and scenario grouping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e94934142be975415b9b20661d4cd5507fbdf224. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->