### PR TITLE
fix(hosted): route Vercel freshness status

### DIFF
--- a/src/build/vercel-origin-build.ts
+++ b/src/build/vercel-origin-build.ts
@@ -16,6 +16,12 @@ export interface BuildVercelOriginOptions {
 
 const OUTPUT_DIR = '.vercel/output';
 const FUNCTION_DIR = `${OUTPUT_DIR}/functions/index.func`;
+const HOSTED_FPF_STATUS_ROUTE = '/api/fpf/status';
+
+export interface VercelOriginOutputConfig {
+  version: 3;
+  routes: Array<{ src: string; dest: string }>;
+}
 
 export async function buildVercelOrigin(
   options: BuildVercelOriginOptions = {},
@@ -55,14 +61,19 @@ async function bundleFunction(rootDir: string, functionDir: string): Promise<voi
 
 async function writeVercelConfig(outputDir: string): Promise<void> {
   await mkdir(outputDir, { recursive: true });
-  await writeJson(resolve(outputDir, 'config.json'), {
+  await writeJson(resolve(outputDir, 'config.json'), createVercelOriginOutputConfig());
+}
+
+export function createVercelOriginOutputConfig(): VercelOriginOutputConfig {
+  return {
     version: 3,
     routes: [
       { src: '^/$', dest: '/index' },
       { src: '^/connect-mcp$', dest: '/index' },
+      { src: `^${HOSTED_FPF_STATUS_ROUTE}$`, dest: '/index' },
       { src: '^/api/mcp/fpf_memory/mcp$', dest: '/index' },
     ],
-  });
+  };
 }
 
 async function writeFunctionConfig(functionDir: string): Promise<void> {

--- a/src/build/vercel-origin-build.ts
+++ b/src/build/vercel-origin-build.ts
@@ -8,6 +8,11 @@ import {
   HOSTED_STAGED_MANIFEST_PATH,
   HOSTED_STAGED_SOURCE_PATH,
 } from '../core/constants.js';
+import {
+  HOSTED_FPF_STATUS_ROUTE,
+  HOSTED_HOME_ROUTES,
+  HOSTED_MCP_ROUTE,
+} from '../composition/hosted.js';
 
 export interface BuildVercelOriginOptions {
   rootDir?: string;
@@ -16,11 +21,19 @@ export interface BuildVercelOriginOptions {
 
 const OUTPUT_DIR = '.vercel/output';
 const FUNCTION_DIR = `${OUTPUT_DIR}/functions/index.func`;
-const HOSTED_FPF_STATUS_ROUTE = '/api/fpf/status';
 
 export interface VercelOriginOutputConfig {
   version: 3;
-  routes: Array<{ src: string; dest: string }>;
+  routes: Array<{
+    src: string;
+    dest?: string;
+    headers?: Record<string, string>;
+    methods?: string[];
+    status?: number;
+    continue?: boolean;
+    check?: boolean;
+    caseSensitive?: boolean;
+  }>;
 }
 
 export async function buildVercelOrigin(
@@ -65,13 +78,13 @@ async function writeVercelConfig(outputDir: string): Promise<void> {
 }
 
 export function createVercelOriginOutputConfig(): VercelOriginOutputConfig {
+  const dest = '/index';
   return {
     version: 3,
     routes: [
-      { src: '^/$', dest: '/index' },
-      { src: '^/connect-mcp$', dest: '/index' },
-      { src: `^${HOSTED_FPF_STATUS_ROUTE}$`, dest: '/index' },
-      { src: '^/api/mcp/fpf_memory/mcp$', dest: '/index' },
+      ...HOSTED_HOME_ROUTES.map((route) => ({ src: `^${route}$`, dest })),
+      { src: `^${HOSTED_FPF_STATUS_ROUTE}$`, dest },
+      { src: `^${HOSTED_MCP_ROUTE}$`, dest },
     ],
   };
 }

--- a/tests/vercel-origin-config.test.ts
+++ b/tests/vercel-origin-config.test.ts
@@ -3,6 +3,9 @@ import { resolve } from 'node:path';
 
 import { describe, expect, it } from '@rstest/core';
 
+import { HOSTED_FPF_STATUS_ROUTE } from '../src/adapters/hosted/status-page.js';
+import { createVercelOriginOutputConfig } from '../src/build/vercel-origin-build.js';
+
 interface VercelConfig {
   buildCommand?: string | null;
 }
@@ -32,5 +35,14 @@ describe('Vercel MCP origin config', () => {
     expect(
       Object.keys(packageJson.scripts).some((script) => script.startsWith(retiredScriptPrefix)),
     ).toBe(false);
+  });
+
+  it('routes the hosted freshness status endpoint through the Vercel origin function', () => {
+    const config = createVercelOriginOutputConfig();
+
+    expect(config.routes).toContainEqual({
+      src: `^${HOSTED_FPF_STATUS_ROUTE}$`,
+      dest: '/index',
+    });
   });
 });


### PR DESCRIPTION
## What

Routes `/api/fpf/status` through the generated Vercel Build Output API function config.

## Why

The hosted Hono app already serves the FPF freshness status endpoint, but the Vercel output route table omitted it, so production returned `404` while `/` and the MCP endpoint worked.

## Type

- `fix` — bug fix

## Changes

- Adds `/api/fpf/status` to the generated `.vercel/output/config.json` route table.
- Adds a regression test around the Vercel origin route config.

## Validation

- `bunx rstest run tests/vercel-origin-config.test.ts tests/hosted-status.test.ts` passes locally: 2 files, 6 tests.
- `bun run check` passes locally.
- `bun run lint` passes locally: 0 lint errors, 0 type errors, 0 warnings.
- `bun run vercel:origin:build` passes locally.
- End-to-end verification command + output excerpt: `bun run vercel:origin:build` wrote `^/api/fpf/status$` into `.vercel/output/config.json` and reported `PASS: bundle is within the configured budget.`
- Caveats or blocker: production Vercel will keep returning `404` until this PR is merged and deployed.

## TPR fast-track

- [ ] Enable TPR review/merge timer

Use this only for small, reversible PRs from trusted maintainers or collaborators. The timer does not fake approval or bypass branch protection:

- after 1 hour without a non-author review signal, automation comments `@codex review`;
- after 2 hours, automation enables auto-merge only when checks pass, no trusted reviewer requested changes, and at least one trusted non-author approval exists for the current head commit.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | local desktop |
| Prompt  | Okay, make the PR and also fix it. |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single Vercel route entry and a small regression test, with no changes to runtime request handling beyond routing the existing endpoint to the function.
> 
> **Overview**
> Fixes production 404s for the hosted freshness status endpoint by adding `^/api/fpf/status$` to the generated Vercel Build Output `config.json` routes so it is served by the origin function.
> 
> Refactors config generation into an exported `createVercelOriginOutputConfig()` (with a typed `VercelOriginOutputConfig`) and adds a regression test asserting the status route is included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb556d359edddd245eb26c60caae91f26591be8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->