### PR TITLE
fix: resolve route ids in read_fpf_doc

### DIFF
--- a/src/runtime/query-engine.ts
+++ b/src/runtime/query-engine.ts
@@ -312,6 +312,11 @@ export class QueryEngine {
     }
 
     if (kind === 'route' || kind === 'auto') {
+      const routeIdMatch = this.routeIdSelectorMatch(selector, normalizedSelector);
+      if (routeIdMatch) {
+        return routeIdMatch;
+      }
+
       const routeMatch = this.snapshot.indexes.routeNameIndex[normalizedSelector]?.[0];
       if (routeMatch) {
         return routeMatch;
@@ -337,6 +342,20 @@ export class QueryEngine {
     }
 
     return undefined;
+  }
+
+  private routeIdSelectorMatch(
+    selector: string,
+    normalizedSelector: string,
+  ): string | undefined {
+    const exactNode = this.snapshot.compiledNodes[selector];
+    if (exactNode?.kind === 'route') {
+      return exactNode.id;
+    }
+
+    return this.snapshot.indexes.idIndex[normalizedSelector]?.find(
+      (nodeId) => this.snapshot.compiledNodes[nodeId]?.kind === 'route',
+    );
   }
 
   private bestLexemeSelectorMatch(normalizedSelector: string): string | undefined {

--- a/tests/fpf-spec-runtime.test.ts
+++ b/tests/fpf-spec-runtime.test.ts
@@ -270,6 +270,14 @@ describe('FpfRuntime', () => {
     );
     expect(readByRoute.markdown).toContain('# project alignment');
 
+    const readByRouteId = await runtime.readDoc('route:project-alignment', 'route');
+    expect(readByRouteId.status).toBe('ok');
+    expect(readByRouteId.resolvedAs).toBe('route');
+    expect(readByRouteId.nodeId).toBe('route:project-alignment');
+    expect(readByRouteId.docRef?.markdownPath).toBe(
+      'docs/generated/routes/route_project-alignment.md',
+    );
+
     const readByLexeme = await runtime.readDoc('U.BoundedContext', 'lexeme');
     expect(readByLexeme.status).toBe('ok');
     expect(readByLexeme.nodeId).toBe('A.1.1');

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -299,6 +299,18 @@ describe('Mastra MCP server', () => {
     expect(readDocPayload.nodeId).toBe('A.1.1');
     expect(readDocPayload.markdown).toContain('# U.BoundedContext: The Semantic Frame');
 
+    const readRouteDoc = await harness.request('tools/call', {
+      name: 'read_fpf_doc',
+      arguments: {
+        selector: 'route:project-alignment',
+        kind: 'route',
+      },
+    });
+    const readRouteDocPayload = asToolPayload(readRouteDoc);
+    expect(readRouteDocPayload.resolvedAs).toBe('route');
+    expect(readRouteDocPayload.nodeId).toBe('route:project-alignment');
+    expect(readRouteDocPayload.markdown).toContain('# project alignment');
+
     const ask = await harness.request('tools/call', {
       name: 'ask_fpf',
       arguments: {


### PR DESCRIPTION
## What

Fixes `read_fpf_doc` route-kind resolution so route IDs returned by `browse_fpf_catalog`, such as `route:project-alignment`, resolve to their generated route docs.

## Why

Product feedback in Discussion #61 showed the hosted MCP catalog can expose useful route IDs, but `read_fpf_doc({ selector: "route:boundary-burden", kind: "route" })` returned `not_found`. That breaks the compact adoption path from route discovery to exact route wording.

## Type

- `fix` — bug fix

## Changes

- Accept exact route IDs in the route selector branch before falling back to route-name lookup.
- Add runtime and MCP-server regression coverage for `read_fpf_doc` with `kind: "route"` and a `route:*` selector.

## Validation

- `bun run check` passes locally
- `bun run test tests/fpf-spec-runtime.test.ts` passes locally
- `bun run test tests/mcp-server.test.ts` passes locally
- Not run: `bun run lint`, full `bun run test`, `bun run build`
- E2E report command: `bun run e2e:report -- cli`
- E2E path exercised: CLI work-evaluation smoke for CLI/MCP/retrieval changes
- E2E video recording path/link: `/Users/stas-studio/.codex/worktrees/e709/fpf-memory/.runtime/e2e-recordings/2026-05-03T03-27-42-549Z-cli-smoke/e2e-report.webm`
- E2E report path/link: `/Users/stas-studio/.codex/worktrees/e709/fpf-memory/.runtime/e2e-recordings/2026-05-03T03-27-42-549Z-cli-smoke/report.md`
- E2E caveats or blocker: evaluator reports `usable_with_followups` with existing medium wiki working-model and term-sheet followups; no blocker/high gaps.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/adapters/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | `daily-fpf-feedback-review-and-address` |
| Prompt  | Daily FPF feedback review and address |

Related: https://github.com/venikman/fpf-memory/discussions/61

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted change to selector resolution for `kind: "route"`, plus regression tests; main risk is unintended selector ambiguity if an ID matches multiple node kinds.
> 
> **Overview**
> Fixes `readDoc`/`read_fpf_doc` resolution for `kind: "route"` so exact route IDs like `route:project-alignment` resolve to the generated route markdown instead of falling through to route-name matching.
> 
> Adds `QueryEngine.routeIdSelectorMatch()` to prefer compiled-node route IDs (and route-typed matches from the ID index) before route-name lookup, and adds runtime + MCP server tests covering `read_fpf_doc` with a `route:*` selector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 053a6b3acc2b9008a6e157c0091cf96a3dd0195f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->