### PR TITLE
ci: wrap mastra deploy install

### DIFF
--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -125,4 +125,4 @@ jobs:
           MASTRA_API_TOKEN: ${{ secrets.MASTRA_KEY }}
           MASTRA_ORG_ID: ${{ vars.MASTRA_ORG_ID }}
           MASTRA_PROJECT_ID: ${{ vars.MASTRA_PROJECT_ID }}
-        run: bunx mastra server deploy --yes
+        run: bun run mastra:deploy -- --yes

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "videos:use-cases": "bun scripts/record-use-case-videos.ts",
     "stage:from-published": "bun scripts/stage-from-published.ts",
     "mastra:build": "bun scripts/mastra-build.ts",
+    "mastra:deploy": "bun scripts/mastra-deploy.ts",
     "build": "bun run build:runtime && bun run build:mcp",
     "build:runtime": "bun build ./src/cli.ts ./src/server.ts --outdir dist --target bun",
     "build:mcp": "tsup src/mastra/stdio.ts --format esm --out-dir dist --no-splitting && bun scripts/fixup-stdio-build.ts",
@@ -34,7 +35,7 @@
     "check:boundaries": "bun scripts/check-boundaries.ts",
     "test": "rstest run",
     "predeploy": "bun run stage:from-published",
-    "deploy": "bun run predeploy && bun run mastra:build && bunx mastra server deploy --yes"
+    "deploy": "bun run predeploy && bun run mastra:build && bun run mastra:deploy -- --yes"
   },
   "license": "ISC",
   "type": "module",

--- a/scripts/mastra-deploy.ts
+++ b/scripts/mastra-deploy.ts
@@ -1,0 +1,5 @@
+import { runMastraServerDeploy } from '../src/build/mastra-build.js';
+
+await runMastraServerDeploy({
+  args: process.argv.slice(2),
+});

--- a/src/build/mastra-build.ts
+++ b/src/build/mastra-build.ts
@@ -23,8 +23,8 @@ const TEMPORARY_PACKAGE_LOCK = {
  * under the project root. This repo is Bun-first, but the generated
  * `.mastra/output` package hangs on `bun install` while `npm install` completes
  * quickly and deterministically. Create a temporary root `package-lock.json`
- * during `mastra build` so the nested install uses npm without changing the
- * repo's primary package manager.
+ * during `mastra build` and `mastra server deploy` so the nested install uses
+ * npm without changing the repo's primary package manager.
  */
 export async function withTemporaryMastraPackageLock<T>(
   rootDir: string,
@@ -59,6 +59,21 @@ export async function runMastraBuild(
 
   await withTemporaryMastraPackageLock(rootDir, async () => {
     await runCommand('bunx', ['mastra', 'build', ...args], {
+      cwd: rootDir,
+      env: process.env,
+    });
+  });
+}
+
+export async function runMastraServerDeploy(
+  options: RunMastraBuildOptions = {},
+): Promise<void> {
+  const rootDir = resolve(options.rootDir ?? process.cwd());
+  const args = options.args ?? [];
+  const runCommand = options.runCommand ?? runSpawnedCommand;
+
+  await withTemporaryMastraPackageLock(rootDir, async () => {
+    await runCommand('bunx', ['mastra', 'server', 'deploy', ...args], {
       cwd: rootDir,
       env: process.env,
     });

--- a/tests/mastra-build.test.ts
+++ b/tests/mastra-build.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from '@rstest/core';
 
 import {
   runMastraBuild,
+  runMastraServerDeploy,
   withTemporaryMastraPackageLock,
 } from '../src/build/mastra-build.js';
 
@@ -56,7 +57,7 @@ describe('withTemporaryMastraPackageLock', () => {
   });
 });
 
-describe('runMastraBuild', () => {
+describe('Mastra CLI wrappers', () => {
   let tempRoot: string;
 
   beforeEach(async () => {
@@ -81,6 +82,24 @@ describe('runMastraBuild', () => {
     });
 
     expect(seenArgs).toEqual(['bunx', 'mastra', 'build', '--debug']);
+    expect(sawTemporaryLock).toBe(true);
+    expect(await pathExists(resolve(tempRoot, 'package-lock.json'))).toBe(false);
+  });
+
+  it('runs mastra server deploy while the temporary package-lock.json exists', async () => {
+    let sawTemporaryLock = false;
+    let seenArgs: string[] | undefined;
+
+    await runMastraServerDeploy({
+      rootDir: tempRoot,
+      args: ['--yes'],
+      runCommand: async (command, args, options) => {
+        seenArgs = [command, ...args];
+        sawTemporaryLock = await pathExists(resolve(options.cwd, 'package-lock.json'));
+      },
+    });
+
+    expect(seenArgs).toEqual(['bunx', 'mastra', 'server', 'deploy', '--yes']);
     expect(sawTemporaryLock).toBe(true);
     expect(await pathExists(resolve(tempRoot, 'package-lock.json'))).toBe(false);
   });


### PR DESCRIPTION
Summary:\n- Add a mastra:deploy wrapper that runs mastra server deploy under the temporary package-lock workaround.\n- Switch local deploy and the MCP deploy workflow to use the wrapper so Mastra's internal build/install uses npm instead of hanging on Bun.\n- Add unit coverage for the deploy wrapper.\n\nValidation:\n- bun run test -- tests/mastra-build.test.ts\n- bun run mastra:deploy -- --help\n- bun run lint\n- bun run check\n- bun run check:boundaries\n- git diff --check\n- bun run e2e:report -- deploy-dry-run --video-duration-ms 3000\n- bun run test\n- bun run build
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the deployment execution path in both CI and local scripts, which could affect release reliability if the wrapper behavior diverges from direct CLI usage. Scope is limited to build/deploy tooling and adds test coverage for the new wrapper.
> 
> **Overview**
> Routes Mastra cloud deployments through a new `mastra:deploy` script that runs `mastra server deploy` under the existing temporary `package-lock.json` workaround (to force Mastra’s nested install to use npm instead of Bun).
> 
> Updates the MCP deploy GitHub Actions workflow and the top-level `deploy` npm script to use this wrapper, and adds a unit test to ensure the temporary lockfile exists during deploy and is cleaned up afterward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a612ac689b0cc4a44dfc3c27e4679947852fbe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->