### PR TITLE
ci: shard rstest on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,10 @@ jobs:
         run: bun run check
 
       - name: Test
-        run: bun run test
+        # Run the CI suite in two fresh Rstest processes. The full FPF suite
+        # can push a single long-lived worker over the GitHub runner memory
+        # cliff even with `maxWorkers: 1`.
+        run: bun run test:ci
 
       - name: Build docs
         run: bun run docs:build

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "check": "tsc --noEmit",
     "check:boundaries": "bun scripts/check-boundaries.ts",
     "test": "rstest run",
+    "test:ci": "rstest run --shard=1/2 && rstest run --shard=2/2",
     "predeploy": "bun run stage:from-published",
     "deploy": "bun run predeploy && bun run mastra:build && bun run mastra:deploy -- --yes"
   },


### PR DESCRIPTION
## What

Runs the CI test suite through two Rstest shards instead of one long `rstest run` process.

## Why

After PR #64 was merged, main CI failed twice in the Test step after 171 tests had already passed. The failed file reported zero tests and `Worker exited unexpectedly`, while the same file and nearby slice pass locally. Splitting the CI suite gives Rstest a fresh process mid-suite and avoids the GitHub runner worker cliff without changing local `bun run test` behavior.

## Type

- `chore` — maintenance (deps, CI, cleanup)

## Changes

- Add `bun run test:ci` as `rstest run --shard=1/2 && rstest run --shard=2/2`.
- Point the GitHub Actions CI Test step at `bun run test:ci`.

## Validation

- `bun run check` passes locally
- `git diff --check` passes locally
- E2E report command: `bun run e2e:report -- --name ci-rstest-shards --timeout-ms 600000 --command "CI=1 bun run test:ci"`
- E2E path exercised: CI-equivalent sharded Rstest suite
- E2E video recording path/link: `/Users/stas-studio/.codex/worktrees/e709/fpf-memory/.runtime/e2e-recordings/2026-05-03T05-04-09-961Z-ci-rstest-shards/e2e-report.webm`
- E2E report path/link: `/Users/stas-studio/.codex/worktrees/e709/fpf-memory/.runtime/e2e-recordings/2026-05-03T05-04-09-961Z-ci-rstest-shards/report.md`
- E2E caveats or blocker: the first E2E attempt used the default 120000 ms timeout and timed out after shard 1 passed; rerun with 600000 ms passed both shards.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/adapters/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | follow-up to merge PR #64 |
| Prompt  | if you happy - merge |

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that alters how tests are executed (two shards/processes) without affecting production code paths; main risk is potential shard-related ordering/flake issues.
> 
> **Overview**
> Updates CI to run the test suite via a new `bun run test:ci` command that executes `rstest` in two shards (`--shard=1/2` then `--shard=2/2`) instead of a single long `rstest run`.
> 
> This is intended to reduce GitHub Actions memory-related worker crashes by splitting the suite across two fresh processes, while keeping the local `bun run test` behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 255e7e53658b64390fe5e905db64cafab919a72e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->