### PR TITLE
docs: add legacy video entry pages

### DIFF
--- a/docs/demo-videos.md
+++ b/docs/demo-videos.md
@@ -1,0 +1,26 @@
+---
+title: "Demo Videos"
+description: "Legacy entry point for the former demo video surface."
+outline: deep
+---
+
+# Demo Videos
+
+The demo video surface has been retired. Use the current adoption pages instead.
+
+## What this page is
+
+This is a compatibility page for older links to fpf-memory demo videos. It is not a video catalog and it is not the full FPF specification.
+
+## Methodology
+
+Start from the work a person or agent is trying to do, then use the smallest current surface that can support that work. Keep the full reference available for audit after the first path is clear.
+
+## Current entry points
+
+| Need | Use |
+| --- | --- |
+| First orientation | [Start Here](/start-here) |
+| Task-sized examples | [Work Packets](/work-packets) |
+| Agent or MCP usage | [MCP Recipes](/mcp-recipes) |
+| Client setup | [Connect MCP](/connect-mcp) |

--- a/docs/use-case-videos.md
+++ b/docs/use-case-videos.md
@@ -1,0 +1,26 @@
+---
+title: "Use Case Videos"
+description: "Legacy entry point for the former use-case video surface."
+outline: deep
+---
+
+# Use Case Videos
+
+The use-case video surface has been retired. Use the current adoption pages instead.
+
+## What this page is
+
+This is a compatibility page for older links to fpf-memory use-case videos. It is not a video catalog and it is not the full FPF specification.
+
+## Methodology
+
+Pick the current page by job: orientation, task packet, agent retrieval, or client setup. Read exact generated FPF pages only when the work needs source-level detail.
+
+## Current entry points
+
+| Need | Use |
+| --- | --- |
+| First orientation | [Start Here](/start-here) |
+| Product-role feedback | [Work Packets](/work-packets#product-role-feedback-packet) |
+| Compact grounded retrieval | [MCP Recipes](/mcp-recipes) |
+| Hosted MCP connection | [Connect MCP](/connect-mcp) |


### PR DESCRIPTION
## Summary
- Add compatibility pages for the retired `/demo-videos` and `/use-case-videos` adoption URLs.
- Point legacy visitors to Start Here, Work Packets, MCP Recipes, and Connect MCP instead of restoring the old video surface.

## Validation
- `bun run docs:build`
- `bun run test tests/docs-projection.test.ts`
- `bun run check`
- `git diff --cached --check` before commit

## Product feedback
Addresses the standing product-feedback note in Discussion #57 that old video adoption URLs still dead-end after video surfaces were removed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds two new compatibility pages and links; no runtime logic, security, or data handling changes.
> 
> **Overview**
> Adds two new documentation pages, `docs/demo-videos.md` and `docs/use-case-videos.md`, to serve as **legacy compatibility entry points** now that the old video surfaces are retired.
> 
> Each page explains the retirement and routes users to the current adoption pages (*Start Here*, *Work Packets*, *MCP Recipes*, *Connect MCP*) instead of restoring a video catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aaaece0e813d98b2f3ec7106d24adc3ab6bd67d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->