### PR TITLE
ci: split rstest into four shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: bun run check
 
       - name: Test
-        # Run the CI suite in two fresh Rstest processes. The full FPF suite
+        # Run the CI suite in four fresh Rstest processes. The full FPF suite
         # can push a single long-lived worker over the GitHub runner memory
         # cliff even with `maxWorkers: 1`.
         run: bun run test:ci

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "check": "tsc --noEmit",
     "check:boundaries": "bun scripts/check-boundaries.ts",
     "test": "rstest run",
-    "test:ci": "rstest run --shard=1/2 && rstest run --shard=2/2",
+    "test:ci": "rstest run --shard=1/4 && rstest run --shard=2/4 && rstest run --shard=3/4 && rstest run --shard=4/4",
     "predeploy": "bun run stage:from-published",
     "deploy": "bun run predeploy && bun run mastra:build && bun run mastra:deploy -- --yes"
   },


### PR DESCRIPTION
## Summary

- Split CI `test:ci` from two Rstest shards into four fresh Rstest processes.
- Update the workflow comment to match the new process boundary.

## Why

PR #65 reduced the original full-suite worker crash but main still failed in shard 2 at `tests/mcp-session-roundtrip.test.ts` with `Worker exited unexpectedly`. Four shards lowers the cumulative work per Rstest process further while keeping the change reversible and limited to CI execution.

## Validation

- `bun run check`
- `git diff --check`
- `bun run e2e:report -- --name ci-rstest-four-shards --timeout-ms 600000 --command "CI=1 bun run test:ci"`

E2E recording: `/Users/stas-studio/.codex/worktrees/e709/fpf-memory/.runtime/e2e-recordings/2026-05-03T05-25-18-279Z-ci-rstest-four-shards/e2e-report.webm`

E2E report: `/Users/stas-studio/.codex/worktrees/e709/fpf-memory/.runtime/e2e-recordings/2026-05-03T05-25-18-279Z-ci-rstest-four-shards/report.md`

## Risk

This only changes CI test process partitioning. It does not change product code, schemas, deploy configuration, or dependencies.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts CI test sharding/execution to reduce per-process load; no product code or dependencies change.
> 
> **Overview**
> Updates CI test execution to run `rstest` in **four shards** instead of two by expanding `test:ci` into four separate shard invocations.
> 
> Also updates the workflow comment in `.github/workflows/ci.yml` to reflect the new four-process test strategy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 111a90ac59389b07307a93e112b6776edf0f9150. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->