### PR TITLE
ci: parallelize jobs, cache bun deps, scope concurrency to PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,39 @@ permissions:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded PR runs, but keep main-branch runs so post-merge signal
+  # isn't lost if commits land back-to-back.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # Opt into the Node.js 24 runtime for JavaScript actions ahead of the
+  # June 2026 forced upgrade. Silences the actions/checkout@v4 deprecation
+  # warning without changing pinned action versions.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
-  ci:
+  setup:
+    name: Install + validate published
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      cache-key: ${{ steps.cache-key.outputs.key }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.5
+
+      - id: cache-key
+        run: echo "key=bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ steps.cache-key.outputs.key }}
 
       - run: bun install --frozen-lockfile
 
@@ -33,27 +55,92 @@ jobs:
         # broken push doesn't reach the deploy job.
         run: bun run validate:published
 
-      - name: Lint
-        run: bun run lint
+  lint:
+    name: Lint + boundaries
+    runs-on: ubuntu-latest
+    needs: setup
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ needs.setup.outputs.cache-key }}
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run check:boundaries
 
-      - name: Boundary check
-        run: bun run check:boundaries
+  typecheck:
+    name: Type check
+    runs-on: ubuntu-latest
+    needs: setup
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ needs.setup.outputs.cache-key }}
+      - run: bun install --frozen-lockfile
+      - run: bun run check
 
-      - name: Type check
-        run: bun run check
+  test:
+    name: Test (shard ${{ matrix.shard }}/4)
+    runs-on: ubuntu-latest
+    needs: setup
+    timeout-minutes: 15
+    strategy:
+      # Surface every failing shard, don't mask 2-4 because shard 1 broke.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ needs.setup.outputs.cache-key }}
+      - run: bun install --frozen-lockfile
+      # Run one shard per runner. The full FPF suite can push a single
+      # long-lived worker over the GitHub runner memory cliff even with
+      # `maxWorkers: 1`, so each shard gets a fresh process *and* a fresh
+      # runner.
+      - run: bunx rstest run --shard=${{ matrix.shard }}/4
 
-      - name: Test
-        # Run the CI suite in four fresh Rstest processes. The full FPF suite
-        # can push a single long-lived worker over the GitHub runner memory
-        # cliff even with `maxWorkers: 1`.
-        run: bun run test:ci
-
-      - name: Build docs
-        run: bun run docs:build
-
-      - name: Build MCP bundle
-        run: bun run build:mcp
-
+  build:
+    name: Build (docs + MCP + mastra dry-run)
+    runs-on: ubuntu-latest
+    needs: setup
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ needs.setup.outputs.cache-key }}
+      - run: bun install --frozen-lockfile
+      - run: bun run docs:build
+      - run: bun run build:mcp
       - name: Stage + mastra build (deploy dry-run)
         # Assemble the deploy bundle without uploading. Catches packaging
         # regressions (missing hosted files, broken `mastra build`) on
@@ -64,3 +151,18 @@ jobs:
           test -f .mastra/output/index.mjs
           test -f .mastra/output/hosted/FPF-Spec.md
           test -f .mastra/output/hosted/fpf-index/snapshot.json
+
+  # Single green check for branch protection: required only this job, and
+  # it goes green iff every parallel job above succeeded.
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    needs: [setup, lint, typecheck, test, build]
+    if: always()
+    steps:
+      - name: Verify all jobs succeeded
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,19 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
-  # Cancel superseded PR runs, but keep main-branch runs so post-merge signal
-  # isn't lost if commits land back-to-back.
+  # PRs share a group per PR number so a follow-up commit cancels the prior
+  # run. Pushes to `main` use the SHA so every commit gets its own group —
+  # otherwise GitHub's per-group queue (only one pending run is kept) would
+  # silently discard intermediate `main` commits when they land faster than
+  # CI can start, even with `cancel-in-progress: false`.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
+  # Single source of truth for the bun toolchain version. Used by setup-bun
+  # in every job and baked into the cache key so a version bump invalidates
+  # incompatible node_modules caches.
+  BUN_VERSION: '1.3.5'
   # Opt into the Node.js 24 runtime for JavaScript actions ahead of the
   # June 2026 forced upgrade. Silences the actions/checkout@v4 deprecation
   # warning without changing pinned action versions.
@@ -33,10 +40,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: ${{ env.BUN_VERSION }}
 
       - id: cache-key
-        run: echo "key=bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}" >> "$GITHUB_OUTPUT"
+        # Include the bun version + runner arch so toolchain bumps and
+        # cross-arch runners don't restore an incompatible node_modules.
+        run: echo "key=bun-${{ env.BUN_VERSION }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         with:
@@ -64,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/cache@v4
         with:
           path: |
@@ -84,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/cache@v4
         with:
           path: |
@@ -108,7 +117,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/cache@v4
         with:
           path: |
@@ -131,7 +140,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/cache@v4
         with:
           path: |
@@ -152,17 +161,26 @@ jobs:
           test -f .mastra/output/hosted/FPF-Spec.md
           test -f .mastra/output/hosted/fpf-index/snapshot.json
 
-  # Single green check for branch protection: required only this job, and
-  # it goes green iff every parallel job above succeeded.
+  # Single green check for branch protection: this is the only required
+  # status. It goes green iff every parallel job above succeeded. The job
+  # ID stays `ci` (no `name:` override) so the status-check context
+  # remains `CI / ci`, matching existing branch-protection rules.
   ci:
-    name: CI
     runs-on: ubuntu-latest
     needs: [setup, lint, typecheck, test, build]
     if: always()
     steps:
-      - name: Verify all jobs succeeded
+      - name: Verify all required jobs succeeded
+        # Require every dependency result to be exactly `success`. Checking
+        # only for `failure`/`cancelled` would let a `skipped` result slip
+        # through as green if a future change adds an `if:` to a job.
         run: |
-          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
-            echo "One or more required jobs failed or were cancelled."
-            exit 1
-          fi
+          results='${{ join(needs.*.result, ',') }}'
+          echo "Required job results: $results"
+          IFS=','
+          for r in $results; do
+            if [[ "$r" != "success" ]]; then
+              echo "::error::A required job did not succeed (got: '$r')."
+              exit 1
+            fi
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,6 @@ env:
   # in every job and baked into the cache key so a version bump invalidates
   # incompatible node_modules caches.
   BUN_VERSION: '1.3.5'
-  # Opt into the Node.js 24 runtime for JavaScript actions ahead of the
-  # June 2026 forced upgrade. Silences the actions/checkout@v4 deprecation
-  # warning without changing pinned action versions.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   setup:
@@ -36,7 +32,7 @@ jobs:
     outputs:
       cache-key: ${{ steps.cache-key.outputs.key }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -47,7 +43,7 @@ jobs:
         # cross-arch runners don't restore an incompatible node_modules.
         run: echo "key=bun-${{ env.BUN_VERSION }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache
@@ -70,11 +66,11 @@ jobs:
     needs: setup
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache
@@ -90,11 +86,11 @@ jobs:
     needs: setup
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache
@@ -114,11 +110,11 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache
@@ -137,11 +133,11 @@ jobs:
     needs: setup
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache


### PR DESCRIPTION
## Summary
- Splits the previously-monolithic `ci` job into `setup` → parallel `{lint, typecheck, test (matrix 1..4), build}` so a lint or typecheck failure surfaces in <1 min instead of after the full sequential run.
- Test shards now run on **separate runners** via `strategy.matrix` (one runner per shard) instead of four sequential `rstest run` invocations on a single runner. Wall-clock test time drops to the longest single shard.
- Adds `actions/cache@v4` keyed on `bun.lock` so `bun install --frozen-lockfile` is a fast no-op after the first run.
- Adds per-job `timeout-minutes` (5m for fast checks, 15m for test/build) — a hung process can no longer burn 6 hours of runner time.
- Scopes `cancel-in-progress` to `pull_request` only so back-to-back commits to `main` don't lose post-merge CI signal.
- Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at the workflow level to silence the `actions/checkout@v4` Node-20 deprecation warning ahead of the June 2026 forced upgrade.
- Adds a single `ci` aggregator job at the bottom so existing branch-protection rules that require the `ci` check keep working without changes.

## Why
A recent run on PR #70 was auto-cancelled mid-test by the `concurrency` block when a follow-up commit landed. While investigating, several adjacent CI weaknesses surfaced:
1. The job is monolithic — a 5s lint failure waits 5 minutes behind preceding steps.
2. Test shards run sequentially on one runner — the `&&` chain in `test:ci` doesn't actually parallelize.
3. No bun cache — `bun install` is paid in full every run.
4. No job-level timeouts — a hung shard could exhaust runner-minutes silently.
5. `cancel-in-progress: true` applies to every ref, including `main` pushes.
6. Node-20 deprecation warning on every run.

## Trade-off worth flagging
Splitting the job adds ~30s of overhead per child job (queue + checkout + cache restore + bun-install validation). Wall-clock time drops significantly, but **runner-minute usage per run goes up** because more runners are involved. If cost is a concern over latency, the cheaper subset is to keep a single job and only adopt the `matrix` for test shards.

## Test plan
- [ ] CI on this PR runs the new workflow end-to-end and goes green.
- [ ] `setup` runs first; `lint`, `typecheck`, `test` (×4), `build` all run in parallel after it.
- [ ] Aggregator `ci` job goes green only when all upstream jobs succeed (verify by inspecting the run graph).
- [ ] Cache hit on the second push (cold install on first run, restored on subsequent runs).
- [ ] If branch protection currently requires the `ci` check, confirm it still resolves — the aggregator job preserves the name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it restructures the GitHub Actions pipeline (job dependencies, matrix sharding, caching, and concurrency cancellation), which can cause false positives/negatives or missed CI signal if misconfigured.
> 
> **Overview**
> Refactors the GitHub Actions workflow from a single sequential `ci` job into a `setup` job followed by parallel `lint`, `typecheck`, `test` (4-way matrix shard), and `build` jobs, with an aggregator `ci` job to keep a single required check for branch protection.
> 
> Adds Bun dependency caching keyed by `bun.lock`, per-job timeouts, PR-only `cancel-in-progress` behavior, and a workflow-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var to silence upcoming JavaScript action runtime deprecation warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10e73d0503e45431ea03199e08b25b57f7fe5aa0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->