### PR TITLE
docs: add FPF automation playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 > **📖 Live reference:** [venikman.github.io/fpf-memory](https://venikman.github.io/fpf-memory/) — searchable pattern catalog, routes, and preface. Type an ID like `A.2` or `route:project-alignment` in the search box to jump in.
 >
 > **🤖 Working with this repo as an agent?** See [`AGENTS.md`](./AGENTS.md) for the MCP tool guide and workspace conventions.
+>
+> **🧭 Coordinating repo automation?** See the [Automation Playbook](https://venikman.github.io/fpf-memory/automation-playbook) for role boundaries, access rules, merge authority, and draft-only publishing packets.
 
 ## What is this?
 

--- a/docs/automation-playbook.md
+++ b/docs/automation-playbook.md
@@ -1,0 +1,195 @@
+---
+title: "Automation Playbook"
+description: "Operating model for fpf-memory automation roles, evidence, access, and publishing drafts."
+outline: deep
+---
+
+# Automation Playbook
+
+Use this page when you want agentic help around fpf-memory without collapsing every job into one agent.
+
+## What this page is
+
+This is the public operating model for fpf-memory automation. It explains the roles, what each role may do, what evidence it should produce, and where user approval is required.
+
+It is not a list of private automation records, thread IDs, local paths, account credentials, or personal scheduling details.
+
+## Methodology
+
+Keep role, capability, promise, work, and evidence separate.
+
+- Role: what stance the automation takes.
+- Capability: what the automation can technically inspect or change.
+- Promise: what the automation is expected to provide.
+- Work: what an actual run did.
+- Evidence: URLs, commands, PRs, discussions, checks, screenshots, or logs that prove the work.
+
+The main safety rule is simple: discovery roles stay read-only, implementation roles make PRs, and merge or publishing authority stays explicit.
+
+## Role map
+
+| Role | Promise | May do | Must not do by default | Output artifact |
+| --- | --- | --- | --- | --- |
+| Dogfood/product scout | Act as one product user role and report friction. | Try docs, MCP, CLI, evaluator, deploy evidence, and onboarding flows. | Edit repo files, create PRs, open issues, comment, merge, or post externally. | Role/job report with evidence, friction, severity, and handoffs. |
+| Discussion steward | Keep GitHub Discussions actionable. | Inspect discussions, issues, and PRs; dedupe signals; maintain a Top 3 work list. | Implement fixes or create noisy new threads by default. | Discussion change report and issue-conversion recommendation. |
+| Implementation PR agent | Turn one ready item into a bounded PR. | Edit code/docs, validate, open or update one PR. | Self-merge or perform broad product scouting. | PR with source links, validation output, and residual risk. |
+| PR review and merge captain | Keep PRs moving with independent judgement. | Review PRs, check CI/reviews/mergeability, comment on blockers, merge when policy is met. | Implement fixes or silently wait on blocked PRs. | Merge/no-merge decision with evidence. |
+| Manager brief | Compress automation state for the user. | Read automation memory, repo state, PRs, discussions, docs, and hosted MCP health. | Replace the specialist roles or make external commitments. | Product readiness, changed, validated, Top 3 next actions, decisions needed. |
+| Technical architect | Make periodic system-level judgement. | Review MCP server, index/runtime, docs/adoption UX, CLI, evaluator, packaging/deploy, CI, and automation health. | Create implementation work unless explicitly asked. | Architecture state, risks, recommendations, handoffs, and stop/replan triggers. |
+| Growth and publishing scout | Turn validated evidence into draft public material. | Draft Medium/Substack posts, short social posts, README/forum blurbs, and outreach notes. | Publish, email, DM, post, or log into external accounts without explicit approval. | Share packet with audience, proof points, caveats, links, and call to action. |
+
+## Work flow
+
+```txt
+Dogfood/product scout
+  -> friction evidence
+Discussion steward
+  -> ready work item
+Implementation PR agent
+  -> validated PR
+PR review and merge captain
+  -> merge or blocker
+Manager brief
+
+Technical architect
+  -> system risks and decisions
+Manager brief
+
+Dogfood/product scout
+  -> validated proof points
+Growth and publishing scout
+  -> draft share packet
+Manager brief
+```
+
+## Access and authority
+
+| Capability | Needed by | Default |
+| --- | --- | --- |
+| Local repo and public product read access | All roles | Allowed for evidence gathering. |
+| GitHub read access | All roles that inspect discussions, issues, PRs, and CI | Allowed for evidence gathering. |
+| GitHub write access | Implementation PR agent and PR review/merge captain | Allowed only within their role boundaries. |
+| External publishing accounts | Growth and publishing scout | Draft-only unless the user explicitly approves a specific publish/send action. |
+| Secrets, billing, deploy settings, destructive actions | User or explicitly delegated operator | Prepare instructions; do not perform final actions by default. |
+
+For purchases, subscriptions, billing changes, account changes, or external publishing, the automation may prepare the flow and draft the copy. The user performs or explicitly approves the final action.
+
+## Merge policy
+
+Implementation and merge authority are separate.
+
+A PR may be merged by the review/merge role only when:
+
+- required CI and branch-protection checks are green;
+- the PR is not draft and is mergeable;
+- there is no unresolved blocking review or requested change on the current head;
+- validation evidence is sufficient for the changed surface;
+- the PR has independent approval or an approved fast-track condition for the current head.
+
+If any condition is missing, the role should report the exact blocker rather than waiting silently.
+
+## Publishing and outreach packets
+
+Off-GitHub publishing is prepared as a draft packet. The packet should include:
+
+- channel and audience;
+- promise being made;
+- product ability that supports the promise;
+- observed performance or evidence;
+- caveat that should stay visible;
+- canonical links;
+- suggested call to action;
+- approval needed before sending or publishing.
+
+### Medium or Substack draft packet
+
+```txt
+Channel: Medium or Substack
+Audience: agent-tool builders and technical leads who keep pasting large framework specs into coding chats
+
+Working title:
+Stop pasting the whole spec: using fpf-memory as bounded FPF context for agents
+
+Hook:
+FPF work needs exact IDs, routes, and evidence, but a whole-spec dump is the wrong interface for daily agent work.
+
+Claim:
+fpf-memory turns the published FPF spec into deterministic lookup surfaces: MCP tools, CLI queries, and generated docs.
+
+Proof points:
+- compiler-backed vectorless index;
+- hosted MCP endpoint;
+- generated docs and work packets;
+- deterministic retrieval first, optional synthesis second.
+
+Caveat:
+Do not claim broad adoption or benchmark superiority unless current evidence supports it.
+
+Call to action:
+Try one bounded FPF query through MCP before putting the whole specification into a prompt.
+```
+
+### Short social post packet
+
+```txt
+Channel: LinkedIn, X, Mastodon, or another short-form surface
+
+Draft:
+Built a small MCP-oriented runtime for FPF.
+
+fpf-memory compiles the published FPF spec into deterministic lookup surfaces so agents can ask for exact routes, IDs, docs, and bounded context instead of loading the whole spec.
+
+Useful for PR review, project alignment, spec writing, and adoption UX checks.
+
+Docs: https://venikman.github.io/fpf-memory/
+Connect MCP: https://venikman.github.io/fpf-memory/connect-mcp
+
+Caveat: deterministic retrieval first; synthesis is optional.
+```
+
+### One-to-one outreach packet
+
+```txt
+Recipient type:
+Someone building MCP tools, coding agents, or structured reasoning workflows.
+
+Subject:
+Short FPF/MCP artifact I wanted to share
+
+Draft:
+Hi <name>,
+
+I have a compact artifact that may be relevant to your agent/MCP work.
+
+fpf-memory is a compiler-backed runtime for the published First Principles Framework spec. The basic idea is to avoid pasting the whole framework into agents. Instead, the agent can retrieve exact FPF routes, IDs, generated docs, and bounded context through MCP or CLI.
+
+The current material:
+- Website: https://venikman.github.io/fpf-memory/
+- Connect MCP: https://venikman.github.io/fpf-memory/connect-mcp
+- Hosted endpoint: https://fpf-memory-mcp-vercel-origin.vercel.app/api/mcp/fpf_memory/mcp
+
+The claim I am comfortable making right now is narrow: it is useful for bounded FPF lookup and agent workflows that need evidence-backed framework context. I am not claiming broad adoption or benchmark superiority yet.
+
+If you are open to it, I would value a quick critique of the MCP onboarding path.
+```
+
+## Approval checklist
+
+Before anything leaves GitHub or a local draft:
+
+- The channel is named.
+- The audience is named.
+- The claim is backed by current evidence.
+- The caveat is visible.
+- The user has approved the exact copy or the exact destination.
+- No private repo, account, credential, thread, or local-machine detail is included.
+
+## Done condition
+
+The automation system is healthy when each role can answer:
+
+- what it inspected;
+- what it changed, if anything;
+- what evidence supports the result;
+- what it cannot do without approval;
+- who owns the next action.

--- a/docs/automation-playbook.md
+++ b/docs/automation-playbook.md
@@ -33,12 +33,12 @@ The main safety rule is simple: discovery roles stay read-only, implementation r
 | Dogfood/product scout | Act as one product user role and report friction. | Try docs, MCP, CLI, evaluator, deploy evidence, and onboarding flows. | Edit repo files, create PRs, open issues, comment, merge, or post externally. | Role/job report with evidence, friction, severity, and handoffs. |
 | Discussion steward | Keep GitHub Discussions actionable. | Inspect discussions, issues, and PRs; dedupe signals; maintain a Top 3 work list. | Implement fixes or create noisy new threads by default. | Discussion change report and issue-conversion recommendation. |
 | Implementation PR agent | Turn one ready item into a bounded PR. | Edit code/docs, validate, open or update one PR. | Self-merge or perform broad product scouting. | PR with source links, validation output, and residual risk. |
-| PR review and merge captain | Keep PRs moving with independent judgement. | Review PRs, check CI/reviews/mergeability, comment on blockers, merge when policy is met. | Implement fixes or silently wait on blocked PRs. | Merge/no-merge decision with evidence. |
+| PR review and merge captain | Keep PRs moving with independent judgment. | Review PRs, check CI/reviews/mergeability, comment on blockers, merge when policy is met. | Implement fixes or silently wait on blocked PRs. | Merge/no-merge decision with evidence. |
 | Manager brief | Compress automation state for the user. | Read automation memory, repo state, PRs, discussions, docs, and hosted MCP health. | Replace the specialist roles or make external commitments. | Product readiness, changed, validated, Top 3 next actions, decisions needed. |
-| Technical architect | Make periodic system-level judgement. | Review MCP server, index/runtime, docs/adoption UX, CLI, evaluator, packaging/deploy, CI, and automation health. | Create implementation work unless explicitly asked. | Architecture state, risks, recommendations, handoffs, and stop/replan triggers. |
+| Technical architect | Make periodic system-level judgment. | Review MCP server, index/runtime, docs/adoption UX, CLI, evaluator, packaging/deploy, CI, and automation health. | Create implementation work unless explicitly asked. | Architecture state, risks, recommendations, handoffs, and stop/replan triggers. |
 | Growth and publishing scout | Turn validated evidence into draft public material. | Draft Medium/Substack posts, short social posts, README/forum blurbs, and outreach notes. | Publish, email, DM, post, or log into external accounts without explicit approval. | Share packet with audience, proof points, caveats, links, and call to action. |
 
-## Work flow
+## Workflow
 
 ```txt
 Dogfood/product scout

--- a/docs/work-packets.md
+++ b/docs/work-packets.md
@@ -135,6 +135,7 @@ Goal: let an agent use FPF without loading the whole FPF.
 Use:
 
 - [MCP recipes](/mcp-recipes)
+- [Automation Playbook](/automation-playbook) when the work needs role boundaries, access rules, merge authority, or draft-only publishing packets
 - `route:project-alignment` via [Routes](/generated/routes/index)
 - [E.8 Authoring conventions](/generated/patterns/E.8)
 - [E.19 — Pattern Quality Gates: Review & Refresh Profiles](/generated/patterns/E.19) — use as the pattern change-record gate
@@ -142,6 +143,7 @@ Use:
 Packet:
 
 - Ask the agent to name the work type first.
+- Assign the work to a role before giving it write, merge, or publishing authority.
 - Retrieve the route or 3-8 exact IDs through MCP.
 - Ask for assumptions, model, options, pick, tests, risks, and next move.
 - Require citations to FPF IDs when the framework changes a decision.

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -240,6 +240,7 @@ window.addEventListener('transitionend',fixSidebarInert);
         items: [
           { text: 'Recipes', link: '/mcp-recipes' },
           { text: 'Connect to clients', link: '/connect-mcp' },
+          { text: 'Automation playbook', link: '/automation-playbook' },
           { text: 'Vercel hosting', link: '/vercel-hosting' },
         ],
       },

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -240,7 +240,7 @@ window.addEventListener('transitionend',fixSidebarInert);
         items: [
           { text: 'Recipes', link: '/mcp-recipes' },
           { text: 'Connect to clients', link: '/connect-mcp' },
-          { text: 'Automation playbook', link: '/automation-playbook' },
+          { text: 'Automation Playbook', link: '/automation-playbook' },
           { text: 'Vercel hosting', link: '/vercel-hosting' },
         ],
       },
@@ -259,8 +259,9 @@ window.addEventListener('transitionend',fixSidebarInert);
       //     full pattern tree.
       //   - `/generated/routes/...` get the routes tree.
       //   - The root `/` and authored pages (start-here, work-packets,
-      //     mcp-recipes, connect-mcp, vercel-hosting) get NO sidebar so the
-      //     orientation surface stays focused on its own task-first cards.
+      //     mcp-recipes, connect-mcp, automation-playbook, vercel-hosting)
+      //     get NO sidebar so the orientation surface stays focused on its
+      //     own task-first cards.
       '/patterns': [
         {
           text: 'Patterns',


### PR DESCRIPTION
## What

Adds a public Automation Playbook for the fpf-memory automation operating model.

## Why

The automation reset created clear roles, but the repo did not have a GitHub-facing guide for role boundaries, access authority, merge responsibility, or draft-only publishing packets.

## Changes

- Add `docs/automation-playbook.md` with role map, work flow, access rules, merge policy, publishing/outreach packet examples, approval checklist, and done conditions.
- Link the playbook from the MCP nav group in `rspress.config.ts`.
- Add pointers from `README.md` and the Agent workflow use packet in `docs/work-packets.md`.

## Validation

- `bun install --frozen-lockfile`
- `bun run docs:build`
- `bun run test tests/docs-projection.test.ts` — 9 passed
- `bun run check`
- `bun run lint`
- `git diff --check`

## Caveat

Docs-only. This PR does not commit Codex automation config, change schedules, grant external account access, or post/send/publish anything off GitHub.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, docs-only changes: adds a new documentation page and links to it from existing docs/navigation with no runtime or data-handling impact.
> 
> **Overview**
> Adds a new **public `Automation Playbook`** doc that defines automation roles, access/authority boundaries, merge policy, and *draft-only* publishing/outreach packet templates.
> 
> Surfaces the playbook by linking it from the README, the `Work Packets` agent workflow section, and the docs site `MCP` navigation in `rspress.config.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6f62819adada406d3c3fdbcfe125ade22fb7eba. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->