### PR TITLE
refactor(runtime): land source parser scanner rewrite

### DIFF
--- a/published/current/manifest.json
+++ b/published/current/manifest.json
@@ -1,10 +1,10 @@
 {
   "channel": "latest-published",
   "sourceHash": "sha256:4bd579472278104ec472ad32f473b51a58d43e6066cc605f7693badcd2ca691d",
-  "compilerFingerprint": "sha256:9576bedb3cc2db23a27428714a78d2d5cf403b1cf511994c62de016607ed072c",
+  "compilerFingerprint": "sha256:49804e6faa640494c9b3f0789910ce11101f6de356ad9ad2b796611b8787d99e",
   "upstreamRef": "75536eb67fe58e6ffe5c87d21631403fd71c3e10",
   "specPath": "published/current/FPF-Spec.md",
   "snapshotPath": "published/current/fpf-index/snapshot.json",
   "specBytes": 5449072,
-  "publishedAt": "2026-05-03T21:46:50.854Z"
+  "publishedAt": "2026-05-03T23:29:49.755Z"
 }

--- a/published/current/manifest.json
+++ b/published/current/manifest.json
@@ -1,10 +1,10 @@
 {
   "channel": "latest-published",
   "sourceHash": "sha256:4bd579472278104ec472ad32f473b51a58d43e6066cc605f7693badcd2ca691d",
-  "compilerFingerprint": "sha256:49804e6faa640494c9b3f0789910ce11101f6de356ad9ad2b796611b8787d99e",
+  "compilerFingerprint": "sha256:c02a02f71af145621cdd5b3e935258091de10bf95801d372dab47d10e2d2b101",
   "upstreamRef": "75536eb67fe58e6ffe5c87d21631403fd71c3e10",
   "specPath": "published/current/FPF-Spec.md",
   "snapshotPath": "published/current/fpf-index/snapshot.json",
   "specBytes": 5449072,
-  "publishedAt": "2026-05-03T23:29:49.755Z"
+  "publishedAt": "2026-05-03T23:49:38.957Z"
 }

--- a/src/build/compiler-fingerprint.ts
+++ b/src/build/compiler-fingerprint.ts
@@ -16,6 +16,7 @@ export const SNAPSHOT_COMPILER_FINGERPRINT_INPUTS = [
   'src/runtime/index-projector.ts',
   'src/runtime/validation-runner.ts',
   'src/runtime/text.ts',
+  'src/runtime/text-scan.ts',
 ] as const;
 
 export const DEFAULT_COMPILER_FINGERPRINT_ROOT = resolve(

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -17,6 +17,10 @@ import {
   SessionCache,
   type RetrievalSessionState,
 } from './session-cache.js';
+import {
+  collapseWhitespace,
+  findTokenPosition,
+} from './text-scan.js';
 import type {
   AnswerMode,
   BrowseCatalogResult,
@@ -723,103 +727,13 @@ function nodeToCatalogEntry(
 
 const SNIPPET_RADIUS = 80;
 
-function isAsciiAlphaNumeric(character: string | undefined): boolean {
-  return (
-    character !== undefined &&
-    ((character >= 'a' && character <= 'z') ||
-      (character >= '0' && character <= '9') ||
-      (character >= 'A' && character <= 'Z'))
-  );
-}
-
-function isInlineWhitespace(character: string | undefined): boolean {
-  return (
-    character === ' ' ||
-    character === '\t' ||
-    character === '\n' ||
-    character === '\r' ||
-    character === '\f'
-  );
-}
-
-function findCollapsedTokenPosition(
-  lower: string,
-  token: string,
-): { pos: number; len: number } | undefined {
-  for (let start = 0; start < lower.length; start += 1) {
-    if (lower[start] !== token[0]) {
-      continue;
-    }
-
-    let cursor = start + 1;
-    let tokenIndex = 1;
-    while (tokenIndex < token.length) {
-      while (cursor < lower.length && !isAsciiAlphaNumeric(lower[cursor])) {
-        cursor += 1;
-      }
-      if (cursor >= lower.length || lower[cursor] !== token[tokenIndex]) {
-        tokenIndex = -1;
-        break;
-      }
-      cursor += 1;
-      tokenIndex += 1;
-    }
-
-    if (tokenIndex === token.length) {
-      return { pos: start, len: cursor - start };
-    }
-  }
-
-  return undefined;
-}
-
-function findTokenPosition(
-  lower: string,
-  token: string,
-): { pos: number; len: number } | undefined {
-  // Try literal substring match first.
-  const literalPos = lower.indexOf(token);
-  if (literalPos !== -1) {
-    return { pos: literalPos, len: token.length };
-  }
-
-  // For collapsed tokens (e.g. "a23" from "A.2.3"), match the same
-  // alphanumeric sequence while allowing only punctuation or spacing between
-  // characters.
-  if (token.length > 0) {
-    return findCollapsedTokenPosition(lower, token);
-  }
-
-  return undefined;
-}
-
-function collapseWhitespace(text: string): string {
-  let result = '';
-  let sawWhitespace = false;
-
-  for (const character of text) {
-    if (isInlineWhitespace(character)) {
-      sawWhitespace = result.length > 0;
-      continue;
-    }
-    if (sawWhitespace) {
-      result += ' ';
-      sawWhitespace = false;
-    }
-    result += character;
-  }
-
-  return result.trim();
-}
-
 function extractSnippet(searchableText: string, queryTokens: string[]): string {
-  const lower = searchableText.toLowerCase();
   let bestPos = 0;
   let bestLen = 0;
   let bestTokenLen = 0;
 
   for (const token of queryTokens) {
-    const hit = findTokenPosition(lower, token);
+    const hit = findTokenPosition(searchableText, token);
     if (hit && token.length > bestTokenLen) {
       bestPos = hit.pos;
       bestLen = hit.len;

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -723,8 +723,57 @@ function nodeToCatalogEntry(
 
 const SNIPPET_RADIUS = 80;
 
+function isAsciiAlphaNumeric(character: string | undefined): boolean {
+  return (
+    character !== undefined &&
+    ((character >= 'a' && character <= 'z') ||
+      (character >= '0' && character <= '9') ||
+      (character >= 'A' && character <= 'Z'))
+  );
+}
+
+function isInlineWhitespace(character: string | undefined): boolean {
+  return (
+    character === ' ' ||
+    character === '\t' ||
+    character === '\n' ||
+    character === '\r' ||
+    character === '\f'
+  );
+}
+
+function findCollapsedTokenPosition(
+  lower: string,
+  token: string,
+): { pos: number; len: number } | undefined {
+  for (let start = 0; start < lower.length; start += 1) {
+    if (lower[start] !== token[0]) {
+      continue;
+    }
+
+    let cursor = start + 1;
+    let tokenIndex = 1;
+    while (tokenIndex < token.length) {
+      while (cursor < lower.length && !isAsciiAlphaNumeric(lower[cursor])) {
+        cursor += 1;
+      }
+      if (cursor >= lower.length || lower[cursor] !== token[tokenIndex]) {
+        tokenIndex = -1;
+        break;
+      }
+      cursor += 1;
+      tokenIndex += 1;
+    }
+
+    if (tokenIndex === token.length) {
+      return { pos: start, len: cursor - start };
+    }
+  }
+
+  return undefined;
+}
+
 function findTokenPosition(
-  searchableText: string,
   lower: string,
   token: string,
 ): { pos: number; len: number } | undefined {
@@ -734,20 +783,33 @@ function findTokenPosition(
     return { pos: literalPos, len: token.length };
   }
 
-  // For collapsed tokens (e.g. "a23" from "A.2.3"), try matching with
-  // optional non-alphanumeric separators between each character.
+  // For collapsed tokens (e.g. "a23" from "A.2.3"), match the same
+  // alphanumeric sequence while allowing only punctuation or spacing between
+  // characters.
   if (token.length > 0) {
-    const escaped = Array.from(token).map((c) =>
-      c.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
-    );
-    const pattern = new RegExp(escaped.join('[^a-z0-9]*'), 'i');
-    const match = pattern.exec(searchableText);
-    if (match && match.index !== undefined) {
-      return { pos: match.index, len: match[0].length };
-    }
+    return findCollapsedTokenPosition(lower, token);
   }
 
   return undefined;
+}
+
+function collapseWhitespace(text: string): string {
+  let result = '';
+  let sawWhitespace = false;
+
+  for (const character of text) {
+    if (isInlineWhitespace(character)) {
+      sawWhitespace = result.length > 0;
+      continue;
+    }
+    if (sawWhitespace) {
+      result += ' ';
+      sawWhitespace = false;
+    }
+    result += character;
+  }
+
+  return result.trim();
 }
 
 function extractSnippet(searchableText: string, queryTokens: string[]): string {
@@ -757,7 +819,7 @@ function extractSnippet(searchableText: string, queryTokens: string[]): string {
   let bestTokenLen = 0;
 
   for (const token of queryTokens) {
-    const hit = findTokenPosition(searchableText, lower, token);
+    const hit = findTokenPosition(lower, token);
     if (hit && token.length > bestTokenLen) {
       bestPos = hit.pos;
       bestLen = hit.len;
@@ -782,7 +844,7 @@ function extractSnippet(searchableText: string, queryTokens: string[]): string {
     }
   }
 
-  let snippet = searchableText.slice(start, end).replace(/\s+/g, ' ').trim();
+  let snippet = collapseWhitespace(searchableText.slice(start, end));
   if (start > 0) {
     snippet = `…${snippet}`;
   }

--- a/src/runtime/source-parser.ts
+++ b/src/runtime/source-parser.ts
@@ -65,20 +65,281 @@ const RELATION_LABELS: Record<string, RelationKind> = {
   'interacts with': 'interacts_with',
 };
 
-const RELATION_LABEL_ALTERNATION = Object.keys(RELATION_LABELS)
-  .sort((left, right) => right.length - left.length)
-  .map((label) => label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-  .join('|');
-const RELATION_LABEL_TOKEN =
-  `(?:\\*\\*\\s*)?(?:${RELATION_LABEL_ALTERNATION}):(?:\\s*\\*\\*)?`;
-const LABELED_RELATION_REGEX = new RegExp(
-  `(?:\\*\\*\\s*)?(${RELATION_LABEL_ALTERNATION}):(?:\\s*\\*\\*)?\\s*([\\s\\S]*?)(?=(?:\\s*(?:[*-]\\s*)?${RELATION_LABEL_TOKEN})|$)`,
-  'gis',
+const ORDERED_RELATION_LABELS = Object.keys(RELATION_LABELS).sort(
+  (left, right) => right.length - left.length,
 );
 
 const PATTERN_ROW_ID = /^\**[A-Z]\.\d+(?:\.[A-Za-z0-9]+)*\**$/;
-const HEADING_ID =
-  /^([A-Z]\.\d+(?:\.[A-Za-z0-9]+)*(?::[A-Za-z0-9.]+)?)\s+-\s+(.+)$/;
+
+interface ParsedHeadingLine {
+  level: number;
+  title: string;
+  fullId?: string;
+  patternId?: string;
+}
+
+interface RelationLabelMatch {
+  start: number;
+  label: string;
+  contentStart: number;
+}
+
+function isAsciiWhitespace(character: string | undefined): boolean {
+  return character === ' ' || character === '\t' || character === '\n' || character === '\r';
+}
+
+function skipWhitespace(text: string, startIndex: number): number {
+  let index = startIndex;
+  while (index < text.length && isAsciiWhitespace(text[index])) {
+    index += 1;
+  }
+  return index;
+}
+
+function isUppercaseLetter(character: string | undefined): boolean {
+  return character !== undefined && character >= 'A' && character <= 'Z';
+}
+
+function isAsciiDigit(character: string | undefined): boolean {
+  return character !== undefined && character >= '0' && character <= '9';
+}
+
+function isAsciiAlphaNumeric(character: string | undefined): boolean {
+  return (
+    character !== undefined &&
+    ((character >= 'A' && character <= 'Z') ||
+      (character >= 'a' && character <= 'z') ||
+      (character >= '0' && character <= '9'))
+  );
+}
+
+function parseHeadingLine(line: string): ParsedHeadingLine | undefined {
+  let index = 0;
+  while (index < line.length && line[index] === '#') {
+    index += 1;
+  }
+
+  if (index === 0 || index > 6 || !isAsciiWhitespace(line[index])) {
+    return undefined;
+  }
+
+  const level = index;
+  const title = cleanMarkdown(line.slice(skipWhitespace(line, index)));
+  const { fullId, patternId } = parseStructuredHeading(title);
+  return { level, title, fullId, patternId };
+}
+
+function parseStructuredHeading(
+  title: string,
+): { fullId?: string; patternId?: string } {
+  const separatorIndex = findSpacedDashSeparator(title);
+  if (separatorIndex < 0) {
+    return {};
+  }
+
+  const fullId = title.slice(0, separatorIndex).trimEnd();
+  const remainder = title.slice(separatorIndex + 1).trimStart();
+  if (!remainder || !isStructuredHeadingId(fullId)) {
+    return {};
+  }
+
+  return {
+    fullId,
+    patternId: fullId.split(':')[0],
+  };
+}
+
+function findSpacedDashSeparator(text: string): number {
+  for (let index = 1; index < text.length - 1; index += 1) {
+    if (
+      text[index] === '-' &&
+      isAsciiWhitespace(text[index - 1]) &&
+      isAsciiWhitespace(text[index + 1])
+    ) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function isStructuredHeadingId(value: string): boolean {
+  let index = 0;
+  if (!isUppercaseLetter(value[index])) {
+    return false;
+  }
+  index += 1;
+
+  if (value[index] !== '.') {
+    return false;
+  }
+  index += 1;
+
+  const afterMajor = consumeDigits(value, index);
+  if (afterMajor === index) {
+    return false;
+  }
+  index = afterMajor;
+
+  while (value[index] === '.') {
+    index += 1;
+    const nextIndex = consumeAlphaNumeric(value, index);
+    if (nextIndex === index) {
+      return false;
+    }
+    index = nextIndex;
+  }
+
+  if (value[index] === ':') {
+    index += 1;
+    const nextIndex = consumeAlphaNumericOrDots(value, index);
+    if (nextIndex === index) {
+      return false;
+    }
+    index = nextIndex;
+  }
+
+  return index === value.length;
+}
+
+function consumeDigits(text: string, startIndex: number): number {
+  let index = startIndex;
+  while (isAsciiDigit(text[index])) {
+    index += 1;
+  }
+  return index;
+}
+
+function consumeAlphaNumeric(text: string, startIndex: number): number {
+  let index = startIndex;
+  while (isAsciiAlphaNumeric(text[index])) {
+    index += 1;
+  }
+  return index;
+}
+
+function consumeAlphaNumericOrDots(text: string, startIndex: number): number {
+  let index = startIndex;
+  while (isAsciiAlphaNumeric(text[index]) || text[index] === '.') {
+    index += 1;
+  }
+  return index;
+}
+
+function isDashCharacter(character: string | undefined): boolean {
+  return character === '-' || character === '–' || character === '—';
+}
+
+function parseCatalogPartHeading(line: string): string | undefined {
+  if (!line.startsWith('**') || !line.endsWith('**')) {
+    return undefined;
+  }
+
+  const normalized = normalizeLabel(line.slice(2, -2));
+  if (!normalized.startsWith('Part ')) {
+    return undefined;
+  }
+
+  let index = 'Part '.length;
+  const letter = normalized[index];
+  if (!isUppercaseLetter(letter)) {
+    return undefined;
+  }
+  index += 1;
+  index = skipWhitespace(normalized, index);
+
+  if (!isDashCharacter(normalized[index])) {
+    return undefined;
+  }
+  index += 1;
+  index = skipWhitespace(normalized, index);
+
+  const title = normalized.slice(index).trim();
+  if (!title) {
+    return undefined;
+  }
+
+  return `Part ${letter} - ${title}`;
+}
+
+function stripLeadingBlockquoteMarker(line: string): string {
+  if (!line.startsWith('>')) {
+    return line;
+  }
+  return line.slice(skipWhitespace(line, 1));
+}
+
+function parseLabeledValue(line: string): { key: string; value: string } | undefined {
+  const separatorIndex = line.indexOf(':');
+  if (separatorIndex <= 0) {
+    return undefined;
+  }
+
+  const key = line.slice(0, separatorIndex).trim();
+  const value = line.slice(separatorIndex + 1).trim();
+  if (!key || !value) {
+    return undefined;
+  }
+
+  return { key, value };
+}
+
+function findNextRelationLabel(
+  text: string,
+  lower: string,
+  fromIndex: number,
+): RelationLabelMatch | undefined {
+  for (let index = fromIndex; index < text.length; index += 1) {
+    const match = parseRelationLabelAt(text, lower, index);
+    if (match) {
+      return match;
+    }
+  }
+  return undefined;
+}
+
+function parseRelationLabelAt(
+  text: string,
+  lower: string,
+  startIndex: number,
+): RelationLabelMatch | undefined {
+  let index = skipWhitespace(text, startIndex);
+
+  if (text[index] === '-' || (text[index] === '*' && text[index + 1] !== '*')) {
+    index += 1;
+    index = skipWhitespace(text, index);
+  }
+
+  if (text[index] === '*' && text[index + 1] === '*') {
+    index += 2;
+    index = skipWhitespace(text, index);
+  }
+
+  for (const label of ORDERED_RELATION_LABELS) {
+    if (!lower.startsWith(label, index)) {
+      continue;
+    }
+
+    let cursor = index + label.length;
+    if (text[cursor] !== ':') {
+      continue;
+    }
+    cursor += 1;
+    cursor = skipWhitespace(text, cursor);
+
+    if (text[cursor] === '*' && text[cursor + 1] === '*') {
+      cursor += 2;
+      cursor = skipWhitespace(text, cursor);
+    }
+
+    return {
+      start: startIndex,
+      label,
+      contentStart: cursor,
+    };
+  }
+
+  return undefined;
+}
 
 export function parseSource(sourceText: string): SourceIR {
   const lines = sourceText.split(/\r?\n/);
@@ -103,22 +364,16 @@ function parseHeadingSections(lines: string[]): HeadingSection[] {
   }> = [];
 
   for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index];
-    const match = line.match(/^(#{1,6})\s+(.*)$/);
-    if (!match) {
+    const parsedHeading = parseHeadingLine(lines[index] ?? '');
+    if (!parsedHeading) {
       continue;
     }
-    const level = match[1].length;
-    const title = cleanMarkdown(match[2]);
-    const idMatch = title.match(HEADING_ID);
-    const fullId = idMatch?.[1];
-    const patternId = fullId ? fullId.split(':')[0] : undefined;
     headings.push({
       lineIndex: index,
-      level,
-      title,
-      fullId,
-      patternId,
+      level: parsedHeading.level,
+      title: parsedHeading.title,
+      fullId: parsedHeading.fullId,
+      patternId: parsedHeading.patternId,
     });
   }
 
@@ -276,9 +531,9 @@ function parseCatalogMetadata(lines: string[]): Record<string, PatternMeta> {
   for (const line of lines) {
     const trimmed = line.trim();
     if (!trimmed.startsWith('|')) {
-      const partMatch = trimmed.match(/^\*\*Part\s+([A-Z])\s*[–—-]\s*(.+)\*\*$/);
-      if (partMatch) {
-        currentPart = normalizeLabel(`Part ${partMatch[1]} - ${partMatch[2]}`);
+      const partHeading = parseCatalogPartHeading(trimmed);
+      if (partHeading) {
+        currentPart = partHeading;
         currentCluster = undefined;
       }
       continue;
@@ -303,10 +558,12 @@ function parseCatalogMetadata(lines: string[]): Record<string, PatternMeta> {
     const status = normalizeLabel(cells[2] ?? '');
     const keywordsCell = cleanMarkdown(cells[3] ?? '');
     const dependenciesRaw = cleanMarkdown(cells[4] ?? '');
+    const normalizedKeywordsCell = normalizeForLookup(keywordsCell);
     const description =
       !dependenciesRaw &&
       keywordsCell &&
-      !/\*keywords:\*|\*queries:\*/i.test(keywordsCell)
+      !normalizedKeywordsCell.includes('keywords:') &&
+      !normalizedKeywordsCell.includes('queries:')
         ? keywordsCell
         : undefined;
 
@@ -341,18 +598,18 @@ export function parseHeadingMetadata(
       }
       continue;
     }
-    const cleanLine = cleanMarkdown(line.replace(/^>\s*/, ''));
-    const match = cleanLine.match(/^([^:]+):\s*(.+)$/);
-    if (!match) {
+    const cleanLine = cleanMarkdown(stripLeadingBlockquoteMarker(line));
+    const labeledValue = parseLabeledValue(cleanLine);
+    if (!labeledValue) {
       continue;
     }
-    const key = normalizeForLookup(match[1] ?? '');
+    const key = normalizeForLookup(labeledValue.key);
     if (key === 'type') {
-      result.type = match[2];
+      result.type = labeledValue.value;
     } else if (key === 'status') {
-      result.status = match[2];
+      result.status = labeledValue.value;
     } else if (key === 'normativity') {
-      result.normativity = match[2];
+      result.normativity = labeledValue.value;
     }
   }
   return result;
@@ -371,9 +628,14 @@ export function parseLabeledRelations(
   sourceCitation: string,
 ): RelationEdge[] {
   const relationEdges: RelationEdge[] = [];
+  const lower = text.toLowerCase();
 
-  for (const match of text.matchAll(LABELED_RELATION_REGEX)) {
-    pushRelationEdges(relationEdges, sourceId, match[1] ?? '', match[2] ?? '', sourceCitation);
+  let current = findNextRelationLabel(text, lower, 0);
+  while (current) {
+    const next = findNextRelationLabel(text, lower, current.contentStart);
+    const rawTargets = text.slice(current.contentStart, next?.start ?? text.length);
+    pushRelationEdges(relationEdges, sourceId, current.label, rawTargets, sourceCitation);
+    current = next;
   }
 
   return relationEdges;
@@ -425,23 +687,60 @@ export function inferSectionRole(heading: string, fullId?: string): SectionRole 
 }
 
 function parseKeywords(cell: string): string[] {
-  const match = cell.match(/Keywords:\s*(.+?)(?:Queries:|$)/i);
-  if (!match) {
+  const keywordsIndex = indexOfIgnoreCase(cell, 'Keywords:');
+  if (keywordsIndex < 0) {
     return [];
   }
-  return match[1]!
+
+  const valueStart = keywordsIndex + 'Keywords:'.length;
+  const queriesIndex = indexOfIgnoreCase(cell, 'Queries:', valueStart);
+  const segment = cell.slice(valueStart, queriesIndex >= 0 ? queriesIndex : undefined).trim();
+  if (!segment) {
+    return [];
+  }
+
+  return segment
     .split(',')
     .map((entry) => normalizeLabel(entry))
     .filter(Boolean);
 }
 
 function parseQueries(cell: string): string[] {
-  const match = cell.match(/Queries:\s*(.+)$/i);
-  if (!match) {
+  const queriesIndex = indexOfIgnoreCase(cell, 'Queries:');
+  if (queriesIndex < 0) {
     return [];
   }
-  return Array.from(match[1]!.matchAll(/"([^"]+)"/g), (item) => normalizeLabel(item[1] ?? ''))
+
+  const segment = cell.slice(queriesIndex + 'Queries:'.length);
+  return extractDoubleQuotedSegments(segment)
+    .map((entry) => normalizeLabel(entry))
     .filter(Boolean);
+}
+
+function indexOfIgnoreCase(text: string, search: string, fromIndex = 0): number {
+  return text.toLowerCase().indexOf(search.toLowerCase(), fromIndex);
+}
+
+function extractDoubleQuotedSegments(text: string): string[] {
+  const matches: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (const character of text) {
+    if (character === '"') {
+      if (inQuotes && current.trim()) {
+        matches.push(current.trim());
+      }
+      current = '';
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (inQuotes) {
+      current += character;
+    }
+  }
+
+  return matches;
 }
 
 function normalizeClusterLabel(label: string): string {

--- a/src/runtime/source-parser.ts
+++ b/src/runtime/source-parser.ts
@@ -14,6 +14,15 @@ import {
   stripMarkdownToText,
   unique,
 } from './text.js';
+import {
+  isAsciiAlphaNumeric,
+  isAsciiDigit,
+  isUppercaseAsciiLetter,
+  isWhitespaceCharacter,
+  skipWhitespace,
+  startsWithAsciiIgnoreCase,
+  toLowerAscii,
+} from './text-scan.js';
 import type { AnchorRef, RelationEdge, RelationKind, SectionRole } from './types.js';
 
 export interface HeadingSection extends AnchorRef {
@@ -68,6 +77,14 @@ const RELATION_LABELS: Record<string, RelationKind> = {
 const ORDERED_RELATION_LABELS = Object.keys(RELATION_LABELS).sort(
   (left, right) => right.length - left.length,
 );
+const RELATION_LABELS_BY_FIRST_CHARACTER = ORDERED_RELATION_LABELS.reduce<
+  Record<string, string[]>
+>((labelsByFirstCharacter, label) => {
+  const firstCharacter = label[0]!;
+  labelsByFirstCharacter[firstCharacter] ??= [];
+  labelsByFirstCharacter[firstCharacter]!.push(label);
+  return labelsByFirstCharacter;
+}, {});
 
 const PATTERN_ROW_ID = /^\**[A-Z]\.\d+(?:\.[A-Za-z0-9]+)*\**$/;
 
@@ -84,42 +101,13 @@ interface RelationLabelMatch {
   contentStart: number;
 }
 
-function isAsciiWhitespace(character: string | undefined): boolean {
-  return character === ' ' || character === '\t' || character === '\n' || character === '\r';
-}
-
-function skipWhitespace(text: string, startIndex: number): number {
-  let index = startIndex;
-  while (index < text.length && isAsciiWhitespace(text[index])) {
-    index += 1;
-  }
-  return index;
-}
-
-function isUppercaseLetter(character: string | undefined): boolean {
-  return character !== undefined && character >= 'A' && character <= 'Z';
-}
-
-function isAsciiDigit(character: string | undefined): boolean {
-  return character !== undefined && character >= '0' && character <= '9';
-}
-
-function isAsciiAlphaNumeric(character: string | undefined): boolean {
-  return (
-    character !== undefined &&
-    ((character >= 'A' && character <= 'Z') ||
-      (character >= 'a' && character <= 'z') ||
-      (character >= '0' && character <= '9'))
-  );
-}
-
 function parseHeadingLine(line: string): ParsedHeadingLine | undefined {
   let index = 0;
   while (index < line.length && line[index] === '#') {
     index += 1;
   }
 
-  if (index === 0 || index > 6 || !isAsciiWhitespace(line[index])) {
+  if (index === 0 || index > 6 || !isWhitespaceCharacter(line[index])) {
     return undefined;
   }
 
@@ -153,8 +141,8 @@ function findSpacedDashSeparator(text: string): number {
   for (let index = 1; index < text.length - 1; index += 1) {
     if (
       text[index] === '-' &&
-      isAsciiWhitespace(text[index - 1]) &&
-      isAsciiWhitespace(text[index + 1])
+      isWhitespaceCharacter(text[index - 1]) &&
+      isWhitespaceCharacter(text[index + 1])
     ) {
       return index;
     }
@@ -164,7 +152,7 @@ function findSpacedDashSeparator(text: string): number {
 
 function isStructuredHeadingId(value: string): boolean {
   let index = 0;
-  if (!isUppercaseLetter(value[index])) {
+  if (!isUppercaseAsciiLetter(value[index])) {
     return false;
   }
   index += 1;
@@ -241,7 +229,7 @@ function parseCatalogPartHeading(line: string): string | undefined {
 
   let index = 'Part '.length;
   const letter = normalized[index];
-  if (!isUppercaseLetter(letter)) {
+  if (!isUppercaseAsciiLetter(letter)) {
     return undefined;
   }
   index += 1;
@@ -285,11 +273,10 @@ function parseLabeledValue(line: string): { key: string; value: string } | undef
 
 function findNextRelationLabel(
   text: string,
-  lower: string,
   fromIndex: number,
 ): RelationLabelMatch | undefined {
   for (let index = fromIndex; index < text.length; index += 1) {
-    const match = parseRelationLabelAt(text, lower, index);
+    const match = parseRelationLabelAt(text, index);
     if (match) {
       return match;
     }
@@ -299,7 +286,6 @@ function findNextRelationLabel(
 
 function parseRelationLabelAt(
   text: string,
-  lower: string,
   startIndex: number,
 ): RelationLabelMatch | undefined {
   let index = skipWhitespace(text, startIndex);
@@ -314,8 +300,12 @@ function parseRelationLabelAt(
     index = skipWhitespace(text, index);
   }
 
-  for (const label of ORDERED_RELATION_LABELS) {
-    if (!lower.startsWith(label, index)) {
+  if (!isRelationLabelBoundaryBefore(text, index)) {
+    return undefined;
+  }
+
+  for (const label of RELATION_LABELS_BY_FIRST_CHARACTER[toLowerAscii(text[index]) ?? ''] ?? []) {
+    if (!startsWithAsciiIgnoreCase(text, label, index)) {
       continue;
     }
 
@@ -339,6 +329,10 @@ function parseRelationLabelAt(
   }
 
   return undefined;
+}
+
+function isRelationLabelBoundaryBefore(text: string, index: number): boolean {
+  return index === 0 || !isAsciiAlphaNumeric(text[index - 1]);
 }
 
 export function parseSource(sourceText: string): SourceIR {
@@ -628,11 +622,10 @@ export function parseLabeledRelations(
   sourceCitation: string,
 ): RelationEdge[] {
   const relationEdges: RelationEdge[] = [];
-  const lower = text.toLowerCase();
 
-  let current = findNextRelationLabel(text, lower, 0);
+  let current = findNextRelationLabel(text, 0);
   while (current) {
-    const next = findNextRelationLabel(text, lower, current.contentStart);
+    const next = findNextRelationLabel(text, current.contentStart);
     const rawTargets = text.slice(current.contentStart, next?.start ?? text.length);
     pushRelationEdges(relationEdges, sourceId, current.label, rawTargets, sourceCitation);
     current = next;

--- a/src/runtime/text-scan.ts
+++ b/src/runtime/text-scan.ts
@@ -1,0 +1,123 @@
+export interface TokenPosition {
+  pos: number;
+  len: number;
+}
+
+export function isWhitespaceCharacter(character: string | undefined): boolean {
+  return character !== undefined && character.trim() === '';
+}
+
+export function skipWhitespace(text: string, startIndex: number): number {
+  let index = startIndex;
+  while (index < text.length && isWhitespaceCharacter(text[index])) {
+    index += 1;
+  }
+  return index;
+}
+
+export function isUppercaseAsciiLetter(character: string | undefined): boolean {
+  return character !== undefined && character >= 'A' && character <= 'Z';
+}
+
+export function isAsciiDigit(character: string | undefined): boolean {
+  return character !== undefined && character >= '0' && character <= '9';
+}
+
+export function isAsciiAlphaNumeric(character: string | undefined): boolean {
+  return (
+    character !== undefined &&
+    ((character >= 'A' && character <= 'Z') ||
+      (character >= 'a' && character <= 'z') ||
+      (character >= '0' && character <= '9'))
+  );
+}
+
+export function toLowerAscii(character: string | undefined): string | undefined {
+  return character !== undefined && character >= 'A' && character <= 'Z'
+    ? character.toLowerCase()
+    : character;
+}
+
+export function startsWithAsciiIgnoreCase(
+  text: string,
+  search: string,
+  startIndex: number,
+): boolean {
+  if (startIndex < 0 || startIndex + search.length > text.length) {
+    return false;
+  }
+
+  for (let index = 0; index < search.length; index += 1) {
+    if (toLowerAscii(text[startIndex + index]) !== search[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function findCollapsedTokenPosition(
+  text: string,
+  token: string,
+): TokenPosition | undefined {
+  for (let start = 0; start < text.length; start += 1) {
+    if (toLowerAscii(text[start]) !== token[0]) {
+      continue;
+    }
+
+    let cursor = start + 1;
+    let tokenIndex = 1;
+    while (tokenIndex < token.length) {
+      while (cursor < text.length && !isAsciiAlphaNumeric(text[cursor])) {
+        cursor += 1;
+      }
+      if (cursor >= text.length || toLowerAscii(text[cursor]) !== token[tokenIndex]) {
+        tokenIndex = -1;
+        break;
+      }
+      cursor += 1;
+      tokenIndex += 1;
+    }
+
+    if (tokenIndex === token.length) {
+      return { pos: start, len: cursor - start };
+    }
+  }
+
+  return undefined;
+}
+
+export function findTokenPosition(
+  text: string,
+  token: string,
+): TokenPosition | undefined {
+  for (let start = 0; start <= text.length - token.length; start += 1) {
+    if (startsWithAsciiIgnoreCase(text, token, start)) {
+      return { pos: start, len: token.length };
+    }
+  }
+
+  if (token.length > 0) {
+    return findCollapsedTokenPosition(text, token);
+  }
+
+  return undefined;
+}
+
+export function collapseWhitespace(text: string): string {
+  let result = '';
+  let sawWhitespace = false;
+
+  for (const character of text) {
+    if (isWhitespaceCharacter(character)) {
+      sawWhitespace = result.length > 0;
+      continue;
+    }
+    if (sawWhitespace) {
+      result += ' ';
+      sawWhitespace = false;
+    }
+    result += character;
+  }
+
+  return result.trim();
+}

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -47,6 +47,27 @@ describe('source-parser', () => {
     });
   });
 
+  it('accepts copy-pasted whitespace around structured headings and part labels', () => {
+    const sourceText = [
+      '**Part  A — Foundations**',
+      '| ID | Title | Status | Keywords | Dependencies |',
+      '| --- | --- | --- | --- | --- |',
+      '| A.1 | Example Pattern | Draft | short description | |',
+      '',
+      '#\u00a0A.1\u00a0-\u2003Example Pattern',
+      'Body paragraph',
+    ].join('\n');
+
+    const ir = parseSource(sourceText);
+
+    expect(ir.metadata['A.1']?.part).toBe('Part A - Foundations');
+    expect(ir.sections[0]).toMatchObject({
+      id: 'A.1',
+      fullId: 'A.1',
+      patternId: 'A.1',
+    });
+  });
+
   it('parses heading metadata from labeled blockquote lines', () => {
     const lines = [
       '# A.1 - Example Pattern',
@@ -103,5 +124,22 @@ describe('source-parser', () => {
         },
       ]),
     );
+  });
+
+  it('does not match relation labels inside larger words', () => {
+    const relations = parseLabeledRelations(
+      'X.1',
+      'precoordinates with: A.1\nCoordinates with: B.1',
+      'X.1:test',
+    );
+
+    expect(relations).toEqual([
+      {
+        from: 'X.1',
+        relation: 'coordinates_with',
+        to: 'B.1',
+        source: 'X.1:test',
+      },
+    ]);
   });
 });

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from '@rstest/core';
+
+import {
+  parseHeadingMetadata,
+  parseLabeledRelations,
+  parseSource,
+} from '../src/runtime/source-parser.js';
+
+describe('source-parser', () => {
+  it('parses part headings and structured heading IDs with line-oriented scanners', () => {
+    const sourceText = [
+      '**Part A - Foundations**',
+      '| ID | Title | Status | Keywords | Dependencies |',
+      '| --- | --- | --- | --- | --- |',
+      '| A.1 | Example Pattern | Draft | short description | |',
+      '',
+      '# A.1 - Example Pattern',
+      '> Type: Pattern',
+      '> Status: Draft',
+      '',
+      'Body paragraph',
+      '',
+      '## A.1:Definition - Definition',
+      'Definition body',
+    ].join('\n');
+
+    const ir = parseSource(sourceText);
+
+    expect(ir.metadata['A.1']).toMatchObject({
+      id: 'A.1',
+      title: 'Example Pattern',
+      status: 'Draft',
+      part: 'Part A - Foundations',
+      description: 'short description',
+    });
+    expect(ir.sections[0]).toMatchObject({
+      id: 'A.1',
+      fullId: 'A.1',
+      patternId: 'A.1',
+      heading: 'A.1 - Example Pattern',
+    });
+    expect(ir.sections[1]).toMatchObject({
+      id: 'A.1:Definition',
+      fullId: 'A.1:Definition',
+      patternId: 'A.1',
+      heading: 'A.1:Definition - Definition',
+    });
+  });
+
+  it('parses heading metadata from labeled blockquote lines', () => {
+    const lines = [
+      '# A.1 - Example Pattern',
+      '> Type: Pattern',
+      '> Status: Draft',
+      '> Normativity: Informative',
+      '',
+      'Body paragraph',
+    ];
+
+    expect(parseHeadingMetadata(lines, 2, 5)).toEqual({
+      type: 'Pattern',
+      status: 'Draft',
+      normativity: 'Informative',
+    });
+  });
+
+  it('parses multiline relation labels without relying on a giant regex', () => {
+    const relations = parseLabeledRelations(
+      'X.1',
+      [
+        '- **Builds on:** A.1, A.2',
+        '  Prerequisite for: B.1',
+        '* Coordinates with: C.3',
+      ].join('\n'),
+      'X.1:test',
+    );
+
+    expect(relations).toEqual(
+      expect.arrayContaining([
+        {
+          from: 'X.1',
+          relation: 'builds_on',
+          to: 'A.1',
+          source: 'X.1:test',
+        },
+        {
+          from: 'X.1',
+          relation: 'builds_on',
+          to: 'A.2',
+          source: 'X.1:test',
+        },
+        {
+          from: 'X.1',
+          relation: 'prerequisite_for',
+          to: 'B.1',
+          source: 'X.1:test',
+        },
+        {
+          from: 'X.1',
+          relation: 'coordinates_with',
+          to: 'C.3',
+          source: 'X.1:test',
+        },
+      ]),
+    );
+  });
+});

--- a/tests/text-scan.test.ts
+++ b/tests/text-scan.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from '@rstest/core';
+
+import {
+  collapseWhitespace,
+  findCollapsedTokenPosition,
+  findTokenPosition,
+} from '../src/runtime/text-scan.js';
+
+describe('text-scan', () => {
+  it('matches dotted IDs through collapsed query tokens', () => {
+    expect(findCollapsedTokenPosition('see a.2.3 for details', 'a23')).toEqual({
+      pos: 4,
+      len: 5,
+    });
+    expect(findTokenPosition('see a.2.3 for details', 'a23')).toEqual({
+      pos: 4,
+      len: 5,
+    });
+  });
+
+  it('keeps positions aligned when earlier Unicode lowercasing would expand', () => {
+    expect(findTokenPosition('İ prefix A.2.3 for details', 'a23')).toEqual({
+      pos: 9,
+      len: 5,
+    });
+  });
+
+  it('collapses Unicode whitespace in snippets', () => {
+    expect(collapseWhitespace(' Alpha\u00a0\u2003Beta\nGamma\u2028Delta ')).toBe(
+      'Alpha Beta Gamma Delta',
+    );
+  });
+});


### PR DESCRIPTION
## What

Land the source-parser scanner rewrite as its own runtime PR and use it as the concrete mitigation for the snapshot rebuild timeout investigation.

Closes #47.
Closes #49.

## Why

Issue #47 was valid: the preserved `refactor/source-parser-scanners` branch still contained an isolated scanner commit that was not on `main`, but the old branch also carried stale docs-history drift. Issue #49 was valid as a CI risk: the expensive refresh path still sits behind the runtime test timeout budget, though current `main` has already added sharded CI and lower worker contention. This PR isolates the scanner commit on current `origin/main` so parser backtracking is removed without bringing stale branch history along.

Local refresh profiling with clean temp artifacts showed `origin/main` at 1228 ms average across 3 runs and this branch at 1169 ms average across 5 runs on this machine. That is relative local evidence, not a claim that macOS timings reproduce the earlier ubuntu-latest 16-18 s runner behavior.

## Type

- `refactor` — code restructuring
- `fix` — review feedback follow-up

## Changes

- Replaces heading, catalog metadata, labeled relation, and snippet extraction regex paths with line-oriented scanners.
- Adds shared `src/runtime/text-scan.ts` scanner helpers for ASCII token scans, Unicode whitespace collapsing, and collapsed token lookup.
- Accepts Unicode whitespace in structured headings and snippet whitespace collapse.
- Keeps token positions aligned by scanning original text instead of relying on whole-string lowercasing.
- Tightens relation-label matching so labels are not detected inside larger words, and buckets labels by first character before comparison.
- Adds focused tests for structured heading IDs, copy-pasted whitespace, multiline labeled relations, negative relation-label matching, collapsed dotted-ID tokens, and Unicode snippet whitespace.
- Refreshes `published/current` so the committed manifest compiler fingerprint matches the runtime compiler code.

## Validation

Clean detached worktree at `3f5ded6d`:

- `bun install --frozen-lockfile` passes
- `bun run check` passes
- `bun run lint` passes: 0 errors, 0 warnings
- `bun run validate:published` passes
- `bunx rstest run tests/source-parser.test.ts tests/text-scan.test.ts tests/compiled-index-golden.test.ts tests/cache-freshness-regression.test.ts` passes: 4 files, 16 tests
- `bun run build` succeeds
- `bun run check:boundaries` passes
- `bun run test` passes: 25 files, 187 tests
- GitHub CI passes on head `3f5ded6d`: setup, lint/boundaries, typecheck, all 4 test shards, build, and aggregate `ci`
- No new warnings introduced
- Relevant docs updated: not applicable; runtime-only refactor

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | local Codex desktop |
| Prompt  | `validate https://github.com/venikman/fpf-memory/issues 2 issues and if they valid fix them in one PR`; follow-up: `address commnets` |
