### PR TITLE
fix: use Node transport for Vercel MCP

### DIFF
--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -1,7 +1,9 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import type { createMcpTools, FpfMcpTool, FpfMcpToolMap } from './tools.js';
 
@@ -29,6 +31,21 @@ export class FpfMcpServer {
     const server = this.createSdkServer();
     await server.connect(transport);
     return transport.handleRequest(request);
+  }
+
+  async handleNodeStreamableHttp(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    const transport = new StreamableHTTPServerTransport({
+      enableJsonResponse: true,
+    });
+    // Vercel functions expose Node request/response objects. Use the SDK's
+    // Node adapter there so streaming headers and request bodies are flushed
+    // through the platform's native path instead of a manual Web conversion.
+    const server = this.createSdkServer();
+    await server.connect(transport);
+    await transport.handleRequest(request, response);
   }
 
   createSdkServer(): McpServer {

--- a/src/entrypoints/vercel-function.ts
+++ b/src/entrypoints/vercel-function.ts
@@ -6,6 +6,7 @@ import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
 import {
   createHostedComposition,
   createHostedErrorLogger,
+  HOSTED_MCP_ROUTE,
 } from '../composition/hosted.js';
 
 type HostedComposition = ReturnType<typeof createHostedComposition>;
@@ -17,7 +18,12 @@ export default async function handler(
   response: ServerResponse,
 ): Promise<void> {
   try {
-    const { app } = await getHostedComposition();
+    const { app, mcpServer } = await getHostedComposition();
+    if (isMcpRoute(request)) {
+      await mcpServer.handleNodeStreamableHttp(request, response);
+      return;
+    }
+
     const webRequest = toWebRequest(request);
     const webResponse = await app.fetch(webRequest);
     await sendWebResponse(response, webResponse);
@@ -41,6 +47,11 @@ function getHostedComposition(): Promise<HostedComposition> {
       throw error;
     });
   return hostedCompositionPromise;
+}
+
+function isMcpRoute(request: IncomingMessage): boolean {
+  const url = new URL(request.url ?? '/', 'https://localhost');
+  return url.pathname === HOSTED_MCP_ROUTE;
 }
 
 function toWebRequest(request: IncomingMessage): Request {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
+import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import readline from 'node:readline';
@@ -8,6 +9,7 @@ import { afterEach, describe, expect, it } from '@rstest/core';
 
 import { createHostedComposition } from '../src/composition/hosted.js';
 import { DEFAULT_SOURCE_PATH } from '../src/core/constants.js';
+import vercelHandler from '../src/entrypoints/vercel-function.js';
 
 interface JsonRpcResponse {
   jsonrpc: '2.0';
@@ -394,6 +396,70 @@ describe('direct MCP server', () => {
     } as NodeJS.ProcessEnv);
     const response = await app.request('/');
     expect(response.status).toBe(200);
+  });
+
+  it('initializes hosted MCP through the Vercel Node adapter', async () => {
+    const server = createServer((request, response) => {
+      vercelHandler(request, response).catch((error: unknown) => {
+        response.statusCode = 500;
+        response.end(error instanceof Error ? error.message : String(error));
+      });
+    });
+
+    await new Promise<void>((resolveListen) => {
+      server.listen(0, '127.0.0.1', resolveListen);
+    });
+
+    try {
+      const address = server.address();
+      expect(typeof address).toBe('object');
+      expect(address).not.toBeNull();
+      const port = (address as { port: number }).port;
+      const response = await fetch(
+        `http://127.0.0.1:${port}/api/mcp/fpf_memory/mcp`,
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream',
+            'MCP-Protocol-Version': '2025-06-18',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+              protocolVersion: '2025-06-18',
+              capabilities: {},
+              clientInfo: {
+                name: 'rstest-vercel-node-adapter',
+                version: '1.0.0',
+              },
+            },
+          }),
+          signal: AbortSignal.timeout(5_000),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('content-type')).toContain('application/json');
+      const payload = await response.json() as JsonRpcResponse;
+      expect(payload.error).toBeUndefined();
+      expect(payload.result?.serverInfo).toEqual({
+        name: 'fpf_memory',
+        version: '1.0.0',
+      });
+    } finally {
+      await new Promise<void>((resolveClose, rejectClose) => {
+        server.close((error) => {
+          if (error) {
+            rejectClose(error);
+            return;
+          }
+          resolveClose();
+        });
+      });
+    }
   });
 });
 


### PR DESCRIPTION
## What

- Route the Vercel MCP endpoint through the MCP SDK Node streamable-HTTP transport instead of manually converting Node requests/responses through the Web transport.
- Keep the Hono/Web path for the hosted home pages.
- Add a regression that initializes MCP through a real Node `IncomingMessage` / `ServerResponse` server path.

## Why

Discussion #80 has fresh production evidence that the canonical Vercel-origin MCP route times out before initialize even though the hosted home page, main CI, Pages, and Vercel deployment are green. The failure boundary is the serverless MCP HTTP adapter path, not the FPF index freshness path.

## Validation

- `bunx rstest run tests/mcp-server.test.ts` -> 6 tests passed
- `bun run test` -> 35 files / 267 tests passed
- `bun run check` -> passed
- `bun run lint` -> 0 lint errors, 0 type errors, 0 warnings
- `bun run check:boundaries` -> passed
- `bun run validate:published` -> source hash `sha256:4bd579472278104ec472ad32f473b51a58d43e6066cc605f7693badcd2ca691d`
- `bun run vercel:origin:build` -> Vercel function bundle 66.15 MB, PASS within budget
- `git diff --check` -> passed

E2E terminal recording: `/Users/stas-studio/.codex/worktrees/10ad/fpf-memory/.runtime/e2e-recordings/2026-05-09T13-16-30-vercel-node-mcp/terminal.txt`
E2E report: `/Users/stas-studio/.codex/worktrees/10ad/fpf-memory/.runtime/e2e-recordings/2026-05-09T13-16-30-vercel-node-mcp/report.md`

## Caveats

- Production hosted MCP still times out until this PR is merged and the Vercel production deployment completes.
- Local `git fetch origin main` in the shared worktree is blocked by sandbox permissions on the linked worktree `FETCH_HEAD`; live GitHub API evidence shows current `main` is `4dad439e17dd6049448747d19bb867c22990076e`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the hosted MCP endpoint is handled in the Vercel function by switching to the SDK’s Node transport, which could affect streaming/headers and request handling in production. Surface area is limited to the MCP route and is covered by a new integration-style test.
> 
> **Overview**
> Fixes Vercel-hosted MCP requests by **routing the MCP endpoint through the MCP SDK’s Node `StreamableHTTPServerTransport`** instead of converting Node `IncomingMessage`/`ServerResponse` into Web `Request`/`Response`.
> 
> The Vercel function now detects `HOSTED_MCP_ROUTE` and delegates directly to `mcpServer.handleNodeStreamableHttp`, while keeping the existing Web/Hono fetch path for non-MCP routes. Adds a regression test that spins up a real Node HTTP server using the Vercel handler and validates an `initialize` JSON-RPC call succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ec07240237ae871e7c316a8ec067d2872ec81e7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->