### PR TITLE
docs: surface the pattern index link

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -231,6 +231,11 @@ window.addEventListener('transitionend',fixSidebarInert);
         link: '/work-packets',
       },
       {
+        text: 'Index',
+        link: '/patterns',
+        activeMatch: '/patterns/?($|\\?|#)',
+      },
+      {
         text: 'MCP',
         items: [
           { text: 'Recipes', link: '/mcp-recipes' },

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -231,7 +231,7 @@ window.addEventListener('transitionend',fixSidebarInert);
         link: '/work-packets',
       },
       {
-        text: 'Index',
+        text: 'Pattern Index',
         link: '/patterns',
         activeMatch: '/patterns/?($|\\?|#)',
       },
@@ -246,11 +246,6 @@ window.addEventListener('transitionend',fixSidebarInert);
       {
         text: 'Reference',
         items: [
-          // `activeMatch` anchors the regex so `/patterns` doesn't fire as
-          // active on every `/generated/patterns/*` pattern page (R3-P2-003).
-          // Rspress's matchNavbar uses `RegExp(activeMatch || link).test(path)`
-          // and a bare `/patterns` would substring-match `/generated/patterns/H.1`.
-          { text: 'Pattern catalog', link: '/patterns', activeMatch: '/patterns/?($|\\?|#)' },
           { text: 'Routes', link: '/generated/routes/index' },
           { text: 'Glossary', link: '/generated/patterns/H.1' },
           { text: 'Change log', link: '/generated/patterns/I.3' },

--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -449,15 +449,18 @@ function renderHomeFrontMatter(patternCount: number): string {
     '      text: "→ Open the adoption guide"',
     '      link: /start-here',
     '    - theme: alt',
+    '      text: Index',
+    '      link: /patterns',
+    '    - theme: alt',
     '      text: Work packets',
     '      link: /work-packets',
     '    - theme: alt',
     '      text: MCP recipes',
     '      link: /mcp-recipes',
     'features:',
-    '  - title: Patterns',
-    `    details: ${patternCount} patterns across parts A–K. Open an exact ID, audit the full reference, or compare neighboring patterns by Part.`,
-    // Patterns and Routes are categories — using a real ID like `A.1`
+    '  - title: Index',
+    `    details: The clickable FPF pattern index: ${patternCount} patterns across parts A–K. Open an exact ID, audit the full reference, or compare neighboring patterns by Part.`,
+    // Index and Routes are categories — using a real ID like `A.1`
     // or `F.1` as the chip (R5-P2-007) misleads users into thinking
     // those IDs *are* "all patterns" or "all routes". Use a category
     // badge instead. H.1 and I.3 chips stay because those IDs *are*

--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -449,7 +449,7 @@ function renderHomeFrontMatter(patternCount: number): string {
     '      text: "→ Open the adoption guide"',
     '      link: /start-here',
     '    - theme: alt',
-    '      text: Index',
+    '      text: Pattern Index',
     '      link: /patterns',
     '    - theme: alt',
     '      text: Work packets',
@@ -458,13 +458,13 @@ function renderHomeFrontMatter(patternCount: number): string {
     '      text: MCP recipes',
     '      link: /mcp-recipes',
     'features:',
-    '  - title: Index',
-    `    details: The clickable FPF pattern index: ${patternCount} patterns across parts A–K. Open an exact ID, audit the full reference, or compare neighboring patterns by Part.`,
-    // Index and Routes are categories — using a real ID like `A.1`
-    // or `F.1` as the chip (R5-P2-007) misleads users into thinking
-    // those IDs *are* "all patterns" or "all routes". Use a category
-    // badge instead. H.1 and I.3 chips stay because those IDs *are*
-    // the canonical glossary and change-log anchors.
+    '  - title: Pattern Index',
+    `    details: "The clickable FPF pattern index: ${patternCount} patterns across parts A–K. Open an exact ID, audit the full reference, or compare neighboring patterns by Part."`,
+    // The Pattern Index and Routes cards each cover a catalog of items —
+    // using a real ID like `A.1` or `F.1` as the chip (R5-P2-007)
+    // misleads users into thinking those IDs *are* "all patterns" or
+    // "all routes". Use a category badge instead. H.1 and I.3 chips stay
+    // because those IDs *are* the canonical glossary and change-log anchors.
     '    icon: A–K',
     '    link: /patterns',
     '  - title: Routes',

--- a/tests/docs-projection.test.ts
+++ b/tests/docs-projection.test.ts
@@ -242,14 +242,16 @@ describe('docs projection', () => {
       // Primary CTA verb-prefixed; secondary actions stay as plain text.
       expect(rootIndex).toContain('Open the adoption guide');
       expect(rootIndex).toContain('link: /start-here');
+      expect(rootIndex).toContain('text: Index');
+      expect(rootIndex).toContain('link: /patterns');
       expect(rootIndex).toContain('text: Work packets');
       expect(rootIndex).toContain('link: /work-packets');
       expect(rootIndex).toContain('text: MCP recipes');
       expect(rootIndex).toContain('link: /mcp-recipes');
-      expect(rootIndex).toContain('  - title: Patterns');
-      // Patterns feature card now points at the short Pattern Catalog
+      expect(rootIndex).toContain('  - title: Index');
+      // Index feature card points at the short Pattern Catalog
       // URL `/patterns`, not the deep-link `/generated/patterns/index`.
-      expect(rootIndex).toMatch(/- title: Patterns[\s\S]*?link: \/patterns/);
+      expect(rootIndex).toMatch(/- title: Index[\s\S]*?link: \/patterns/);
       expect(rootIndex).toContain('  - title: Routes');
       expect(rootIndex).toContain('link: /generated/routes/index');
       // Card titles dropped the "anchor" suffix per PR #72 design

--- a/tests/docs-projection.test.ts
+++ b/tests/docs-projection.test.ts
@@ -242,16 +242,15 @@ describe('docs projection', () => {
       // Primary CTA verb-prefixed; secondary actions stay as plain text.
       expect(rootIndex).toContain('Open the adoption guide');
       expect(rootIndex).toContain('link: /start-here');
-      expect(rootIndex).toContain('text: Index');
-      expect(rootIndex).toContain('link: /patterns');
+      expect(rootIndex).toMatch(/text: Pattern Index[\s\S]*?link: \/patterns/);
       expect(rootIndex).toContain('text: Work packets');
       expect(rootIndex).toContain('link: /work-packets');
       expect(rootIndex).toContain('text: MCP recipes');
       expect(rootIndex).toContain('link: /mcp-recipes');
-      expect(rootIndex).toContain('  - title: Index');
+      expect(rootIndex).toContain('  - title: Pattern Index');
       // Index feature card points at the short Pattern Catalog
       // URL `/patterns`, not the deep-link `/generated/patterns/index`.
-      expect(rootIndex).toMatch(/- title: Index[\s\S]*?link: \/patterns/);
+      expect(rootIndex).toMatch(/- title: Pattern Index[\s\S]*?link: \/patterns/);
       expect(rootIndex).toContain('  - title: Routes');
       expect(rootIndex).toContain('link: /generated/routes/index');
       // Card titles dropped the "anchor" suffix per PR #72 design


### PR DESCRIPTION
## What

- Add a top-level `Index` nav link to `/patterns`.
- Add an `Index` hero action and rename the home feature card so the pattern index is obvious from the first screen.
- Update docs projection expectations to cover the new link.

## Why

Users should have a clickable, easy-to-find path to the FPF pattern index without discovering it through the Reference dropdown.

## Validation

- `bun install --frozen-lockfile`
- `bunx rstest run tests/docs-projection.test.ts` -> 9 tests passed
- `bun run check` -> passed
- `bun run docs:build` -> generated 827 files; Rspress build succeeded
- `rg -n "href=\"/fpf-memory/patterns\"[^>]*>Index|Index</a>|text: Index|title: Index|clickable FPF pattern index" doc_build/index.html docs/index.md src/core/documents.ts rspress.config.ts tests/docs-projection.test.ts` -> built HTML contains top-level `/fpf-memory/patterns` `Index` link
- `bun run lint` -> 0 lint errors, 0 type errors, 0 warnings

## Caveats

- The previous `bun test tests/docs-projection.test.ts` attempt failed because this repo uses Rstest, not Bun test, for that file.
- A first `bun run check` attempt failed before dependencies were installed; it passed after `bun install --frozen-lockfile`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/89" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/navigation change that only adjusts labels and links to make the pattern index more discoverable; no runtime/business logic changes.
> 
> **Overview**
> Surfaces the FPF pattern catalog more prominently by adding a top-level **`Index`** nav item linking to `/patterns` (with an `activeMatch` to avoid false activation).
> 
> Updates the home page projection frontmatter to include an `Index` hero action and renames the patterns feature card from `Patterns` to **`Index`** (still linking to `/patterns`).
> 
> Extends `docs-projection` tests to assert the new `Index` CTA and feature-card title/link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d683e8b0bc74a98a9b61aa12588ce971ac8e45d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->