### PR TITLE
ci: isolate sharded test files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,25 +124,31 @@ jobs:
       # Run one shard per runner, then split that shard into one Rstest
       # process per file. The full FPF suite includes docs and runtime index
       # builds; keeping each file in a fresh process prevents late-shard worker
-      # exits from accumulated test-runner state while preserving shard
-      # selection and failure visibility.
+      # exits from accumulated test-runner state while preserving failure
+      # visibility.
       - name: Run test shard
         run: |
-          files="$(
-            bunx rstest list --shard=${{ matrix.shard }}/4 \
-              | awk '/^tests\/.*\.test\.ts/ && !seen[$1]++ { print $1 }'
-          )"
+          mapfile -t all_files < <(find tests -maxdepth 1 -type f -name '*.test.ts' | sort)
+          files=()
+          shard_index=${{ matrix.shard }}
+          shard_count=4
 
-          if [[ -z "$files" ]]; then
+          for i in "${!all_files[@]}"; do
+            if (( i % shard_count == shard_index - 1 )); then
+              files+=("${all_files[$i]}")
+            fi
+          done
+
+          if (( ${#files[@]} == 0 )); then
             echo "::error::No tests found for shard ${{ matrix.shard }}/4."
             exit 1
           fi
 
-          while IFS= read -r file; do
+          for file in "${files[@]}"; do
             echo "::group::$file"
             bun run test -- "$file"
             echo "::endgroup::"
-          done <<< "$files"
+          done
 
   build:
     name: Build (docs + MCP + mastra dry-run)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,11 +121,28 @@ jobs:
             node_modules
           key: ${{ needs.setup.outputs.cache-key }}
       - run: bun install --frozen-lockfile
-      # Run one shard per runner. The full FPF suite can push a single
-      # long-lived worker over the GitHub runner memory cliff even with
-      # `maxWorkers: 1`, so each shard gets a fresh process *and* a fresh
-      # runner.
-      - run: bunx rstest run --shard=${{ matrix.shard }}/4
+      # Run one shard per runner, then split that shard into one Rstest
+      # process per file. The full FPF suite includes docs and runtime index
+      # builds; keeping each file in a fresh process prevents late-shard worker
+      # exits from accumulated test-runner state while preserving shard
+      # selection and failure visibility.
+      - name: Run test shard
+        run: |
+          files="$(
+            bunx rstest list --shard=${{ matrix.shard }}/4 \
+              | awk '/^tests\/.*\.test\.ts/ && !seen[$1]++ { print $1 }'
+          )"
+
+          if [[ -z "$files" ]]; then
+            echo "::error::No tests found for shard ${{ matrix.shard }}/4."
+            exit 1
+          fi
+
+          while IFS= read -r file; do
+            echo "::group::$file"
+            bun run test -- "$file"
+            echo "::endgroup::"
+          done <<< "$files"
 
   build:
     name: Build (docs + MCP + mastra dry-run)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,28 +127,7 @@ jobs:
       # exits from accumulated test-runner state while preserving failure
       # visibility.
       - name: Run test shard
-        run: |
-          mapfile -t all_files < <(find tests -maxdepth 1 -type f -name '*.test.ts' | sort)
-          files=()
-          shard_index=${{ matrix.shard }}
-          shard_count=4
-
-          for i in "${!all_files[@]}"; do
-            if (( i % shard_count == shard_index - 1 )); then
-              files+=("${all_files[$i]}")
-            fi
-          done
-
-          if (( ${#files[@]} == 0 )); then
-            echo "::error::No tests found for shard ${{ matrix.shard }}/4."
-            exit 1
-          fi
-
-          for file in "${files[@]}"; do
-            echo "::group::$file"
-            bun run test -- "$file"
-            echo "::endgroup::"
-          done
+        run: bun scripts/run-test-shard.ts --shard=${{ matrix.shard }}/4
 
   build:
     name: Build (docs + MCP + mastra dry-run)

--- a/scripts/run-test-shard.ts
+++ b/scripts/run-test-shard.ts
@@ -1,0 +1,143 @@
+import { spawnSync } from 'node:child_process';
+import { readdir } from 'node:fs/promises';
+import { join, relative, sep } from 'node:path';
+
+export interface ParsedShard {
+  index: number;
+  count: number;
+}
+
+export interface RunTestShardOptions {
+  cwd?: string;
+  shard: ParsedShard;
+}
+
+export interface RunSelectedTestFilesOptions {
+  files: string[];
+  cwd?: string;
+  log?: Pick<Console, 'error' | 'log'>;
+  runTestFile?: (file: string, cwd: string) => number | Promise<number>;
+}
+
+export async function discoverTestFiles(cwd = process.cwd()): Promise<string[]> {
+  const testsRoot = join(cwd, 'tests');
+  const discovered = await walkTestFiles(testsRoot, cwd);
+  return discovered.sort();
+}
+
+export function parseShard(value: string): ParsedShard {
+  const match = /^([1-9]\d*)\/([1-9]\d*)$/u.exec(value);
+  if (!match) {
+    throw new Error(`Expected --shard <index/count>, got: ${value}`);
+  }
+
+  const index = Number(match[1]);
+  const count = Number(match[2]);
+  if (index > count) {
+    throw new Error(`Shard index ${index} cannot exceed shard count ${count}.`);
+  }
+
+  return { index, count };
+}
+
+export function selectShardFiles(files: string[], shard: ParsedShard): string[] {
+  return files.filter((_, index) => index % shard.count === shard.index - 1);
+}
+
+export async function runTestShard(options: RunTestShardOptions): Promise<number> {
+  const cwd = options.cwd ?? process.cwd();
+  const files = selectShardFiles(await discoverTestFiles(cwd), options.shard);
+
+  if (files.length === 0) {
+    console.error(`::error::No tests found for shard ${options.shard.index}/${options.shard.count}.`);
+    return 1;
+  }
+
+  return runSelectedTestFiles({ files, cwd });
+}
+
+export async function runSelectedTestFiles(
+  options: RunSelectedTestFilesOptions,
+): Promise<number> {
+  const cwd = options.cwd ?? process.cwd();
+  const log = options.log ?? console;
+  const runTestFile = options.runTestFile ?? runRstestFile;
+  let exitCode = 0;
+
+  for (const file of options.files) {
+    log.log(`::group::${file}`);
+    try {
+      const fileExitCode = await runTestFile(file, cwd);
+      if (fileExitCode !== 0 && exitCode === 0) {
+        exitCode = fileExitCode;
+      }
+    } catch (error) {
+      exitCode = exitCode || 1;
+      log.error(error instanceof Error ? error.message : String(error));
+    } finally {
+      log.log('::endgroup::');
+    }
+  }
+
+  return exitCode;
+}
+
+function runRstestFile(file: string, cwd: string): number {
+  const result = spawnSync('bunx', ['rstest', 'run', file], {
+    cwd,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    console.error(result.error.message);
+    return 1;
+  }
+
+  return result.status ?? 1;
+}
+
+async function walkTestFiles(directory: string, cwd: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const absolutePath = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        return walkTestFiles(absolutePath, cwd);
+      }
+      if (entry.isFile() && entry.name.endsWith('.test.ts')) {
+        return [toPosixPath(relative(cwd, absolutePath))];
+      }
+      return [];
+    }),
+  );
+
+  return files.flat();
+}
+
+function toPosixPath(path: string): string {
+  return path.split(sep).join('/');
+}
+
+function readShardArg(argv: string[]): string {
+  const shardWithValue = argv.find((arg) => arg.startsWith('--shard='));
+  if (shardWithValue) {
+    return shardWithValue.slice('--shard='.length);
+  }
+
+  const shardFlagIndex = argv.indexOf('--shard');
+  if (shardFlagIndex >= 0 && argv[shardFlagIndex + 1]) {
+    return argv[shardFlagIndex + 1];
+  }
+
+  throw new Error('Missing required --shard <index/count> argument.');
+}
+
+if (import.meta.main) {
+  try {
+    const shard = parseShard(readShardArg(process.argv.slice(2)));
+    process.exitCode = await runTestShard({ shard });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/tests/ci-shard-runner.test.ts
+++ b/tests/ci-shard-runner.test.ts
@@ -1,0 +1,79 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from '@rstest/core';
+
+import {
+  discoverTestFiles,
+  parseShard,
+  runSelectedTestFiles,
+  selectShardFiles,
+} from '../scripts/run-test-shard.js';
+
+const tempRoots: string[] = [];
+
+describe('CI test shard runner', () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+    );
+  });
+
+  it('discovers nested test files and returns stable relative paths', async () => {
+    const root = await createFixtureRoot();
+    await writeFixtureFile(root, 'tests/root.test.ts');
+    await writeFixtureFile(root, 'tests/integration/nested.test.ts');
+    await writeFixtureFile(root, 'tests/not-a-test.ts');
+
+    await expect(discoverTestFiles(root)).resolves.toEqual([
+      'tests/integration/nested.test.ts',
+      'tests/root.test.ts',
+    ]);
+  });
+
+  it('selects files by deterministic modulo shard', () => {
+    const files = ['a.test.ts', 'b.test.ts', 'c.test.ts', 'd.test.ts', 'e.test.ts'];
+
+    expect(selectShardFiles(files, parseShard('1/2'))).toEqual([
+      'a.test.ts',
+      'c.test.ts',
+      'e.test.ts',
+    ]);
+    expect(selectShardFiles(files, parseShard('2/2'))).toEqual(['b.test.ts', 'd.test.ts']);
+  });
+
+  it('runs every selected file before returning a failing exit code', async () => {
+    const calls: string[] = [];
+    const logLines: string[] = [];
+
+    const exitCode = await runSelectedTestFiles({
+      files: ['first.test.ts', 'second.test.ts', 'third.test.ts'],
+      cwd: '/repo',
+      log: {
+        error: (line) => logLines.push(line),
+        log: (line) => logLines.push(line),
+      },
+      runTestFile: (file) => {
+        calls.push(file);
+        return file === 'first.test.ts' ? 1 : 0;
+      },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(calls).toEqual(['first.test.ts', 'second.test.ts', 'third.test.ts']);
+    expect(logLines.filter((line) => line === '::endgroup::')).toHaveLength(3);
+  });
+});
+
+async function createFixtureRoot(): Promise<string> {
+  const root = await mkdtemp(resolve(tmpdir(), 'fpf-ci-shard-runner-'));
+  tempRoots.push(root);
+  return root;
+}
+
+async function writeFixtureFile(root: string, relativePath: string): Promise<void> {
+  const filePath = resolve(root, relativePath);
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, 'import { it } from "@rstest/core"; it("works", () => {});\n');
+}


### PR DESCRIPTION
## What

Split CI test execution into one `rstest` process per selected test file, with deterministic 4-way file sharding handled by a small TypeScript script.

## Why

The latest `main` CI run failed in `Test (shard 2/4)` after the docs/runtime-heavy files passed. `tests/fpf-work-evaluator.test.ts` reported `Worker exited unexpectedly` before running tests, while the file and shard pass locally. Running each file in a fresh process reduces late-shard runner state while still letting each shard surface all file-level failures before exiting.

## Type

- `chore` — maintenance (deps, CI, cleanup)

## Changes

- Keep the 4-way CI test matrix.
- Move shard selection/execution into `scripts/run-test-shard.ts`.
- Discover `tests/**/*.test.ts` recursively and select files with a deterministic modulo split.
- Run `bunx rstest run <file>` directly for each selected file.
- Always close GitHub log groups and defer the final non-zero exit until every selected file has run.

## Validation

- `CI=true bun scripts/run-test-shard.ts --shard=4/4` passes locally
- `bunx rstest run tests/ci-shard-runner.test.ts` passes locally
- `CI=true` file-level shard 2 loop passes locally from the earlier workflow version
- `CI=true` file-level shard 3 loop passes locally from the earlier workflow version
- `CI=true bunx rstest run tests/fpf-work-evaluator.test.ts` passes locally
- `CI=true bunx rstest run --shard=2/4` passes locally before the workflow change
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'` passes locally
- `bun run lint` passes locally
- `bun run check` passes locally
- `bun run check:boundaries` passes locally

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts`

## Agent metadata






| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | local |
| Prompt  | check list pipeline failures and create PR to fix them |
