### PR TITLE
[codex] fix issue 78 answer quality fallback

### DIFF
--- a/published/current/manifest.json
+++ b/published/current/manifest.json
@@ -1,10 +1,10 @@
 {
   "channel": "latest-published",
   "sourceHash": "sha256:4bd579472278104ec472ad32f473b51a58d43e6066cc605f7693badcd2ca691d",
-  "compilerFingerprint": "sha256:da2c79d7e17241c234442e66d18d962b6e3e182990cdf798d4a5efe1cc3fe559",
+  "compilerFingerprint": "sha256:f1128417385906be76554dcf47d424e5950519543998e3d9b0bce1a13f25f486",
   "upstreamRef": "75536eb67fe58e6ffe5c87d21631403fd71c3e10",
   "specPath": "published/current/FPF-Spec.md",
   "snapshotPath": "published/current/fpf-index/snapshot.json",
   "specBytes": 5449072,
-  "publishedAt": "2026-05-09T11:27:37.093Z"
+  "publishedAt": "2026-05-09T11:50:43.421Z"
 }

--- a/scripts/bench-mcp-qa.ts
+++ b/scripts/bench-mcp-qa.ts
@@ -57,7 +57,7 @@ interface QaCaseResult {
   ok: boolean;
   durationMs: number;
   status?: string;
-  confidence?: number;
+  confidence?: number | null;
   ids: string[];
   candidateIds: string[];
   expectedIds: string[];
@@ -233,7 +233,10 @@ export async function runQaCase(
   const ids = asStringArray(content.ids, 'ids', failures);
   const candidateIds = asStringArray(content.candidateIds ?? [], 'candidateIds', failures);
   const status = typeof content.status === 'string' ? content.status : undefined;
-  const confidence = typeof content.confidence === 'number' ? content.confidence : undefined;
+  const confidence =
+    typeof content.confidence === 'number' || content.confidence === null
+      ? content.confidence
+      : undefined;
   const gaps = asStringArray(content.gaps, 'gaps', warnings);
   const groundingIds = status === 'degraded' ? candidateIds : ids;
 
@@ -277,7 +280,14 @@ export async function runQaCase(
   if (status === 'degraded' && candidateIds.length === 0) {
     failures.push('degraded answer did not expose candidateIds');
   }
-  if (degraded && (confidence ?? 1) > (testCase.maxConfidenceWhenDegraded ?? 0.5)) {
+  if (status === 'degraded' && confidence !== null) {
+    failures.push(`degraded answer confidence was ${confidence ?? '<missing>'} instead of null`);
+  }
+  if (
+    degraded &&
+    typeof confidence === 'number' &&
+    confidence > (testCase.maxConfidenceWhenDegraded ?? 0.5)
+  ) {
     failures.push(
       `degraded synthesis confidence ${confidence ?? '<missing>'} exceeded ${testCase.maxConfidenceWhenDegraded ?? 0.5}`,
     );

--- a/src/adapters/mcp/tools.ts
+++ b/src/adapters/mcp/tools.ts
@@ -336,7 +336,7 @@ function renderMarkdown(result: QueryResult): string {
     '',
     `- Mode: \`${result.mode}\``,
     `- Status: \`${result.status}\``,
-    `- Confidence: ${result.confidence}`,
+    `- Confidence: ${result.confidence ?? 'n/a'}`,
     `- IDs: ${formatCodeList(result.ids)}`,
     ...(result.candidateIds ? [`- Candidate IDs: ${formatCodeList(result.candidateIds)}`] : []),
     `- Citations: ${formatCodeList(result.citations)}`,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -329,7 +329,7 @@ export interface QueryResult {
   relations: Array<Pick<RelationEdge, 'from' | 'relation' | 'to'>>;
   constraints: string[];
   citations: string[];
-  confidence: number;
+  confidence: number | null;
   gaps: string[];
   candidateIds?: string[];
   snapshot: {
@@ -349,7 +349,7 @@ export interface AskFpfResult {
   citations: string[];
   constraints: string[];
   gaps: string[];
-  confidence: number;
+  confidence: number | null;
   candidateIds?: string[];
   status: AnswerStatus;
   snapshot: {
@@ -625,6 +625,9 @@ export interface BrowseCatalogResult {
     part?: string;
     status?: string;
     kind?: NodeKind;
+  };
+  didYouMean?: {
+    part?: string;
   };
   snapshot: {
     sourceHash: string;

--- a/src/mcp/tool-contracts.ts
+++ b/src/mcp/tool-contracts.ts
@@ -199,7 +199,7 @@ export const queryResultSchema = z
     relations: z.array(relationEdgeSchema),
     constraints: z.array(z.string()),
     citations: z.array(z.string()),
-    confidence: z.number(),
+    confidence: z.number().nullable(),
     gaps: z.array(z.string()),
     candidateIds: z.array(z.string()).optional(),
     snapshot: snapshotWithRebuildSchema,
@@ -217,7 +217,7 @@ export const askFpfResultSchema = z
     citations: z.array(z.string()),
     constraints: z.array(z.string()),
     gaps: z.array(z.string()),
-    confidence: z.number(),
+    confidence: z.number().nullable(),
     candidateIds: z.array(z.string()).optional(),
     status: answerStatusSchema,
     snapshot: snapshotWithRebuildSchema,
@@ -542,6 +542,12 @@ export const browseFpfCatalogResultSchema = z
         kind: nodeKindSchema.optional(),
       })
       .strict(),
+    didYouMean: z
+      .object({
+        part: z.string().optional(),
+      })
+      .strict()
+      .optional(),
     snapshot: z
       .object({
         sourceHash: z.string(),

--- a/src/runtime/candidate-seeder.ts
+++ b/src/runtime/candidate-seeder.ts
@@ -232,7 +232,37 @@ function shouldApplySessionContext(
     return false;
   }
 
-  return /\bit\b|\bthat\b|\bthose\b|\bthem\b|\bconnect\b|\brelate\b|\balso\b/.test(
-    normalizedQuestion,
+  if (/\bit\b|\bthat\b|\bthose\b|\bthem\b|\bconnect\b|\brelate\b|\balso\b/.test(normalizedQuestion)) {
+    return true;
+  }
+
+  return detectedIds.length === 0 && isImplicitSessionFollowUp(normalizedQuestion);
+}
+
+const IMPLICIT_FOLLOW_UP_TOKENS = new Set([
+  'about',
+  'clarify',
+  'continue',
+  'definition',
+  'detail',
+  'details',
+  'elaborate',
+  'example',
+  'examples',
+  'explain',
+  'me',
+  'more',
+  'show',
+  'summarize',
+  'summary',
+  'tell',
+]);
+
+function isImplicitSessionFollowUp(normalizedQuestion: string): boolean {
+  const tokens = tokenize(normalizedQuestion);
+  return (
+    tokens.length > 0 &&
+    tokens.length <= 4 &&
+    tokens.every((token) => IMPLICIT_FOLLOW_UP_TOKENS.has(token))
   );
 }

--- a/src/runtime/candidate-seeder.ts
+++ b/src/runtime/candidate-seeder.ts
@@ -232,7 +232,7 @@ function shouldApplySessionContext(
     return false;
   }
 
-  if (/\bit\b|\bthat\b|\bthose\b|\bthem\b|\bconnect\b|\brelate\b|\balso\b/.test(normalizedQuestion)) {
+  if (/\bit\b|\bthat\b|\bthose\b|\bthem\b/.test(normalizedQuestion)) {
     return true;
   }
 
@@ -241,6 +241,7 @@ function shouldApplySessionContext(
 
 const IMPLICIT_FOLLOW_UP_TOKENS = new Set([
   'about',
+  'also',
   'clarify',
   'continue',
   'definition',

--- a/src/runtime/candidate-seeder.ts
+++ b/src/runtime/candidate-seeder.ts
@@ -232,10 +232,6 @@ function shouldApplySessionContext(
     return false;
   }
 
-  if (detectedIds.length === 0) {
-    return true;
-  }
-
   return /\bit\b|\bthat\b|\bthose\b|\bthem\b|\bconnect\b|\brelate\b|\balso\b/.test(
     normalizedQuestion,
   );

--- a/src/runtime/compiler.ts
+++ b/src/runtime/compiler.ts
@@ -206,6 +206,27 @@ function buildHeuristicSeedRules(
     });
   }
 
+  const agentWorkflowAdoptionNodeIds = ['E.8', 'E.19'].filter(
+    (id) => id in patternNodes || id in routeNodes,
+  );
+  if (agentWorkflowAdoptionNodeIds.length > 0) {
+    rules.push({
+      name: 'agent-workflow-adoption',
+      allOf: [
+        ['agent', 'agentic'],
+        ['workflow'],
+      ],
+      anyOf: [
+        ['adoption', 'adopt'],
+        ['whole spec', 'pasting the whole spec', 'without pasting'],
+      ],
+      seedNodeIds: agentWorkflowAdoptionNodeIds,
+      seedScore: 72,
+      seedOrigin: 'lexical',
+      initialNodeIds: agentWorkflowAdoptionNodeIds.filter((id) => id in patternNodes),
+    });
+  }
+
   const alignmentRoute = Object.values(routeNodes).find(
     (r) => r.name.toLowerCase() === PROJECT_ALIGNMENT_ROUTE_NAME,
   );

--- a/src/runtime/lm-studio-synthesizer.ts
+++ b/src/runtime/lm-studio-synthesizer.ts
@@ -247,7 +247,7 @@ export class LmStudioSynthesizer implements LocalAnswerSynthesizer {
             responseText: body,
           });
           throw new Error(
-            `LM Studio synthesis failed with ${response.status}: ${body.slice(0, 300)}`,
+            `LM Studio synthesis failed with ${response.status}: ${formatRemoteFailurePreview(body)}`,
           );
         }
 
@@ -287,13 +287,30 @@ function summarizeHealthFailure(
     return `LM Studio ${phase} health check failed: ${result.error}`;
   }
   if (result.httpStatus !== undefined) {
-    const preview = result.responsePreview ? `: ${result.responsePreview.slice(0, 160)}` : '';
+    const preview = result.responsePreview
+      ? `: ${formatRemoteFailurePreview(result.responsePreview, 160)}`
+      : '';
     return `LM Studio ${phase} health check returned HTTP ${result.httpStatus}${preview}`;
   }
   if (result.listed === false) {
     return `LM Studio ${phase} health check did not list the configured model.`;
   }
   return `LM Studio ${phase} health check failed.`;
+}
+
+function formatRemoteFailurePreview(body: string, maxLength = 300): string {
+  const collapsed = body.replace(/\s+/g, ' ').trim();
+  if (!collapsed) {
+    return '<empty response body>';
+  }
+  if (looksLikeHtml(collapsed)) {
+    return 'HTML error response omitted';
+  }
+  return collapsed.slice(0, maxLength);
+}
+
+function looksLikeHtml(value: string): boolean {
+  return /^<!doctype html\b/i.test(value) || /^<html\b/i.test(value) || /<body\b/i.test(value);
 }
 
 export function createSynthesizerFromConfig(

--- a/src/runtime/lm-studio-synthesizer.ts
+++ b/src/runtime/lm-studio-synthesizer.ts
@@ -299,7 +299,7 @@ function summarizeHealthFailure(
 }
 
 function formatRemoteFailurePreview(body: string, maxLength = 300): string {
-  const collapsed = body.replace(/\s+/g, ' ').trim();
+  const collapsed = body.slice(0, maxLength * 2).replace(/\s+/g, ' ').trim();
   if (!collapsed) {
     return '<empty response body>';
   }

--- a/src/runtime/lm-studio-synthesizer.ts
+++ b/src/runtime/lm-studio-synthesizer.ts
@@ -310,7 +310,11 @@ function formatRemoteFailurePreview(body: string, maxLength = 300): string {
 }
 
 function looksLikeHtml(value: string): boolean {
-  return /^<!doctype html\b/i.test(value) || /^<html\b/i.test(value) || /<body\b/i.test(value);
+  return (
+    /^<!doctype html\b/i.test(value) ||
+    /^<html\b/i.test(value) ||
+    /<\/?[a-z][a-z0-9-]*(?:\s[^>]*)?>/i.test(value)
+  );
 }
 
 export function createSynthesizerFromConfig(

--- a/src/runtime/query-helpers.ts
+++ b/src/runtime/query-helpers.ts
@@ -28,6 +28,7 @@ const PATTERN_AUTHORING_ACTION_BEFORE_PATTERN =
 
 const PATTERN_AUTHORING_NOUN_AFTER_PATTERN =
   /\bpatterns?\s+(?:writing|authoring|review|reviewing|revision|revisions|draft|drafting)\b/;
+const TITLE_TOKEN_WEIGHT = 5;
 
 export function isPartCDraftQuery(question: string): boolean {
   const normalized = normalizeForLookup(question);
@@ -49,6 +50,11 @@ export function scorePatternQuery(
       if (overlap > 0) {
         score += overlap;
         reasons.push(`token-overlap:${overlap}`);
+      }
+      const titleOverlap = scoreOverlap(queryTokens, pattern.title);
+      if (titleOverlap > 0) {
+        score += titleOverlap * TITLE_TOKEN_WEIGHT;
+        reasons.push(`title-token-overlap:${titleOverlap * TITLE_TOKEN_WEIGHT}`);
       }
       if (exactIds.has(pattern.id)) {
         score += 100;
@@ -85,6 +91,11 @@ export function scoreRouteQuery(
       if (overlap > 0) {
         score += overlap;
         reasons.push(`token-overlap:${overlap}`);
+      }
+      const titleOverlap = scoreOverlap(queryTokens, route.name);
+      if (titleOverlap > 0) {
+        score += titleOverlap * TITLE_TOKEN_WEIGHT;
+        reasons.push(`route-title-token-overlap:${titleOverlap * TITLE_TOKEN_WEIGHT}`);
       }
       if (normalizedQuestion.includes(normalizeForLookup(route.name))) {
         score += 30;

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -745,16 +745,14 @@ interface PartFilterResolution {
   suggestion?: string;
 }
 
+const availablePartsCache = new WeakMap<Snapshot, string[]>();
+
 function resolvePartFilter(part: string | undefined, snapshot: Snapshot): PartFilterResolution {
   if (!part?.trim()) {
     return {};
   }
 
-  const availableParts = unique(
-    Object.values(snapshot.compiledNodes)
-      .map((node) => node.part)
-      .filter((value): value is string => Boolean(value)),
-  ).sort((left, right) => left.localeCompare(right));
+  const availableParts = resolveAvailableParts(snapshot);
   const inputKey = normalizedCatalogFilterKey(part);
   for (const availablePart of availableParts) {
     if (partFilterKeys(availablePart).includes(inputKey)) {
@@ -764,6 +762,21 @@ function resolvePartFilter(part: string | undefined, snapshot: Snapshot): PartFi
 
   const suggestion = suggestPartFilter(inputKey, availableParts);
   return { value: part, suggestion };
+}
+
+function resolveAvailableParts(snapshot: Snapshot): string[] {
+  const cached = availablePartsCache.get(snapshot);
+  if (cached) {
+    return cached;
+  }
+
+  const availableParts = unique(
+    Object.values(snapshot.compiledNodes)
+      .map((node) => node.part)
+      .filter((value): value is string => Boolean(value)),
+  ).sort((left, right) => left.localeCompare(right));
+  availablePartsCache.set(snapshot, availableParts);
+  return availableParts;
 }
 
 function partFilterKeys(part: string): string[] {
@@ -799,8 +812,8 @@ function suggestPartFilter(inputKey: string, availableParts: string[]): string |
 }
 
 function levenshteinDistance(left: string, right: string): number {
-  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
-  const current = new Array<number>(right.length + 1);
+  let previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  let current = new Array<number>(right.length + 1);
   for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
     current[0] = leftIndex;
     for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
@@ -811,7 +824,9 @@ function levenshteinDistance(left: string, right: string): number {
         previous[rightIndex - 1]! + cost,
       );
     }
-    previous.splice(0, previous.length, ...current);
+    const nextPrevious = current;
+    current = previous;
+    previous = nextPrevious;
   }
   return previous[right.length] ?? Math.max(left.length, right.length);
 }

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -40,7 +40,7 @@ import type {
   Snapshot,
   TraceResult,
 } from './types.js';
-import { normalizeForLookup, tokenize, scoreOverlap } from './text.js';
+import { normalizeForLookup, tokenize, scoreOverlap, unique } from './text.js';
 
 export interface FpfRuntimeOptions {
   sourcePath?: string;
@@ -360,7 +360,8 @@ export class FpfRuntime {
     await this.refresh(options.forceRefresh ?? false);
     const snapshot = await this.requireSnapshot();
 
-    const partLower = options.part?.toLowerCase();
+    const partFilter = resolvePartFilter(options.part, snapshot);
+    const partLower = partFilter.value?.toLowerCase();
     const statusLower = options.status?.toLowerCase();
     const limit = Math.min(options.limit ?? 200, 500);
 
@@ -382,14 +383,20 @@ export class FpfRuntime {
       ? entries.slice(0, limit)
       : interleaveBrowseEntries(entries, limit);
 
+    const didYouMean =
+      entries.length === 0 && partFilter.suggestion
+        ? { part: partFilter.suggestion }
+        : undefined;
+
     return {
       entries: trimmed,
       total: entries.length,
       filters: {
-        part: options.part,
+        part: partFilter.value ?? options.part,
         status: options.status,
         kind: options.kind,
       },
+      ...(didYouMean ? { didYouMean } : {}),
       snapshot: { sourceHash: snapshot.sourceHash, builtAt: snapshot.builtAt },
     };
   }
@@ -412,7 +419,9 @@ export class FpfRuntime {
         continue;
       }
 
-      const score = scoreOverlap(queryTokens, node.searchableText);
+      const score =
+        scoreOverlap(queryTokens, node.searchableText)
+        + scoreOverlap(queryTokens, node.title) * SEARCH_TITLE_TOKEN_WEIGHT;
       if (score <= 0) {
         continue;
       }
@@ -731,6 +740,82 @@ function interleaveBrowseEntries(entries: CatalogEntry[], limit: number): Catalo
   return capped;
 }
 
+interface PartFilterResolution {
+  value?: string;
+  suggestion?: string;
+}
+
+function resolvePartFilter(part: string | undefined, snapshot: Snapshot): PartFilterResolution {
+  if (!part?.trim()) {
+    return {};
+  }
+
+  const availableParts = unique(
+    Object.values(snapshot.compiledNodes)
+      .map((node) => node.part)
+      .filter((value): value is string => Boolean(value)),
+  ).sort((left, right) => left.localeCompare(right));
+  const inputKey = normalizedCatalogFilterKey(part);
+  for (const availablePart of availableParts) {
+    if (partFilterKeys(availablePart).includes(inputKey)) {
+      return { value: availablePart };
+    }
+  }
+
+  const suggestion = suggestPartFilter(inputKey, availableParts);
+  return { value: part, suggestion };
+}
+
+function partFilterKeys(part: string): string[] {
+  const keys = [normalizedCatalogFilterKey(part)];
+  const match = /^part\s+([a-z])\b/i.exec(part.trim());
+  if (match?.[1]) {
+    const letter = match[1].toLowerCase();
+    keys.push(letter, `part${letter}`);
+  }
+  return unique(keys);
+}
+
+function normalizedCatalogFilterKey(value: string): string {
+  return normalizeForLookup(value).replace(/[^a-z0-9]+/g, '');
+}
+
+function suggestPartFilter(inputKey: string, availableParts: string[]): string | undefined {
+  if (!inputKey || /^part[a-z]$/i.test(inputKey) || /^[a-z]$/i.test(inputKey)) {
+    return undefined;
+  }
+
+  let best: { part: string; distance: number } | undefined;
+  for (const availablePart of availableParts) {
+    const candidateDistance = Math.min(
+      ...partFilterKeys(availablePart).map((key) => levenshteinDistance(inputKey, key)),
+    );
+    if (!best || candidateDistance < best.distance) {
+      best = { part: availablePart, distance: candidateDistance };
+    }
+  }
+
+  return best && best.distance <= 2 ? best.part : undefined;
+}
+
+function levenshteinDistance(left: string, right: string): number {
+  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  const current = new Array<number>(right.length + 1);
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    current[0] = leftIndex;
+    for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+      const cost = left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1;
+      current[rightIndex] = Math.min(
+        current[rightIndex - 1]! + 1,
+        previous[rightIndex]! + 1,
+        previous[rightIndex - 1]! + cost,
+      );
+    }
+    previous.splice(0, previous.length, ...current);
+  }
+  return previous[right.length] ?? Math.max(left.length, right.length);
+}
+
 function nodeToCatalogEntry(
   node: import('./types.js').CompiledNode,
   snapshot: Snapshot,
@@ -759,6 +844,7 @@ function nodeToCatalogEntry(
   };
 }
 
+const SEARCH_TITLE_TOKEN_WEIGHT = 5;
 const SNIPPET_RADIUS = 80;
 
 function extractSnippet(searchableText: string, queryTokens: string[]): string {

--- a/src/runtime/synthesis-adapter.ts
+++ b/src/runtime/synthesis-adapter.ts
@@ -22,6 +22,7 @@ export async function synthesizeAnswer(
     if (!available) {
       return degradedSynthesisResult(
         deterministicResult,
+        trace,
         'configured local synthesizer reported unavailable',
       );
     }
@@ -46,18 +47,24 @@ export async function synthesizeAnswer(
   } catch (error) {
     const message =
       error instanceof Error ? error.message : 'Local synthesizer failed with an unknown error.';
-    return degradedSynthesisResult(deterministicResult, message);
+    return degradedSynthesisResult(deterministicResult, trace, message);
   }
 }
 
+const MAX_DEGRADED_CANDIDATE_IDS = 8;
+
 function degradedSynthesisResult(
   deterministicResult: QueryResult,
+  trace: TraceResult,
   reason: string,
 ): QueryResult {
   const candidateIds = unique([
+    ...trace.candidateScores
+      .slice(0, MAX_DEGRADED_CANDIDATE_IDS)
+      .map((candidate) => candidate.nodeId),
     ...(deterministicResult.candidateIds ?? []),
     ...deterministicResult.ids,
-  ]);
+  ]).slice(0, MAX_DEGRADED_CANDIDATE_IDS);
   return {
     ...deterministicResult,
     answer:
@@ -66,7 +73,7 @@ function degradedSynthesisResult(
         : 'Local synthesis is unavailable, so no synthesized answer was committed.',
     ids: [],
     candidateIds,
-    confidence: Math.min(deterministicResult.confidence, 0.45),
+    confidence: null,
     gaps: unique([
       ...deterministicResult.gaps,
       `Local synthesis skipped: ${reason}`,

--- a/tests/discovery-layer.test.ts
+++ b/tests/discovery-layer.test.ts
@@ -81,6 +81,22 @@ describe('Discovery layer', () => {
       expect(filtered.entries.length).toBe(filteredLower.entries.length);
     });
 
+    it('canonicalizes part aliases before filtering', async () => {
+      const filtered = await runtime.browse({ part: 'C', limit: 500 });
+
+      expect(filtered.entries.length).toBeGreaterThan(0);
+      expect(filtered.filters.part).toMatch(/^Part C\b/);
+      expect(filtered.entries.every((entry) => entry.part?.startsWith('Part C'))).toBe(true);
+    });
+
+    it('returns a part suggestion for near-miss filters', async () => {
+      const filtered = await runtime.browse({ part: 'prt c', limit: 500 });
+
+      expect(filtered.entries).toEqual([]);
+      expect(filtered.total).toBe(0);
+      expect(filtered.didYouMean?.part).toMatch(/^Part C\b/);
+    });
+
     it('respects the limit parameter', async () => {
       const limited = await runtime.browse({ limit: 3 });
       expect(limited.entries.length).toBe(3);
@@ -167,6 +183,13 @@ describe('Discovery layer', () => {
       const result = await runtime.search('A.1.1');
       expect(result.hits.length).toBeGreaterThan(0);
       expect(result.hits[0]!.id).toBe('A.1.1');
+    });
+
+    it('weights title tokens above body token density', async () => {
+      const result = await runtime.search('evidence graph', { kind: 'pattern', limit: 5 });
+
+      expect(result.hits.length).toBeGreaterThan(0);
+      expect(result.hits[0]!.id).toBe('A.10');
     });
   });
 });

--- a/tests/fpf-spec-runtime.test.ts
+++ b/tests/fpf-spec-runtime.test.ts
@@ -213,6 +213,7 @@ describe('FpfRuntime', () => {
     expect(degradedAnswer.status).toBe('degraded');
     expect(degradedAnswer.ids).toEqual([]);
     expect(degradedAnswer.candidateIds).toContain('A.1.1');
+    expect(degradedAnswer.confidence).toBeNull();
 
     const creativity = await runtime.query(
       'How is creativity and open-ended search represented in FPF?',
@@ -560,6 +561,23 @@ describe('FpfRuntime', () => {
     expect(second.sessionReusedNodeIds).toContain('A.1.1');
     expect(second.selectedNodeIds).toEqual(
       expect.arrayContaining(['A.1.1', 'A.2.1', 'A.2.5']),
+    );
+  });
+
+  it('does not let unrelated session context change top retrieval IDs', async () => {
+    await runtime.refresh();
+
+    const sessionId = 's-unrelated';
+    await runtime.query('What is C.16 measurement template discipline?', 'compact', false, sessionId);
+
+    const question = 'How does evidence graph preserve provenance?';
+    const fresh = await runtime.trace(question, 'verbose');
+    const sessioned = await runtime.trace(question, 'verbose', false, sessionId);
+
+    expect(sessioned.sessionApplied).toBe(false);
+    expect(sessioned.selectedNodeIds).toEqual(fresh.selectedNodeIds);
+    expect(sessioned.candidateScores.map((candidate) => candidate.nodeId)).toEqual(
+      fresh.candidateScores.map((candidate) => candidate.nodeId),
     );
   });
 

--- a/tests/fpf-spec-runtime.test.ts
+++ b/tests/fpf-spec-runtime.test.ts
@@ -564,6 +564,20 @@ describe('FpfRuntime', () => {
     );
   });
 
+  it('reuses session context for low-information implicit follow-up prompts', async () => {
+    await runtime.refresh();
+
+    const sessionId = 's-implicit-followup';
+    const first = await runtime.trace('What is U.BoundedContext?', 'compact', false, sessionId);
+    expect(first.selectedNodeIds).toContain('A.1.1');
+
+    const followup = await runtime.trace('Show examples', 'proof', false, sessionId);
+
+    expect(followup.sessionApplied).toBe(true);
+    expect(followup.sessionReusedNodeIds).toContain('A.1.1');
+    expect(followup.selectedNodeIds).toContain('A.1.1');
+  });
+
   it('does not let unrelated session context change top retrieval IDs', async () => {
     await runtime.refresh();
 

--- a/tests/fpf-spec-runtime.test.ts
+++ b/tests/fpf-spec-runtime.test.ts
@@ -584,15 +584,22 @@ describe('FpfRuntime', () => {
     const sessionId = 's-unrelated';
     await runtime.query('What is C.16 measurement template discipline?', 'compact', false, sessionId);
 
-    const question = 'How does evidence graph preserve provenance?';
-    const fresh = await runtime.trace(question, 'verbose');
-    const sessioned = await runtime.trace(question, 'verbose', false, sessionId);
+    const questions = [
+      'How does evidence graph preserve provenance?',
+      'Also, what is a holon?',
+      'How does evidence graph connect to provenance?',
+    ];
 
-    expect(sessioned.sessionApplied).toBe(false);
-    expect(sessioned.selectedNodeIds).toEqual(fresh.selectedNodeIds);
-    expect(sessioned.candidateScores.map((candidate) => candidate.nodeId)).toEqual(
-      fresh.candidateScores.map((candidate) => candidate.nodeId),
-    );
+    for (const question of questions) {
+      const fresh = await runtime.trace(question, 'verbose');
+      const sessioned = await runtime.trace(question, 'verbose', false, sessionId);
+
+      expect(sessioned.sessionApplied).toBe(false);
+      expect(sessioned.selectedNodeIds).toEqual(fresh.selectedNodeIds);
+      expect(sessioned.candidateScores.map((candidate) => candidate.nodeId)).toEqual(
+        fresh.candidateScores.map((candidate) => candidate.nodeId),
+      );
+    }
   });
 
   it('lists every Draft pattern in Part C grouped by cluster', async () => {

--- a/tests/lm-studio-synthesizer.test.ts
+++ b/tests/lm-studio-synthesizer.test.ts
@@ -311,9 +311,9 @@ describe('LmStudioSynthesizer', () => {
         baseUrl: 'http://localhost:1234/v1',
         model: 'google/gemma-4-31b',
         fetchImpl: async () =>
-          new Response('ngrok 404', {
+          new Response('<!DOCTYPE html><html><body>ngrok 404</body></html>', {
             status: 404,
-            headers: { 'Content-Type': 'text/plain' },
+            headers: { 'Content-Type': 'text/html' },
           }),
       }),
     });
@@ -326,6 +326,8 @@ describe('LmStudioSynthesizer', () => {
     expect(status.synthesizer.checkedAt).toBeDefined();
     expect(status.synthesizer.failure?.httpStatus).toBe(404);
     expect(status.synthesizer.failure?.endpoint).toBe('http://localhost:1234/v1/messages');
+    expect(status.synthesizer.failure?.message).toContain('HTML error response omitted');
+    expect(status.synthesizer.failure?.message).not.toContain('<html>');
   });
 
   it('falls back deterministically when LM Studio returns an error', async () => {
@@ -349,7 +351,7 @@ describe('LmStudioSynthesizer', () => {
     expect(result.status).toBe('degraded');
     expect(result.ids).toEqual([]);
     expect(result.candidateIds).toContain('A.1.1');
-    expect(result.confidence).toBeLessThanOrEqual(0.45);
+    expect(result.confidence).toBeNull();
     expect(result.gaps.some((gap) => gap.includes('Local synthesis skipped'))).toBe(true);
 
     const traceLog = await readFile(aiTraceLogPath, 'utf8');

--- a/tests/lm-studio-synthesizer.test.ts
+++ b/tests/lm-studio-synthesizer.test.ts
@@ -340,9 +340,9 @@ describe('LmStudioSynthesizer', () => {
         traceLogPath: aiTraceLogPath,
         observabilityConfig: createObservabilityConfig(),
         fetchImpl: async () =>
-          new Response('server exploded', {
+          new Response('<h1>ngrok 404</h1>', {
             status: 500,
-            headers: { 'Content-Type': 'text/plain' },
+            headers: { 'Content-Type': 'text/html' },
           }),
       }),
     });
@@ -353,6 +353,8 @@ describe('LmStudioSynthesizer', () => {
     expect(result.candidateIds).toContain('A.1.1');
     expect(result.confidence).toBeNull();
     expect(result.gaps.some((gap) => gap.includes('Local synthesis skipped'))).toBe(true);
+    expect(result.gaps.join('\n')).toContain('HTML error response omitted');
+    expect(result.gaps.join('\n')).not.toContain('<h1>');
 
     const traceLog = await readFile(aiTraceLogPath, 'utf8');
     expect(traceLog).toContain('"phase":"response"');

--- a/tests/mcp-qa-bench.test.ts
+++ b/tests/mcp-qa-bench.test.ts
@@ -152,7 +152,7 @@ describe('MCP Q&A benchmark harness', () => {
           bodyBytes: 2,
           structuredContent: {
             status: 'degraded',
-            confidence: 0.45,
+            confidence: null,
             ids: [],
             candidateIds: ['A.1.1'],
             gaps: ['Local synthesis skipped: configured local synthesizer reported unavailable.'],
@@ -174,6 +174,41 @@ describe('MCP Q&A benchmark harness', () => {
     );
 
     expect(result.ok).toBe(true);
+  });
+
+  it('requires degraded answers to null confidence', async () => {
+    const fakeClient = {
+      async callTool() {
+        return {
+          result: {},
+          httpStatus: 200,
+          contentType: 'application/json',
+          bodyBytes: 2,
+          structuredContent: {
+            status: 'degraded',
+            confidence: 0.45,
+            ids: [],
+            candidateIds: ['A.1.1'],
+            gaps: ['Local synthesis skipped: configured local synthesizer reported unavailable.'],
+          },
+        };
+      },
+    };
+
+    const result = await runQaCase(
+      fakeClient as never,
+      {
+        id: 'case',
+        question: 'question',
+        mode: 'verbose',
+        expectedIds: ['A.1.1'],
+        allowedStatuses: ['ok', 'degraded'],
+      },
+      new Set(['A.1.1']),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('degraded answer confidence was 0.45 instead of null');
   });
 
   it('formats markdown summaries', () => {

--- a/tests/query-contracts.test.ts
+++ b/tests/query-contracts.test.ts
@@ -722,7 +722,7 @@ describe('Query / Synthesis isolation stage', () => {
     expect(result.status).toBe('degraded');
     expect(result.ids).toEqual([]);
     expect(result.candidateIds).toContain('A.1.1');
-    expect(result.confidence).toBeLessThanOrEqual(0.45);
+    expect(result.confidence).toBeNull();
     expect(result.answer).toContain('no synthesized answer was committed');
   });
 
@@ -750,7 +750,7 @@ describe('Query / Synthesis isolation stage', () => {
     expect(result.status).toBe('degraded');
     expect(result.ids).toEqual([]);
     expect(result.candidateIds).toContain('A.1.1');
-    expect(result.confidence).toBeLessThanOrEqual(0.45);
+    expect(result.confidence).toBeNull();
     expect(result.gaps.some((gap) => gap.includes('synthesis skipped') || gap.includes('synthesizer crashed'))).toBe(true);
   });
 
@@ -776,7 +776,9 @@ describe('Query / Synthesis isolation stage', () => {
     );
 
     expect(failedSynthResult.ids).toEqual([]);
-    expect(failedSynthResult.candidateIds).toEqual(deterministicResult.ids);
+    expect(failedSynthResult.candidateIds).toEqual(
+      expect.arrayContaining(deterministicResult.ids),
+    );
     expect(failedSynthResult.citations).toEqual(deterministicResult.citations);
     expect(failedSynthResult.relations).toEqual(deterministicResult.relations);
     expect(failedSynthResult.constraints).toEqual(deterministicResult.constraints);


### PR DESCRIPTION
## What

Fixes https://github.com/venikman/fpf-memory/issues/78 by tightening the public MCP answer-quality behavior around degraded synthesis, session reuse, lexical ranking, and catalog discovery.

## Why

Synthesizer-down answers must be honest uncertainty envelopes instead of committed high-confidence IDs, and unrelated session context must not contaminate fresh retrieval. The catalog/search fixes cover the remaining benchmark acceptance points around title-token recall and `part` near misses.

## Type

`fix` — bug fix

## Changes

- Degraded synthesis now returns `status: degraded`, empty committed `ids`, top retrieval `candidateIds`, and `confidence: null`.
- Session context now applies only to contextual follow-ups, not every sessioned natural-language query.
- Pattern/route/search ranking boosts title-token matches 5x and preserves the agent workflow adoption seed path.
- `browse_fpf_catalog` canonicalizes part aliases like `C` and returns `didYouMean.part` for near misses.
- LM Studio HTTP/HTML failures are sanitized before entering public status/gap messages.
- Refreshed `published/current` snapshot and manifest for the compiler fingerprint change.

## Validation

- `bun run lint` passes locally: `Found 0 lint errors, 0 type errors and 0 warnings`.
- `bun run check` passes locally: `tsc --noEmit` exited 0.
- `bun run test` passes locally: `35` files, `265` tests, `0` failures.
- Known `FPF_MASTRA_*` deprecation messages still print during full test startup; no test failures.
- `bun run build` succeeds: runtime and MCP bundles built (`cli.js`, `server.js`, `stdio.js`).
- Docs build not run; no docs source changed.
- Relevant docs updated: not applicable; runtime contract/tests and committed published snapshot were updated.
- End-to-end verification command + output excerpt:
  - Command: `FPF_LOCAL_LLM_BASE_URL=http://127.0.0.1:9/v1 FPF_LOCAL_LLM_MODEL=google/gemma-4-31b FPF_RUNTIME_ARTIFACT_DIR=.runtime/e2e-issue78 bun run cli -- query --question "What is U.BoundedContext?" --mode verbose --force`
  - Excerpt: `"status": "degraded"`, `"ids": []`, `"confidence": null`, `"candidateIds": ["A.1.1", ...]`.
- Caveats or blocker: `bun run cli -- evaluate-work --target working-tree --format json` returned `usable_with_followups` for existing wiki/navigation publication gaps, not for this issue branch.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added.
- No vector database or remote indexing introduced.
- No Python code added.
- MCP tool contracts are in `src/mcp/tool-contracts.ts`.

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | `codex/issue-78-answer-quality` |
| Prompt  | `https://github.com/venikman/fpf-memory/issues/78 create PR` |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core query/runtime behavior and MCP contracts (degraded synthesis, session seeding, browse/search output), which can change retrieval and client-facing responses. Changes are well-covered by updated unit tests but could still shift ranking/compatibility for existing consumers.
> 
> **Overview**
> Improves **degraded-synthesis honesty** by changing `confidence` to `number | null` end-to-end and requiring `status: degraded` answers to return **no committed `ids`**, `confidence: null`, and a bounded set of retrieval `candidateIds` (also surfaced in the QA bench and MCP schemas/markdown rendering).
> 
> Tightens **session-context reuse** so prior session selections only influence retrieval for explicit pronoun follow-ups or very short implicit follow-up prompts, preventing unrelated sessions from contaminating fresh questions.
> 
> Enhances **discovery quality** by boosting title-token matches in pattern/route scoring and global `search()`, adding `browse()` part-filter canonicalization plus optional `didYouMean.part` suggestions, and sanitizing LM Studio HTML/error bodies in surfaced failure messages/gaps.
> 
> Refreshes the published snapshot/manifest artifacts to the latest compiler fingerprint and adds a new heuristic seed rule (`agent-workflow-adoption`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f1dc3f13bd1765ba7edf966d5b2d60662acd7e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->