### PR TITLE
ci: add opt-in TPR fast-track timer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,6 +30,15 @@
 - End-to-end verification command + output excerpt:
 - Caveats or blocker:
 
+## TPR fast-track
+
+- [ ] Enable TPR review/merge timer
+
+Use this only for small, reversible PRs from trusted maintainers or collaborators. The timer does not fake approval or bypass branch protection:
+
+- after 1 hour without a non-author review signal, automation comments `@codex review`;
+- after 2 hours, automation enables auto-merge only when checks pass, no trusted reviewer requested changes, and at least one trusted non-author approval exists for the current head commit.
+
 ## Boundary check
 
 - Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added

--- a/.github/workflows/tpr-fast-track.yml
+++ b/.github/workflows/tpr-fast-track.yml
@@ -1,0 +1,43 @@
+name: TPR Fast Track
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, ready_for_review, synchronize]
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Optional PR number to process
+        required: false
+
+permissions:
+  checks: read
+  contents: read
+  issues: write
+  pull-requests: write
+  statuses: read
+
+concurrency:
+  group: tpr-fast-track-${{ github.event.pull_request.number || github.event.inputs.pr || github.event_name }}
+  cancel-in-progress: false
+
+jobs:
+  tpr-fast-track:
+    name: TPR Fast Track
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+
+      - name: Run TPR timer
+        run: bun scripts/tpr-fast-track.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TPR_FAST_TRACK_PR: ${{ github.event.inputs.pr || '' }}

--- a/scripts/tpr-fast-track.ts
+++ b/scripts/tpr-fast-track.ts
@@ -1,0 +1,625 @@
+const oneHourMs = 60 * 60 * 1000;
+const twoHoursMs = 2 * oneHourMs;
+
+export const fastTrackCheckboxLabel = 'Enable TPR review/merge timer';
+export const reviewRequestMarker = '<!-- tpr-fast-track:review-requested';
+export const mergeAttemptMarker = '<!-- tpr-fast-track:merge-attempted';
+
+const blockedMarkerPrefix = '<!-- tpr-fast-track:merge-blocked:';
+const reviewSignalStates = new Set(['APPROVED', 'COMMENTED', 'CHANGES_REQUESTED']);
+const blockingReviewState = 'CHANGES_REQUESTED';
+const approvingReviewState = 'APPROVED';
+const trustedAuthorAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+
+type ReviewState = 'APPROVED' | 'COMMENTED' | 'CHANGES_REQUESTED' | 'DISMISSED' | string;
+
+export type ChecksState = {
+  state: 'pass' | 'pending' | 'fail';
+  summary: string;
+};
+
+export type ReviewSummary = {
+  author: string;
+  authorAssociation: string;
+  commitId: string | null;
+  submittedAt: string;
+  state: ReviewState;
+};
+
+export type IssueCommentSummary = {
+  body: string;
+};
+
+export type PullRequestFastTrackState = {
+  author: string;
+  authorAssociation: string;
+  body: string | null;
+  checks: ChecksState;
+  comments: IssueCommentSummary[];
+  draft: boolean;
+  headSha: string;
+  number: number;
+  reviewWindowStartedAt: string;
+  reviews: ReviewSummary[];
+};
+
+export type FastTrackAction =
+  | {
+      type: 'request-review';
+      marker: string;
+      message: string;
+    }
+  | {
+      type: 'merge';
+      marker: string;
+      message: string;
+    }
+  | {
+      type: 'comment-blocked';
+      marker: string;
+      message: string;
+    };
+
+type GitHubPullRequest = {
+  author_association: string;
+  body: string | null;
+  created_at: string;
+  draft: boolean;
+  head: {
+    sha: string;
+  };
+  node_id: string;
+  number: number;
+  user: {
+    login: string;
+  };
+};
+
+type GitHubReview = {
+  author_association: string;
+  commit_id: string | null;
+  state: string;
+  submitted_at: string | null;
+  user: {
+    login: string;
+  } | null;
+};
+
+type GitHubCommit = {
+  commit: {
+    author?: {
+      date?: string;
+    };
+    committer?: {
+      date?: string;
+    };
+  };
+};
+
+type GitHubIssueComment = {
+  body: string | null;
+};
+
+type GitHubCheckRun = {
+  conclusion: string | null;
+  name: string;
+  status: string;
+};
+
+export type GitHubCombinedStatus = {
+  state: 'success' | 'failure' | 'error' | 'pending';
+  statuses: unknown[];
+};
+
+export type GitHubCheckRunSummary = GitHubCheckRun;
+
+type PullRequestContext = {
+  checks: ChecksState;
+  comments: IssueCommentSummary[];
+  pr: GitHubPullRequest;
+  reviewWindowStartedAt: string;
+  reviews: ReviewSummary[];
+};
+
+class GitHubClient {
+  constructor(
+    private readonly token: string,
+    private readonly owner: string,
+    private readonly repo: string,
+  ) {}
+
+  async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const response = await fetch(`https://api.github.com${path}`, {
+      method,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${this.token}`,
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const responseBody = await response.text();
+      throw new Error(`${method} ${path} failed with ${response.status}: ${responseBody}`);
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return (await response.json()) as T;
+  }
+
+  async paginate<T>(path: string): Promise<T[]> {
+    const separator = path.includes('?') ? '&' : '?';
+    const firstPagePath = `${path}${separator}per_page=100`;
+    const items: T[] = [];
+    let nextPath: string | undefined = firstPagePath;
+
+    while (nextPath) {
+      const response = await fetch(`https://api.github.com${nextPath}`, {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${this.token}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+
+      if (!response.ok) {
+        const responseBody = await response.text();
+        throw new Error(`GET ${nextPath} failed with ${response.status}: ${responseBody}`);
+      }
+
+      items.push(...((await response.json()) as T[]));
+      nextPath = parseNextPath(response.headers.get('link'));
+    }
+
+    return items;
+  }
+
+  async graphql<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+    const response = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${this.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    const result = (await response.json()) as { data?: T; errors?: { message: string }[] };
+
+    if (!response.ok || result.errors?.length) {
+      const messages = result.errors?.map((error) => error.message).join('; ') ?? response.statusText;
+      throw new Error(`GraphQL request failed: ${messages}`);
+    }
+
+    if (!result.data) {
+      throw new Error('GraphQL request returned no data.');
+    }
+
+    return result.data;
+  }
+
+  repoPath(path: string): string {
+    return `/repos/${this.owner}/${this.repo}${path}`;
+  }
+}
+
+export function isFastTrackEnabled(body: string | null | undefined): boolean {
+  if (!body) {
+    return false;
+  }
+
+  return new RegExp(`-\\s*\\[[xX]\\]\\s*${escapeRegExp(fastTrackCheckboxLabel)}`).test(body);
+}
+
+export function planTprFastTrackActions(
+  state: PullRequestFastTrackState,
+  now = new Date(),
+): FastTrackAction[] {
+  if (!isFastTrackEnabled(state.body) || state.draft) {
+    return [];
+  }
+
+  const actions: FastTrackAction[] = [];
+  const reviewWindowStartedAt = new Date(state.reviewWindowStartedAt);
+  const ageMs = now.getTime() - reviewWindowStartedAt.getTime();
+  const reviewRequestHeadMarker = markerForHead(reviewRequestMarker, state.headSha);
+  const mergeAttemptHeadMarker = markerForHead(mergeAttemptMarker, state.headSha);
+
+  if (!trustedAuthorAssociations.has(state.authorAssociation)) {
+    return maybeBlockedAction(
+      state,
+      'untrusted-author',
+      'TPR fast-track is enabled, but this automation only runs for OWNER, MEMBER, or COLLABORATOR PR authors.',
+    );
+  }
+
+  const hasReview = hasCurrentHeadReviewSignal(state);
+
+  if (ageMs >= oneHourMs && !hasReview && !hasCommentMarker(state.comments, reviewRequestHeadMarker)) {
+    actions.push({
+      type: 'request-review',
+      marker: reviewRequestHeadMarker,
+      message: `${reviewRequestHeadMarker}
+@codex review
+
+TPR fast-track timer reached 1 hour without a trusted non-author review on the current head commit. Please review this PR. The 2-hour merge path still requires passing checks, a trusted non-author approval on the current head commit, and no requested changes.`,
+    });
+  }
+
+  if (ageMs < twoHoursMs) {
+    return actions;
+  }
+
+  if (hasBlockingChangeRequest(state)) {
+    actions.push(
+      ...maybeBlockedAction(
+        state,
+        'changes-requested',
+        'TPR fast-track reached 2 hours, but merge is blocked because a trusted non-author reviewer requested changes and has not approved since.',
+      ),
+    );
+    return actions;
+  }
+
+  if (!hasCurrentHeadApproval(state)) {
+    actions.push(
+      ...maybeBlockedAction(
+        state,
+        'no-current-head-approval',
+        'TPR fast-track reached 2 hours, but merge is blocked until at least one trusted non-author approval exists on the current head commit.',
+      ),
+    );
+    return actions;
+  }
+
+  if (state.checks.state !== 'pass') {
+    actions.push(
+      ...maybeBlockedAction(
+        state,
+        `checks-${state.checks.state}`,
+        `TPR fast-track reached 2 hours, but merge is blocked because checks are ${state.checks.state}: ${state.checks.summary}`,
+      ),
+    );
+    return actions;
+  }
+
+  if (!hasCommentMarker(state.comments, mergeAttemptHeadMarker)) {
+    actions.push({
+      type: 'merge',
+      marker: mergeAttemptHeadMarker,
+      message: `${mergeAttemptHeadMarker}
+TPR fast-track reached 2 hours with a trusted non-author approval on the current head commit, no requested changes, and passing checks. Auto-merge has been enabled.`,
+    });
+  }
+
+  return actions;
+}
+
+async function main(): Promise<void> {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+
+  if (!token) {
+    throw new Error('GITHUB_TOKEN is required.');
+  }
+
+  if (!repository?.includes('/')) {
+    throw new Error('GITHUB_REPOSITORY must be set to owner/repo.');
+  }
+
+  const [owner, repo] = repository.split('/') as [string, string];
+  const client = new GitHubClient(token, owner, repo);
+  const prNumbers = await resolvePrNumbers(client);
+
+  if (prNumbers.length === 0) {
+    console.log('No PRs to process.');
+    return;
+  }
+
+  let failedCount = 0;
+  for (const prNumber of prNumbers) {
+    try {
+      await processPullRequest(client, prNumber);
+    } catch (error) {
+      failedCount += 1;
+      console.error(`#${prNumber}: failed to process: ${String(error)}`);
+    }
+  }
+
+  if (failedCount > 0) {
+    throw new Error(`TPR fast-track failed to process ${failedCount} PR(s).`);
+  }
+}
+
+async function resolvePrNumbers(client: GitHubClient): Promise<number[]> {
+  const requestedPr = process.env.TPR_FAST_TRACK_PR?.trim();
+
+  if (requestedPr) {
+    const parsed = Number(requestedPr);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new Error(`TPR_FAST_TRACK_PR must be a positive integer, got ${requestedPr}.`);
+    }
+
+    return [parsed];
+  }
+
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath) {
+    const event = await Bun.file(eventPath).json().catch(() => undefined);
+    const eventPrNumber = event?.pull_request?.number;
+    if (typeof eventPrNumber === 'number') {
+      return [eventPrNumber];
+    }
+  }
+
+  const openPrs = await client.paginate<GitHubPullRequest>(client.repoPath('/pulls?state=open'));
+  return openPrs.map((pr) => pr.number);
+}
+
+async function processPullRequest(client: GitHubClient, prNumber: number): Promise<void> {
+  const context = await loadPullRequestContext(client, prNumber);
+  const state: PullRequestFastTrackState = {
+    author: context.pr.user.login,
+    authorAssociation: context.pr.author_association,
+    body: context.pr.body,
+    checks: context.checks,
+    comments: context.comments,
+    draft: context.pr.draft,
+    headSha: context.pr.head.sha,
+    number: context.pr.number,
+    reviewWindowStartedAt: context.reviewWindowStartedAt,
+    reviews: context.reviews,
+  };
+  const actions = planTprFastTrackActions(state);
+
+  if (actions.length === 0) {
+    console.log(`#${prNumber}: no action.`);
+    return;
+  }
+
+  for (const action of actions) {
+    console.log(`#${prNumber}: ${action.type}`);
+
+    if (action.type === 'request-review' || action.type === 'comment-blocked') {
+      await postIssueComment(client, prNumber, action.message);
+      continue;
+    }
+
+    await enableAutoMerge(client, context.pr);
+    await postIssueComment(client, prNumber, action.message);
+  }
+}
+
+async function loadPullRequestContext(client: GitHubClient, prNumber: number): Promise<PullRequestContext> {
+  const pr = await client.request<GitHubPullRequest>('GET', client.repoPath(`/pulls/${prNumber}`));
+  const [reviews, comments, checks, reviewWindowStartedAt] = await Promise.all([
+    loadReviews(client, prNumber),
+    loadIssueComments(client, prNumber),
+    loadChecks(client, pr.head.sha),
+    loadHeadCommitDate(client, pr.head.sha),
+  ]);
+
+  return {
+    checks,
+    comments,
+    pr,
+    reviewWindowStartedAt,
+    reviews,
+  };
+}
+
+async function loadReviews(client: GitHubClient, prNumber: number): Promise<ReviewSummary[]> {
+  const reviews = await client.paginate<GitHubReview>(client.repoPath(`/pulls/${prNumber}/reviews`));
+  return reviews
+    .filter((review) => review.user?.login && review.submitted_at)
+    .map((review) => ({
+      author: review.user!.login,
+      authorAssociation: review.author_association,
+      commitId: review.commit_id,
+      submittedAt: review.submitted_at!,
+      state: review.state,
+    }));
+}
+
+async function loadHeadCommitDate(client: GitHubClient, sha: string): Promise<string> {
+  const commit = await client.request<GitHubCommit>('GET', client.repoPath(`/commits/${sha}`));
+  const date = commit.commit.committer?.date ?? commit.commit.author?.date;
+
+  if (!date) {
+    throw new Error(`Could not resolve commit date for ${sha}.`);
+  }
+
+  return date;
+}
+
+async function loadIssueComments(client: GitHubClient, prNumber: number): Promise<IssueCommentSummary[]> {
+  const comments = await client.paginate<GitHubIssueComment>(client.repoPath(`/issues/${prNumber}/comments`));
+  return comments.map((comment) => ({ body: comment.body ?? '' }));
+}
+
+async function loadChecks(client: GitHubClient, sha: string): Promise<ChecksState> {
+  const [combinedStatus, checkRuns] = await Promise.all([
+    client.request<GitHubCombinedStatus>('GET', client.repoPath(`/commits/${sha}/status`)),
+    loadCheckRuns(client, sha),
+  ]);
+  return summarizeChecks(combinedStatus, checkRuns);
+}
+
+async function loadCheckRuns(client: GitHubClient, sha: string): Promise<GitHubCheckRun[]> {
+  const checkRuns: GitHubCheckRun[] = [];
+  let page = 1;
+
+  while (true) {
+    const response = await client.request<{ check_runs: GitHubCheckRun[] }>(
+      'GET',
+      client.repoPath(`/commits/${sha}/check-runs?per_page=100&page=${page}`),
+    );
+    checkRuns.push(...response.check_runs);
+
+    if (response.check_runs.length < 100) {
+      return checkRuns;
+    }
+
+    page += 1;
+  }
+}
+
+export function summarizeChecks(
+  combinedStatus: GitHubCombinedStatus,
+  checkRuns: GitHubCheckRunSummary[],
+): ChecksState {
+  const ciRun = checkRuns.find((run) => run.name === 'ci');
+
+  if (!ciRun) {
+    return { state: 'pending', summary: 'CI / ci check run not found' };
+  }
+
+  if (ciRun.status !== 'completed') {
+    return { state: 'pending', summary: 'CI / ci is still running' };
+  }
+
+  if (ciRun.conclusion !== 'success') {
+    return { state: 'fail', summary: `CI / ci concluded ${ciRun.conclusion ?? 'without a conclusion'}` };
+  }
+
+  if (combinedStatus.state === 'failure' || combinedStatus.state === 'error') {
+    return { state: 'fail', summary: `combined commit status is ${combinedStatus.state}` };
+  }
+
+  if (combinedStatus.statuses.length > 0 && combinedStatus.state === 'pending') {
+    return { state: 'pending', summary: 'combined commit status is pending' };
+  }
+
+  return { state: 'pass', summary: 'CI / ci and commit status evidence passed' };
+}
+
+async function postIssueComment(client: GitHubClient, prNumber: number, body: string): Promise<void> {
+  await client.request('POST', client.repoPath(`/issues/${prNumber}/comments`), { body });
+}
+
+async function enableAutoMerge(client: GitHubClient, pr: GitHubPullRequest): Promise<void> {
+  await client.graphql(
+    `mutation EnablePullRequestAutoMerge($pullRequestId: ID!) {
+      enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: SQUASH }) {
+        pullRequest {
+          number
+        }
+      }
+    }`,
+    { pullRequestId: pr.node_id },
+  );
+  console.log(`#${pr.number}: auto-merge enabled.`);
+}
+
+function hasCurrentHeadReviewSignal(state: PullRequestFastTrackState): boolean {
+  return currentHeadTrustedNonAuthorReviews(state).some((review) => reviewSignalStates.has(review.state));
+}
+
+function hasBlockingChangeRequest(state: PullRequestFastTrackState): boolean {
+  return latestTrustedNonAuthorDecisiveReviews(state).some((review) => review.state === blockingReviewState);
+}
+
+function hasCurrentHeadApproval(state: PullRequestFastTrackState): boolean {
+  return latestTrustedNonAuthorDecisiveReviews(state).some(
+    (review) => review.state === approvingReviewState && review.commitId === state.headSha,
+  );
+}
+
+function currentHeadTrustedNonAuthorReviews(state: PullRequestFastTrackState): ReviewSummary[] {
+  return latestTrustedNonAuthorReviews(state).filter((review) => review.commitId === state.headSha);
+}
+
+function latestTrustedNonAuthorDecisiveReviews(state: PullRequestFastTrackState): ReviewSummary[] {
+  const latestByAuthor = new Map<string, ReviewSummary>();
+
+  for (const review of state.reviews) {
+    if (review.author === state.author || !trustedAuthorAssociations.has(review.authorAssociation)) {
+      continue;
+    }
+
+    if (
+      review.state !== approvingReviewState &&
+      review.state !== blockingReviewState &&
+      review.state !== 'DISMISSED'
+    ) {
+      continue;
+    }
+
+    const current = latestByAuthor.get(review.author);
+    if (!current || new Date(review.submittedAt).getTime() > new Date(current.submittedAt).getTime()) {
+      latestByAuthor.set(review.author, review);
+    }
+  }
+
+  return Array.from(latestByAuthor.values()).filter((review) => review.state !== 'DISMISSED');
+}
+
+function latestTrustedNonAuthorReviews(state: PullRequestFastTrackState): ReviewSummary[] {
+  const latestByAuthor = new Map<string, ReviewSummary>();
+
+  for (const review of state.reviews) {
+    if (review.author === state.author || !trustedAuthorAssociations.has(review.authorAssociation)) {
+      continue;
+    }
+
+    const current = latestByAuthor.get(review.author);
+    if (!current || new Date(review.submittedAt).getTime() > new Date(current.submittedAt).getTime()) {
+      latestByAuthor.set(review.author, review);
+    }
+  }
+
+  return Array.from(latestByAuthor.values()).filter((review) => review.state !== 'DISMISSED');
+}
+
+function hasCommentMarker(comments: IssueCommentSummary[], marker: string): boolean {
+  return comments.some((comment) => comment.body.includes(marker));
+}
+
+function maybeBlockedAction(
+  state: PullRequestFastTrackState,
+  reason: string,
+  message: string,
+): FastTrackAction[] {
+  const marker = `${blockedMarkerPrefix}${reason}:${state.headSha} -->`;
+
+  if (hasCommentMarker(state.comments, marker)) {
+    return [];
+  }
+
+  return [
+    {
+      type: 'comment-blocked',
+      marker,
+      message: `${marker}
+${message}`,
+    },
+  ];
+}
+
+function markerForHead(markerPrefix: string, headSha: string): string {
+  return `${markerPrefix}:${headSha} -->`;
+}
+
+function parseNextPath(linkHeader: string | null): string | undefined {
+  if (!linkHeader) {
+    return undefined;
+  }
+
+  const nextLink = linkHeader.split(',').find((link) => link.includes('rel="next"'));
+  const urlMatch = nextLink?.match(/<https:\/\/api\.github\.com([^>]+)>/);
+  return urlMatch?.[1];
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/tests/tpr-fast-track.test.ts
+++ b/tests/tpr-fast-track.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it } from '@rstest/core';
+
+import {
+  fastTrackCheckboxLabel,
+  isFastTrackEnabled,
+  mergeAttemptMarker,
+  planTprFastTrackActions,
+  reviewRequestMarker,
+  summarizeChecks,
+  type PullRequestFastTrackState,
+} from '../scripts/tpr-fast-track';
+
+const createdAt = '2026-05-09T10:00:00.000Z';
+const headSha = 'abc123';
+const reviewRequestHeadMarker = `${reviewRequestMarker}:${headSha} -->`;
+const mergeAttemptHeadMarker = `${mergeAttemptMarker}:${headSha} -->`;
+
+describe('TPR fast-track planner', () => {
+  it('detects the opt-in checkbox only when checked', () => {
+    expect(isFastTrackEnabled(`- [x] ${fastTrackCheckboxLabel}`)).toBe(true);
+    expect(isFastTrackEnabled(`- [X] ${fastTrackCheckboxLabel}`)).toBe(true);
+    expect(isFastTrackEnabled(`- [ ] ${fastTrackCheckboxLabel}`)).toBe(false);
+  });
+
+  it('requests Codex review after 1 hour without a non-author review', () => {
+    const actions = planTprFastTrackActions(baseState(), new Date('2026-05-09T11:01:00.000Z'));
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        marker: reviewRequestHeadMarker,
+        type: 'request-review',
+      }),
+    ]);
+  });
+
+  it('does not request review twice', () => {
+    const actions = planTprFastTrackActions(
+      baseState({
+        comments: [{ body: reviewRequestHeadMarker }],
+      }),
+      new Date('2026-05-09T11:01:00.000Z'),
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it('blocks the 2-hour merge path until a current-head approval exists', () => {
+    const actions = planTprFastTrackActions(baseState(), new Date('2026-05-09T12:01:00.000Z'));
+
+    expect(actions.map((action) => action.type)).toEqual(['request-review', 'comment-blocked']);
+    expect(actions[1]?.marker).toContain('no-current-head-approval');
+  });
+
+  it('blocks merge when the latest non-author review requests changes', () => {
+    const actions = planTprFastTrackActions(
+      baseState({
+        reviews: [
+          {
+            author: 'reviewer',
+            authorAssociation: 'MEMBER',
+            commitId: headSha,
+            state: 'APPROVED',
+            submittedAt: '2026-05-09T10:20:00.000Z',
+          },
+          {
+            author: 'reviewer',
+            authorAssociation: 'MEMBER',
+            commitId: headSha,
+            state: 'CHANGES_REQUESTED',
+            submittedAt: '2026-05-09T10:40:00.000Z',
+          },
+        ],
+      }),
+      new Date('2026-05-09T12:01:00.000Z'),
+    );
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        marker: expect.stringContaining('changes-requested') as string,
+        type: 'comment-blocked',
+      }),
+    ]);
+  });
+
+  it('does not count a dismissed latest review as an active review signal', () => {
+    const actions = planTprFastTrackActions(
+      baseState({
+        comments: [{ body: reviewRequestHeadMarker }],
+        reviews: [
+          {
+            author: 'reviewer',
+            authorAssociation: 'MEMBER',
+            commitId: headSha,
+            state: 'APPROVED',
+            submittedAt: '2026-05-09T10:20:00.000Z',
+          },
+          {
+            author: 'reviewer',
+            authorAssociation: 'MEMBER',
+            commitId: headSha,
+            state: 'DISMISSED',
+            submittedAt: '2026-05-09T10:40:00.000Z',
+          },
+        ],
+      }),
+      new Date('2026-05-09T12:01:00.000Z'),
+    );
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        marker: expect.stringContaining('no-current-head-approval') as string,
+        type: 'comment-blocked',
+      }),
+    ]);
+  });
+
+  it('queues merge after 2 hours with current-head approval and passing checks', () => {
+    const actions = planTprFastTrackActions(
+      baseState({
+        reviews: [
+          {
+            author: 'reviewer',
+            authorAssociation: 'MEMBER',
+            commitId: headSha,
+            state: 'APPROVED',
+            submittedAt: '2026-05-09T10:20:00.000Z',
+          },
+        ],
+      }),
+      new Date('2026-05-09T12:01:00.000Z'),
+    );
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        marker: mergeAttemptHeadMarker,
+        type: 'merge',
+      }),
+    ]);
+  });
+
+  it('does not merge when the current-head review is only a comment', () => {
+    const actions = planTprFastTrackActions(
+      baseState({
+        comments: [{ body: reviewRequestHeadMarker }],
+        reviews: [
+          {
+            author: 'reviewer',
+            authorAssociation: 'MEMBER',
+            commitId: headSha,
+            state: 'COMMENTED',
+            submittedAt: '2026-05-09T10:20:00.000Z',
+          },
+        ],
+      }),
+      new Date('2026-05-09T12:01:00.000Z'),
+    );
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        marker: expect.stringContaining('no-current-head-approval') as string,
+        type: 'comment-blocked',
+      }),
+    ]);
+  });
+
+  it('does not let a later review comment clear a requested-changes block', () => {
+    const actions = planTprFastTrackActions(
+      baseState({
+        reviews: [
+          {
+            author: 'reviewer',
+            authorAssociation: 'MEMBER',
+            commitId: headSha,
+            state: 'CHANGES_REQUESTED',
+            submittedAt: '2026-05-09T10:20:00.000Z',
+          },
+          {
+            author: 'reviewer',
+            authorAssociation: 'MEMBER',
+            commitId: headSha,
+            state: 'COMMENTED',
+            submittedAt: '2026-05-09T10:40:00.000Z',
+          },
+        ],
+      }),
+      new Date('2026-05-09T12:01:00.000Z'),
+    );
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        marker: expect.stringContaining('changes-requested') as string,
+        type: 'comment-blocked',
+      }),
+    ]);
+  });
+
+  it('does not merge a new head from a stale approval on an older commit', () => {
+    const actions = planTprFastTrackActions(
+      baseState({
+        comments: [{ body: reviewRequestHeadMarker }],
+        reviews: [
+          {
+            author: 'reviewer',
+            authorAssociation: 'MEMBER',
+            commitId: 'old-sha',
+            state: 'APPROVED',
+            submittedAt: '2026-05-09T10:20:00.000Z',
+          },
+        ],
+      }),
+      new Date('2026-05-09T12:01:00.000Z'),
+    );
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        marker: expect.stringContaining('no-current-head-approval') as string,
+        type: 'comment-blocked',
+      }),
+    ]);
+  });
+
+  it('does not merge from an untrusted reviewer approval', () => {
+    const actions = planTprFastTrackActions(
+      baseState({
+        comments: [{ body: reviewRequestHeadMarker }],
+        reviews: [
+          {
+            author: 'outside-reviewer',
+            authorAssociation: 'CONTRIBUTOR',
+            commitId: headSha,
+            state: 'APPROVED',
+            submittedAt: '2026-05-09T10:20:00.000Z',
+          },
+        ],
+      }),
+      new Date('2026-05-09T12:01:00.000Z'),
+    );
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        marker: expect.stringContaining('no-current-head-approval') as string,
+        type: 'comment-blocked',
+      }),
+    ]);
+  });
+
+  it('requests review for a new head even when an older head had a timer comment', () => {
+    const actions = planTprFastTrackActions(
+      baseState({
+        comments: [{ body: `${reviewRequestMarker}:old-sha -->` }],
+        reviewWindowStartedAt: '2026-05-09T11:00:00.000Z',
+      }),
+      new Date('2026-05-09T12:01:00.000Z'),
+    );
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        marker: reviewRequestHeadMarker,
+        type: 'request-review',
+      }),
+    ]);
+  });
+
+  it('blocks untrusted PR authors even when they opt in', () => {
+    const actions = planTprFastTrackActions(
+      baseState({
+        authorAssociation: 'CONTRIBUTOR',
+      }),
+      new Date('2026-05-09T12:01:00.000Z'),
+    );
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        marker: expect.stringContaining('untrusted-author') as string,
+        type: 'comment-blocked',
+      }),
+    ]);
+  });
+
+  it('treats the aggregate CI check as enough when advisory checks are still pending', () => {
+    const checks = summarizeChecks(
+      {
+        state: 'success',
+        statuses: [{}],
+      },
+      [
+        {
+          conclusion: 'success',
+          name: 'ci',
+          status: 'completed',
+        },
+        {
+          conclusion: null,
+          name: 'Cursor Bugbot',
+          status: 'in_progress',
+        },
+      ],
+    );
+
+    expect(checks).toEqual({
+      state: 'pass',
+      summary: 'CI / ci and commit status evidence passed',
+    });
+  });
+
+  it('allows GitHub Actions only repositories when CI passes and there are no legacy commit statuses', () => {
+    const checks = summarizeChecks(
+      {
+        state: 'pending',
+        statuses: [],
+      },
+      [
+        {
+          conclusion: 'success',
+          name: 'ci',
+          status: 'completed',
+        },
+      ],
+    );
+
+    expect(checks).toEqual({
+      state: 'pass',
+      summary: 'CI / ci and commit status evidence passed',
+    });
+  });
+
+  it('keeps merge pending until the aggregate CI check is present', () => {
+    const checks = summarizeChecks(
+      {
+        state: 'success',
+        statuses: [{}],
+      },
+      [
+        {
+          conclusion: 'success',
+          name: 'Vercel',
+          status: 'completed',
+        },
+      ],
+    );
+
+    expect(checks).toEqual({
+      state: 'pending',
+      summary: 'CI / ci check run not found',
+    });
+  });
+});
+
+function baseState(overrides: Partial<PullRequestFastTrackState> = {}): PullRequestFastTrackState {
+  return {
+    author: 'author',
+    authorAssociation: 'MEMBER',
+    body: `- [x] ${fastTrackCheckboxLabel}`,
+    checks: {
+      state: 'pass',
+      summary: 'ci passed',
+    },
+    comments: [],
+    draft: false,
+    headSha,
+    number: 1,
+    reviewWindowStartedAt: createdAt,
+    reviews: [],
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## What

Adds an opt-in TPR fast-track timer to the PR template and a scheduled GitHub Actions workflow that can:

- comment `@codex review` after 1 hour without a trusted non-author review on the current head commit;
- after 2 hours, enable GitHub auto-merge only when the aggregate `CI / ci` check passes, commit statuses are not pending/failing, no trusted reviewer has an uncleared changes-requested review, and at least one trusted non-author approval exists for the current head commit.

## Why

Small, reversible TPRs should not sit idle when the intended path is bounded review followed by merge. This keeps the path cheap without faking approval, treating comments as approvals, waiting forever on advisory review-bot checks, or bypassing branch protection.

## Type

- `chore` — maintenance (deps, CI, cleanup)

## Changes

- Added a `TPR fast-track` opt-in checkbox to the PR template.
- Added `.github/workflows/tpr-fast-track.yml`, scheduled every 15 minutes and manually dispatchable for a single PR.
- Added `scripts/tpr-fast-track.ts` to plan review requests, blocked-state comments, and GitHub auto-merge enablement.
- Added planner/check-gate tests for opt-in detection, 1-hour review request, 2-hour merge gating, change-request blocking, trusted-author gating, duplicate-comment suppression, aggregate CI gating, pending advisory checks, dismissed reviews, GitHub Actions-only status behavior, current-head approval, stale approval rejection, untrusted reviewer rejection, and per-head timer markers.
- Addressed bot/subagent review findings: dismissed latest reviews no longer count as active signals, scheduled runs isolate per-PR processing errors, check runs are paginated, merge markers are written only after auto-merge succeeds, scheduled concurrency uses a stable key, current-head approvals are required, comments do not authorize merge, requested changes remain blocking until approval, direct squash fallback was removed, and workflow `contents` permission is read-only.

## Validation

- `bunx rstest run tests/tpr-fast-track.test.ts` passes locally: 16 tests passed.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tpr-fast-track.yml"); puts "yaml ok"'` prints `yaml ok`.
- `bun run check` passes locally.
- `bun run lint` passes locally: 0 lint errors, 0 type errors, 0 warnings.
- `bun run check:boundaries` passes locally: `Boundary check passed.`
- `bun run test` passes locally: 36 test files, 282 tests passed.
- PR CI after the previous push passed on GitHub; fresh CI is expected after this review-fix force-push.
- No new warnings introduced beyond existing runtime deprecation notices during full tests.
- `bun run build` succeeds (if runtime/server code touched): not run; no runtime/server code touched.
- `bun run docs:build` succeeds (if docs touched): covered by PR CI build job.
- End-to-end verification command + output excerpt: `bun run test` -> `status: "pass"`, `tests: 282`, `failedTests: 0`.
- Caveats or blocker: live `@codex review`, GitHub auto-merge, and branch-protection interaction can only be proven after this workflow exists on the default branch. The script intentionally blocks merge without a trusted non-author current-head approval, aggregate CI pass, trusted PR author association, and no uncleared requested changes.

## TPR fast-track

- [ ] Enable TPR review/merge timer

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | fpf-product-checks-and-role-feedback follow-up |
| Prompt  | Add opt-in TPR review/merge timer |
