### PR TITLE
docs: apply doorway site redesign

### DIFF
--- a/src/adapters/hosted/home-page.ts
+++ b/src/adapters/hosted/home-page.ts
@@ -116,15 +116,22 @@ export function renderHostedHomePage(): string {
     <style>
       :root {
         color-scheme: light;
-        --bg: #f7f8fa;
-        --panel: #ffffff;
-        --text: #1c2430;
-        --muted: #576474;
-        --line: #d9dee7;
-        --accent: #0b6bcb;
-        --accent-strong: #084f97;
-        --code-bg: #111827;
-        --code-text: #f8fafc;
+        --bg: #f6efe5;
+        --panel: #fffaf2;
+        --panel-soft: #f2eadf;
+        --text: #20241e;
+        --muted: #62685e;
+        --faint: #7a766b;
+        --line: rgb(37 43 36 / 18%);
+        --line-strong: #252b24;
+        --accent: #a23b2e;
+        --green: #28513f;
+        --gold: #c2923a;
+        --code-bg: #12160f;
+        --code-text: #d7b36a;
+        --font-display: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        --font-serif: Georgia, "Times New Roman", serif;
+        --font-mono: "SF Mono", ui-monospace, Menlo, Monaco, Consolas, monospace;
       }
 
       * {
@@ -135,9 +142,10 @@ export function renderHostedHomePage(): string {
         margin: 0;
         background: var(--bg);
         color: var(--text);
-        font-family:
-          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-family: var(--font-display);
         line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
       }
 
       a {
@@ -147,35 +155,49 @@ export function renderHostedHomePage(): string {
       }
 
       a:hover {
-        color: var(--accent-strong);
+        color: var(--green);
       }
 
       main {
-        width: min(1120px, calc(100% - 32px));
+        width: min(1180px, calc(100% - 40px));
         margin: 0 auto;
-        padding: 40px 0 56px;
+        padding: 46px 0 58px;
       }
 
       .hero {
         display: grid;
-        gap: 20px;
-        padding: 32px 0 28px;
+        grid-template-columns: minmax(0, 1fr) minmax(320px, 0.7fr);
+        min-height: 470px;
+        border: 1px solid var(--line-strong);
+        background: var(--panel);
+      }
+
+      .hero > * {
+        margin-left: clamp(30px, 5vw, 64px);
+        margin-right: clamp(30px, 5vw, 64px);
+      }
+
+      .hero .eyebrow {
+        align-self: end;
+        margin-top: clamp(30px, 5vw, 64px);
       }
 
       .eyebrow {
         margin: 0;
-        color: var(--accent-strong);
-        font-size: 0.78rem;
-        font-weight: 700;
+        color: var(--accent);
+        font-family: var(--font-mono);
+        font-size: 0.72rem;
+        font-weight: 600;
         letter-spacing: 0;
-        text-transform: uppercase;
       }
 
       h1 {
         margin: 0;
-        max-width: 820px;
-        font-size: clamp(2.25rem, 5vw, 4.5rem);
-        line-height: 1;
+        max-width: 10ch;
+        font-family: var(--font-serif);
+        font-size: clamp(4rem, 7vw, 7rem);
+        font-weight: 500;
+        line-height: 0.9;
         letter-spacing: 0;
       }
 
@@ -185,62 +207,77 @@ export function renderHostedHomePage(): string {
       }
 
       .lead {
-        max-width: 780px;
+        max-width: 44rem;
         margin: 0;
         color: var(--muted);
-        font-size: 1.1rem;
+        font-size: 1.05rem;
+        line-height: 1.55;
       }
 
       .endpoint {
         display: grid;
-        gap: 10px;
+        grid-column: 2;
+        grid-row: 1 / span 4;
+        align-content: center;
+        gap: 14px;
         padding: 18px;
-        border: 1px solid var(--line);
-        border-radius: 8px;
-        background: var(--panel);
+        border-left: 1px solid var(--line-strong);
+        border-radius: 0;
+        background: #12160f;
       }
 
       .endpoint span {
-        color: var(--muted);
-        font-size: 0.92rem;
-        font-weight: 650;
+        color: var(--accent);
+        font-family: var(--font-mono);
+        font-size: 0.72rem;
+        font-weight: 600;
       }
 
       code,
       pre {
-        font-family:
-          "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        font-family: var(--font-mono);
       }
 
       .endpoint code {
         overflow-wrap: anywhere;
-        color: var(--text);
-        font-size: 0.98rem;
+        padding: 18px;
+        border: 1px solid rgb(246 239 229 / 18%);
+        background: #0c100a;
+        color: var(--gold);
+        font-size: 0.82rem;
+        line-height: 1.55;
       }
 
       .quick {
         display: grid;
         grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: 14px;
-        margin: 8px 0 28px;
+        gap: 0;
+        margin: 0 0 34px;
+        border-right: 1px solid var(--line-strong);
+        border-bottom: 1px solid var(--line-strong);
+        border-left: 1px solid var(--line-strong);
       }
 
       .quick div,
       .client,
       .tools,
       .prompt {
-        border: 1px solid var(--line);
-        border-radius: 8px;
+        border: 0;
+        border-radius: 0;
         background: var(--panel);
       }
 
       .quick div {
-        padding: 16px;
+        padding: 20px;
+        border-right: 1px solid var(--line);
       }
 
       .quick strong {
         display: block;
         margin-bottom: 6px;
+        color: var(--green);
+        font-size: 1.25rem;
+        line-height: 1.08;
       }
 
       .quick p {
@@ -249,26 +286,38 @@ export function renderHostedHomePage(): string {
       }
 
       .section-title {
-        margin: 36px 0 12px;
-        font-size: 1.4rem;
+        margin: 42px 0 14px;
+        padding-top: 18px;
+        border-top: 1px solid var(--line-strong);
+        color: var(--text);
+        font-family: var(--font-serif);
+        font-size: clamp(2.4rem, 4vw, 4rem);
+        font-weight: 500;
+        line-height: 0.94;
       }
 
       .clients {
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 14px;
+        gap: 0;
+        border-top: 1px solid var(--line-strong);
+        border-left: 1px solid var(--line-strong);
       }
 
       .client {
         display: grid;
         gap: 12px;
         align-content: start;
-        padding: 18px;
+        padding: 22px;
+        border-right: 1px solid var(--line-strong);
+        border-bottom: 1px solid var(--line-strong);
       }
 
       .client h3 {
         margin: 0;
-        font-size: 1.02rem;
+        color: var(--green);
+        font-size: clamp(1.4rem, 2.2vw, 2rem);
+        line-height: 1;
       }
 
       .client p {
@@ -290,7 +339,8 @@ export function renderHostedHomePage(): string {
         margin: 0;
         padding: 14px;
         overflow-x: auto;
-        border-radius: 8px;
+        border: 1px solid rgb(246 239 229 / 18%);
+        border-radius: 0;
         background: var(--code-bg);
         color: var(--code-text);
         font-size: 0.86rem;
@@ -299,6 +349,7 @@ export function renderHostedHomePage(): string {
 
       .tools,
       .prompt {
+        border: 1px solid var(--line-strong);
         padding: 18px;
       }
 
@@ -323,6 +374,7 @@ export function renderHostedHomePage(): string {
       footer {
         margin-top: 34px;
         color: var(--muted);
+        font-family: var(--font-mono);
         font-size: 0.92rem;
       }
 
@@ -339,7 +391,32 @@ export function renderHostedHomePage(): string {
         }
 
         .hero {
-          padding-top: 20px;
+          grid-template-columns: 1fr;
+          min-height: auto;
+        }
+
+        .hero > * {
+          margin-left: 28px;
+          margin-right: 28px;
+        }
+
+        .endpoint {
+          grid-column: auto;
+          grid-row: auto;
+          margin: 28px 0 0;
+          border-top: 1px solid var(--line-strong);
+          border-left: 0;
+          border-radius: 0;
+        }
+
+        h1 {
+          font-size: 48px;
+          line-height: 0.94;
+        }
+
+        .quick div,
+        .client {
+          border-right: 0;
         }
       }
     </style>

--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -366,8 +366,9 @@ function buildPatternsAliasPage(snapshot: Snapshot): GeneratedDocPage {
 /**
  * The site root (`/`) is the orientation/welcome surface. First-time
  * visitors land here and choose a path; the full Pattern Catalog lives one
- * click away at `/patterns`. Rendered with Rspress's `pageType: home`
- * layout (hero + 4-up feature grid).
+ * click away at `/patterns`. Rendered as authored markdown + scoped CSS so
+ * the first screen can use the Doorway model instead of Rspress's stock home
+ * hero, whose layout centers against the docs column rather than the viewport.
  */
 function buildRootIndexPage(
   snapshot: Snapshot,
@@ -384,104 +385,120 @@ function buildRootIndexPage(
 
 function renderHomeMarkdown(
   snapshot: Snapshot,
-  // The manifest parameter is intentionally unused since rspress's
-  // home layout drops body markdown — provenance now renders via
-  // the inline shim reading <meta> tags. Kept on the signature so
-  // call sites in `buildDocsProjection` don't need to change shape.
-  _manifest?: PublicationManifestSummary,
+  manifest?: PublicationManifestSummary,
 ): string {
   const patternCount = Object.keys(snapshot.patternGraph.nodes).length;
+  const provenanceDetail = renderHomeProvenanceDetail(manifest);
+  const patternCountLabel = `${patternCount} generated pattern pages across the published parts.`;
 
-  const lines: string[] = [renderHomeFrontMatter(patternCount)];
-
-  // The "Published from" provenance line is injected client-side by the
-  // a11y shim in rspress.config.ts (PR #72 design review). We can't put
-  // it in this markdown body because rspress's `pageType: home` layout
-  // drops body content entirely — only the frontmatter (hero + features)
-  // renders. The shim reads `<meta name="fpf-source-hash">` etc. and
-  // injects a `.fpf-home-byline` element directly under the hero.
-  // The body markdown below is kept for non-home tooling that consumes
-  // the projection (search index, MCP, etc.) and harmless on the home
-  // page itself since the layout ignores it.
+  const lines: string[] = [
+    renderFrontMatter({
+      title: 'FPF Reference',
+      description: 'Compiler-backed reference for the latest published FPF, projected as a slim wiki.',
+      outline: false,
+    }),
+  ];
 
   lines.push(
     '',
-    '## Methodology',
+    '<div class="fpf-doorway-home" aria-label="FPF Reference homepage">',
+    '  <section class="fpf-doorway-hero" aria-labelledby="doorway-home-title">',
+    '    <div class="fpf-doorway-hero__copy">',
+    '      <p class="fpf-doorway-kicker">FPF Reference</p>',
+    '      <h1 id="doorway-home-title">The doorway, then the source.</h1>',
+    '      <p>Use the full First Principles Framework without loading the whole specification first. Start with the work, choose the smallest grounded surface, and open exact IDs only when wording matters.</p>',
+    '      <nav class="fpf-doorway-actions" aria-label="Primary site paths">',
+    '        <a class="fpf-doorway-button fpf-doorway-button--primary" href="/start-here">Start here</a>',
+    '        <a class="fpf-doorway-button" href="/patterns">Open the index</a>',
+    '        <a class="fpf-doorway-button" href="/connect-mcp">Connect MCP</a>',
+    '      </nav>',
+    '    </div>',
+    '    <aside class="fpf-doorway-principle" aria-label="Operating rule">',
+    '      <span>Operating rule</span>',
+    '      <strong>Smallest useful surface first.</strong>',
+    '      <p>Move from human orientation to route work, exact generated pages, and MCP retrieval only when the task needs precision.</p>',
+    '    </aside>',
+    '  </section>',
     '',
-    'Name the work first, choose the smallest matching route or packet, then open generated pattern pages only when exact wording matters. Keep the full FPF intact as the canonical source while retrieving only the slice needed for the task.',
+    '  <section class="fpf-doorway-surfaces" aria-label="Core reference surfaces">',
+    '    <a href="/generated/routes/index"><span>routes</span><strong>Choose the work before the pattern.</strong><em>Generated working paths for alignment, review, feedback, and boundary work.</em></a>',
+    `    <a href="/patterns"><span>index</span><strong>A curated shelf before the full catalog.</strong><em>${escapeHtml(patternCountLabel)}</em></a>`,
+    '    <a href="/connect-mcp"><span>mcp</span><strong>The utility desk for agents.</strong><em>Hosted endpoint, client setup, tool names, and first prompts.</em></a>',
+    '    <a href="/work-packets"><span>packets</span><strong>Task-sized operating surfaces.</strong><em>Review, product-role feedback, and adoption packets for repeated work.</em></a>',
+    '  </section>',
     '',
-    '## MCP endpoint',
+    '  <section class="fpf-doorway-routes" aria-labelledby="doorway-route-title">',
+    '    <div class="fpf-doorway-section-head">',
+    '      <p>Work lanes</p>',
+    '      <h2 id="doorway-route-title">Fast route selection for known work shapes.</h2>',
+    '    </div>',
+    '    <div class="fpf-doorway-route-grid">',
+    '      <a href="/generated/routes/route_project-alignment"><span>Alignment</span><strong>Set the shared operating frame.</strong><em>Context, roles, method, and first surface.</em></a>',
+    '      <a href="/generated/routes/route_writing-or-reviewing-patterns"><span>Review</span><strong>Make critique replayable.</strong><em>Findings tied to IDs, constraints, risks, and tests.</em></a>',
+    '      <a href="/work-packets#product-role-feedback-packet"><span>Feedback</span><strong>Translate role friction into an artifact.</strong><em>Observed job, failed expectation, and proposed improvement.</em></a>',
+    '      <a href="/generated/routes/route_boundary-burden"><span>Boundary</span><strong>Separate claims from obligations.</strong><em>Promises, duties, evidence needs, and handoff risks.</em></a>',
+    '    </div>',
+    '  </section>',
     '',
-    'Point an MCP-aware client at the hosted endpoint to retrieve compact grounded slices on demand. See [Connect MCP](/connect-mcp) for client-by-client setup, and [MCP recipes](/mcp-recipes) for ready-made retrieval patterns.',
+    '  <section class="fpf-doorway-reference" aria-labelledby="doorway-reference-title">',
+    '    <div class="fpf-doorway-section-head">',
+    '      <p>Reference access</p>',
+    '      <h2 id="doorway-reference-title">The full framework stays close, but not first.</h2>',
+    '    </div>',
+    '    <div class="fpf-doorway-reference-grid">',
+    '      <a href="/generated/patterns/E.14"><span>E.14</span><strong>Human-Centric Working-Model</strong></a>',
+    '      <a href="/generated/patterns/E.8"><span>E.8</span><strong>Authoring Conventions</strong></a>',
+    '      <a href="/generated/patterns/E.10"><span>E.10</span><strong>LEX-BUNDLE</strong></a>',
+    '      <a href="/generated/patterns/F.17"><span>F.17</span><strong>Unified Term Sheet</strong></a>',
+    '      <a href="/generated/patterns/F.9"><span>F.9</span><strong>Alignment & Bridge</strong></a>',
+    '      <a href="/generated/patterns/E.19"><span>E.19</span><strong>Pattern Quality Gates</strong></a>',
+    '    </div>',
+    '  </section>',
     '',
-    '```text',
-    HOSTED_MCP_ENDPOINT,
-    '```',
+    '  <section class="fpf-doorway-mcp" aria-labelledby="doorway-mcp-title">',
+    '    <div>',
+    '      <p class="fpf-doorway-kicker">Agent path</p>',
+    '      <h2 id="doorway-mcp-title">Ask for a slice, not the whole spec.</h2>',
+    '      <p>Connect an MCP-aware client and retrieve compact, grounded context when the work needs FPF.</p>',
+    '    </div>',
+    '    <div class="fpf-doorway-endpoint">',
+    `      <code>${escapeHtml(HOSTED_MCP_ENDPOINT)}</code>`,
+    '      <nav aria-label="MCP links">',
+    '        <a href="/connect-mcp">Connect clients</a>',
+    '        <a href="/mcp-recipes">Use recipes</a>',
+    '      </nav>',
+    '    </div>',
+    '  </section>',
     '',
-    'Tool catalog and local-surface setup: [README on GitHub](https://github.com/venikman/fpf-memory#run-and-test-mcp).',
+    '  <section class="fpf-doorway-provenance" aria-label="Source and provenance promise">',
+    '    <p>Projection of the latest published FPF.</p>',
+    '    <strong>Human-readable first, generated-reference exact, source status visible.</strong>',
+    `    <span>${escapeHtml(provenanceDetail)}</span>`,
+    '  </section>',
+    '</div>',
   );
 
   return `${lines.join('\n')}\n`;
 }
 
-function renderHomeFrontMatter(patternCount: number): string {
-  return [
-    '---',
-    'pageType: home',
-    'title: FPF Reference',
-    'description: Compiler-backed reference for the latest published FPF, projected as a slim wiki.',
-    'hero:',
-    // The "name" slot renders as the small mono kicker above the H1.
-    // Extended per PR #72 design review to carry the static framing
-    // ("projection of the latest published spec") so the kicker reads
-    // as both brand + role.
-    '  name: "FPF Reference · Projection of the latest published spec"',
-    '  text: Small, grounded entry points to the framework.',
-    // Tagline tightened per design review — closes with "the doorways"
-    // to forward-link to the index list of stable anchors below.
-    '  tagline: Use the full First Principles Framework instead of pasting the whole specification into every conversation. Not the spec, not a release page — the doorways.',
-    '  actions:',
-    // Primary CTA carries an inline arrow + verb ("Open the adoption
-    // guide") so it reads as the action it is. Secondary actions stay
-    // as plain text links — the arrow on those was redundant once the
-    // primary already had one.
-    '    - theme: brand',
-    '      text: "→ Open the adoption guide"',
-    '      link: /start-here',
-    '    - theme: alt',
-    '      text: Pattern Index',
-    '      link: /patterns',
-    '    - theme: alt',
-    '      text: Work packets',
-    '      link: /work-packets',
-    '    - theme: alt',
-    '      text: MCP recipes',
-    '      link: /mcp-recipes',
-    'features:',
-    '  - title: Pattern Index',
-    `    details: "The clickable FPF pattern index: ${patternCount} patterns across parts A–K. Open an exact ID, audit the full reference, or compare neighboring patterns by Part."`,
-    // The Pattern Index and Routes cards each cover a catalog of items —
-    // using a real ID like `A.1` or `F.1` as the chip (R5-P2-007)
-    // misleads users into thinking those IDs *are* "all patterns" or
-    // "all routes". Use a category badge instead. H.1 and I.3 chips stay
-    // because those IDs *are* the canonical glossary and change-log anchors.
-    '    icon: A–K',
-    '    link: /patterns',
-    '  - title: Routes',
-    '    details: Generated working paths through pattern IDs. Use a route when the work shape is known but the exact patterns are not.',
-    '    icon: "route:"',
-    '    link: /generated/routes/index',
-    '  - title: Glossary',
-    '    details: H.1 is the published glossary anchor — a stable selector for term lookups. Treat it as a starting point for vocabulary, not a complete A–Z list.',
-    '    icon: H.1',
-    '    link: /generated/patterns/H.1',
-    '  - title: Change log',
-    '    details: I.3 is the published change-log anchor — a stable selector for spec version history. Treat it as a starting point, not a release-note feed.',
-    '    icon: I.3',
-    '    link: /generated/patterns/I.3',
-    '---',
-    '',
-  ].join('\n');
+function renderHomeProvenanceDetail(manifest?: PublicationManifestSummary): string {
+  if (!manifest) {
+    return 'Generated reference pages, route IDs, and source status remain discoverable in the site chrome and reference catalog.';
+  }
+
+  const shortHash = manifest.sourceHash.replace(/^sha256:/, '').slice(0, 8);
+  const shortRef = manifest.upstreamRef.slice(0, 8);
+  const publishedAt = formatPublishedDate(manifest.publishedAt);
+  return `Published ${publishedAt} · upstream ${shortRef} · source ${shortHash}.`;
+}
+
+function formatPublishedDate(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  const year = parsed.getUTCFullYear();
+  const month = `${parsed.getUTCMonth() + 1}`.padStart(2, '0');
+  const day = `${parsed.getUTCDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 function buildRouteIndexPage(snapshot: Snapshot): GeneratedDocPage {

--- a/src/docs/theme.css
+++ b/src/docs/theme.css
@@ -489,6 +489,7 @@ body:has(.rp-doc-layout__sidebar:empty) .rp-doc-layout__menu {
 .rspress-doc li,
 .rspress-doc blockquote {
   line-height: var(--fpf-lh-body);
+  overflow-wrap: anywhere;
 }
 
 .rspress-doc p,
@@ -1404,4 +1405,635 @@ html body .rp-home-feature__card .rp-home-feature__title-wrapper.rp-home-feature
   top: 8px;
   outline: 2px solid var(--fpf-accent, #ac3225);
   outline-offset: 2px;
+}
+
+/* ───────── 14. Doorway site redesign ─────────
+ *
+ * The real site now uses the same idea as the selected prototype:
+ * human-readable doorway first, exact generated source second. This final
+ * layer intentionally overrides earlier home-page and generated-doc styling
+ * without removing the accessibility and Rspress compatibility fixes above.
+ */
+
+html:root {
+  --fpf-paper: #f6efe5;
+  --fpf-paper-2: #fffaf2;
+  --fpf-paper-3: #f2eadf;
+  --fpf-ink: #20241e;
+  --fpf-ink-2: #62685e;
+  --fpf-ink-3: #7a766b;
+  --fpf-rule: rgb(37 43 36 / 18%);
+  --fpf-rule-strong: #252b24;
+  --fpf-accent: #a23b2e;
+  --fpf-accent-soft: #eaded1;
+  --fpf-accent-ink: #fffaf2;
+  --fpf-green: #28513f;
+  --fpf-gold: #c2923a;
+  --rp-content-max-width: 1160px;
+}
+
+html.dark {
+  --fpf-paper: #151912;
+  --fpf-paper-2: #1d221a;
+  --fpf-paper-3: #24291f;
+  --fpf-ink: #f6efe5;
+  --fpf-ink-2: rgb(246 239 229 / 76%);
+  --fpf-ink-3: rgb(246 239 229 / 56%);
+  --fpf-rule: rgb(246 239 229 / 18%);
+  --fpf-rule-strong: rgb(246 239 229 / 38%);
+  --fpf-accent: #d7b36a;
+  --fpf-accent-soft: #2d2718;
+  --fpf-accent-ink: #151912;
+  --fpf-green: #9fc4ae;
+}
+
+.rp-doc-layout__container,
+.rp-doc-layout__doc-container,
+.rp-doc-layout__sidebar.rp-doc-layout__sidebar,
+.rspress-doc,
+body {
+  background: var(--fpf-paper);
+}
+
+.rp-doc-layout__doc {
+  min-width: 0;
+}
+
+.rp-doc-layout__container:has(> .rp-doc-layout__sidebar:empty) .rp-doc-layout__doc {
+  width: min(100%, 1180px);
+  max-width: min(100%, 1180px);
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.rp-doc-layout__outline,
+.rp-doc-layout__outline-placeholder {
+  width: min(18vw, 220px);
+}
+
+.rp-doc-layout__doc-container .rspress-doc,
+.rspress-doc-container .rspress-doc {
+  max-width: min(100%, 1120px);
+}
+
+.rspress-doc {
+  font-family: var(--fpf-font-serif);
+}
+
+.rspress-doc h1,
+.rspress-doc-container .rspress-doc-title {
+  font-family: var(--fpf-font-serif);
+  max-width: 15ch;
+  font-size: clamp(3rem, 7vw, 6.4rem);
+  font-weight: 500;
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+
+.rspress-doc .fpf-breadcrumb + h1 {
+  max-width: 24ch;
+  font-family: var(--fpf-font-serif);
+  font-size: clamp(2.25rem, 3.2vw, 4.2rem);
+  line-height: 0.98;
+}
+
+.rspress-doc h2 {
+  border-top-color: var(--fpf-rule-strong);
+  color: var(--fpf-green);
+  font-family: var(--fpf-font-display);
+  font-size: clamp(1.7rem, 2.2vw, 2.6rem);
+  letter-spacing: 0;
+}
+
+.rspress-doc h3,
+.rspress-doc h4 {
+  color: var(--fpf-ink);
+  font-family: var(--fpf-font-display);
+  letter-spacing: 0;
+}
+
+.rspress-doc > blockquote:first-of-type,
+.rspress-doc [class*="rspress-directive"],
+.rspress-doc pre,
+.rp-codeblock.rp-codeblock {
+  border: 1px solid var(--fpf-rule-strong);
+  background: var(--fpf-paper-2);
+  box-shadow: none;
+}
+
+.rspress-doc table {
+  border-color: var(--fpf-rule-strong);
+  background: var(--fpf-paper-2);
+}
+
+.rspress-doc th {
+  background: var(--fpf-paper-3);
+  color: var(--fpf-accent);
+}
+
+.rspress-doc td {
+  background: color-mix(in srgb, var(--fpf-paper-2) 82%, var(--fpf-paper));
+}
+
+.fpf-breadcrumb {
+  padding-bottom: 0.85rem;
+  border-bottom: 1px solid var(--fpf-rule);
+}
+
+.fpf-pattern-byline {
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--fpf-rule);
+}
+
+/* Viewport-centered authored landing pages. */
+.rp-doc-layout__container:has(.fpf-doorway-home) {
+  display: block;
+}
+
+.rp-doc-layout__container:has(.fpf-doorway-home) .rp-doc-layout__doc {
+  width: 100%;
+  max-width: none;
+  margin-right: 0;
+  margin-left: 0;
+}
+
+.rp-doc-layout__container:has(.fpf-doorway-home) .rp-doc-layout__sidebar,
+.rp-doc-layout__container:has(.fpf-doorway-home) .rp-doc-layout__outline,
+.rp-doc-layout__container:has(.fpf-doorway-home) .rp-doc-layout__outline-placeholder,
+.rp-doc-layout__container:has(.fpf-doorway-home) .rp-doc-layout__menu {
+  display: none;
+}
+
+.rp-doc-layout__doc-container:has(.fpf-doorway-home) {
+  width: 100%;
+  max-width: none;
+  margin-right: 0;
+  margin-left: 0;
+  padding: 24px 20px 72px;
+}
+
+.rp-doc-layout__doc-container:has(.fpf-doorway-home) .rspress-doc,
+.rspress-doc:has(.fpf-doorway-home) {
+  width: min(100%, 1180px);
+  max-width: 1180px;
+  margin-right: auto;
+  margin-left: auto;
+  padding: 0;
+}
+
+.rspress-doc:has(.fpf-doorway-home) > h1:first-child,
+.rspress-doc:has(.fpf-doorway-home) > p:first-of-type {
+  display: none;
+}
+
+.fpf-doorway-home,
+.fpf-doorway-home * {
+  box-sizing: border-box;
+}
+
+.fpf-doorway-home {
+  color: var(--fpf-ink);
+  font-family: var(--fpf-font-display);
+}
+
+.rspress-doc .fpf-doorway-home a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.fpf-doorway-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.72fr);
+  min-height: min(620px, calc(100vh - var(--rp-nav-height) - 72px));
+  border: 1px solid var(--fpf-rule-strong);
+  background: var(--fpf-paper-2);
+}
+
+.fpf-doorway-hero__copy,
+.fpf-doorway-principle,
+.fpf-doorway-section-head,
+.fpf-doorway-mcp > div {
+  min-width: 0;
+}
+
+.fpf-doorway-hero__copy {
+  display: grid;
+  align-content: center;
+  gap: 24px;
+  padding: clamp(34px, 5vw, 72px);
+}
+
+.fpf-doorway-kicker,
+.fpf-doorway-principle span,
+.fpf-doorway-surfaces span,
+.fpf-doorway-route-grid span,
+.fpf-doorway-reference-grid span,
+.fpf-doorway-section-head p,
+.fpf-doorway-provenance p {
+  margin: 0;
+  color: var(--fpf-accent);
+  font-family: var(--fpf-font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-transform: none;
+}
+
+.fpf-doorway-hero h1 {
+  max-width: 11ch;
+  margin: 0;
+  color: var(--fpf-ink);
+  font-family: var(--fpf-font-serif);
+  font-size: clamp(4rem, 7vw, 7.2rem);
+  font-weight: 500;
+  line-height: 0.9;
+  letter-spacing: 0;
+}
+
+.fpf-doorway-hero p,
+.fpf-doorway-mcp p {
+  max-width: 44rem;
+  margin: 0;
+  color: var(--fpf-ink-2);
+  font-family: var(--fpf-font-display);
+  font-size: 17px;
+  line-height: 1.55;
+}
+
+.fpf-doorway-actions,
+.fpf-doorway-endpoint nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.rspress-doc .fpf-doorway-button,
+.rspress-doc .fpf-doorway-endpoint a {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 14px;
+  border: 1px solid var(--fpf-rule-strong);
+  border-radius: 4px;
+  color: var(--fpf-ink);
+  font-family: var(--fpf-font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none !important;
+}
+
+.rspress-doc a.fpf-doorway-button.fpf-doorway-button--primary,
+.rspress-doc a.fpf-doorway-button--primary,
+.rspress-doc .fpf-doorway-button--primary,
+.rspress-doc .fpf-doorway-button:hover,
+.rspress-doc .fpf-doorway-button:focus-visible,
+.rspress-doc .fpf-doorway-endpoint a:hover,
+.rspress-doc .fpf-doorway-endpoint a:focus-visible {
+  border-color: var(--fpf-accent);
+  background: var(--fpf-accent);
+  color: var(--fpf-accent-ink) !important;
+}
+
+.fpf-doorway-principle {
+  display: grid;
+  align-content: end;
+  gap: 18px;
+  padding: clamp(30px, 4vw, 48px);
+  border-left: 1px solid var(--fpf-rule-strong);
+  background: var(--fpf-paper-3);
+}
+
+.fpf-doorway-principle strong {
+  max-width: 10ch;
+  color: var(--fpf-green);
+  font-size: clamp(2.6rem, 4vw, 4.8rem);
+  font-weight: 650;
+  line-height: 0.95;
+}
+
+.fpf-doorway-principle p {
+  max-width: 24rem;
+  margin: 0;
+  color: var(--fpf-ink-2);
+  font-size: 17px;
+}
+
+.fpf-doorway-surfaces,
+.fpf-doorway-route-grid,
+.fpf-doorway-reference-grid {
+  display: grid;
+  border-right: 1px solid var(--fpf-rule-strong);
+  border-bottom: 1px solid var(--fpf-rule-strong);
+  border-left: 1px solid var(--fpf-rule-strong);
+}
+
+.fpf-doorway-surfaces,
+.fpf-doorway-route-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.fpf-doorway-reference-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.fpf-doorway-surfaces a,
+.fpf-doorway-route-grid a,
+.fpf-doorway-reference-grid a {
+  display: grid;
+  gap: 16px;
+  min-height: 250px;
+  align-content: space-between;
+  padding: 26px;
+  border-right: 1px solid var(--fpf-rule);
+  border-bottom: 1px solid var(--fpf-rule);
+  background: var(--fpf-paper);
+}
+
+.fpf-doorway-surfaces a:nth-child(4n),
+.fpf-doorway-route-grid a:nth-child(4n),
+.fpf-doorway-reference-grid a:nth-child(3n) {
+  border-right: 0;
+}
+
+.fpf-doorway-surfaces a:nth-last-child(-n + 4),
+.fpf-doorway-route-grid a:nth-last-child(-n + 4),
+.fpf-doorway-reference-grid a:nth-last-child(-n + 3) {
+  border-bottom: 0;
+}
+
+.fpf-doorway-surfaces a:hover,
+.fpf-doorway-surfaces a:focus-visible,
+.fpf-doorway-route-grid a:hover,
+.fpf-doorway-route-grid a:focus-visible,
+.fpf-doorway-reference-grid a:hover,
+.fpf-doorway-reference-grid a:focus-visible {
+  background: var(--fpf-accent-soft);
+}
+
+.fpf-doorway-surfaces strong,
+.fpf-doorway-route-grid strong,
+.fpf-doorway-reference-grid strong {
+  color: var(--fpf-green);
+  font-size: clamp(2rem, 3vw, 3.3rem);
+  font-weight: 650;
+  line-height: 0.98;
+}
+
+.fpf-doorway-surfaces em,
+.fpf-doorway-route-grid em {
+  color: var(--fpf-ink-2);
+  font-size: 16px;
+  font-style: normal;
+  line-height: 1.45;
+}
+
+.fpf-doorway-routes,
+.fpf-doorway-reference,
+.fpf-doorway-mcp,
+.fpf-doorway-provenance {
+  border-right: 1px solid var(--fpf-rule-strong);
+  border-bottom: 1px solid var(--fpf-rule-strong);
+  border-left: 1px solid var(--fpf-rule-strong);
+}
+
+.fpf-doorway-section-head {
+  display: grid;
+  gap: 18px;
+  padding: clamp(34px, 5vw, 64px);
+  background: var(--fpf-paper-2);
+}
+
+.fpf-doorway-section-head h2,
+.fpf-doorway-mcp h2 {
+  max-width: 13ch;
+  margin: 0;
+  color: var(--fpf-ink);
+  font-family: var(--fpf-font-serif);
+  font-size: clamp(3rem, 5vw, 5.4rem);
+  font-weight: 500;
+  line-height: 0.92;
+}
+
+.fpf-doorway-mcp {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(340px, 0.78fr);
+  min-height: 430px;
+  background: var(--fpf-ink);
+  color: var(--fpf-paper);
+}
+
+.fpf-doorway-mcp > div {
+  display: grid;
+  align-content: center;
+  gap: 22px;
+  padding: clamp(34px, 5vw, 64px);
+}
+
+.fpf-doorway-mcp h2,
+.fpf-doorway-mcp p {
+  color: var(--fpf-paper);
+}
+
+.fpf-doorway-endpoint {
+  border-left: 1px solid rgb(246 239 229 / 20%);
+  background: #12160f;
+}
+
+.rspress-doc .fpf-doorway-endpoint code {
+  display: block;
+  max-width: 100%;
+  padding: 18px;
+  border: 1px solid rgb(246 239 229 / 18%);
+  background: #0c100a;
+  color: var(--fpf-gold);
+  font-family: var(--fpf-font-mono);
+  font-size: 13px;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.rspress-doc .fpf-doorway-endpoint a {
+  border-color: var(--fpf-gold);
+  color: var(--fpf-gold);
+}
+
+.fpf-doorway-provenance {
+  display: grid;
+  grid-template-columns: 0.7fr 1fr 1.3fr;
+  gap: 24px;
+  align-items: center;
+  padding: 22px 26px;
+  background: var(--fpf-paper-3);
+  font-family: var(--fpf-font-mono);
+  font-size: 12px;
+}
+
+.fpf-doorway-provenance strong {
+  color: var(--fpf-green);
+}
+
+.fpf-doorway-provenance span {
+  color: var(--fpf-ink-2);
+}
+
+@media (width <= 1280px) {
+  .rp-doc-layout__outline,
+  .rp-doc-layout__outline-placeholder {
+    display: none;
+  }
+
+  .rp-doc-layout__doc {
+    max-width: none;
+  }
+}
+
+@media (width <= 1080px) {
+  .fpf-doorway-surfaces,
+  .fpf-doorway-route-grid,
+  .fpf-doorway-reference-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .fpf-doorway-surfaces a,
+  .fpf-doorway-route-grid a,
+  .fpf-doorway-reference-grid a,
+  .fpf-doorway-surfaces a:nth-child(4n),
+  .fpf-doorway-route-grid a:nth-child(4n),
+  .fpf-doorway-reference-grid a:nth-child(3n),
+  .fpf-doorway-surfaces a:nth-last-child(-n + 4),
+  .fpf-doorway-route-grid a:nth-last-child(-n + 4),
+  .fpf-doorway-reference-grid a:nth-last-child(-n + 3) {
+    border-right: 1px solid var(--fpf-rule);
+    border-bottom: 1px solid var(--fpf-rule);
+  }
+
+  .fpf-doorway-surfaces a:nth-child(2n),
+  .fpf-doorway-route-grid a:nth-child(2n),
+  .fpf-doorway-reference-grid a:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .fpf-doorway-surfaces a:nth-last-child(-n + 2),
+  .fpf-doorway-route-grid a:nth-last-child(-n + 2),
+  .fpf-doorway-reference-grid a:nth-last-child(-n + 2) {
+    border-bottom: 0;
+  }
+}
+
+@media (width <= 860px) {
+  .fpf-doorway-hero,
+  .fpf-doorway-mcp {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  .fpf-doorway-principle,
+  .fpf-doorway-endpoint {
+    border-top: 1px solid var(--fpf-rule-strong);
+    border-left: 0;
+  }
+
+  .fpf-doorway-provenance {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (width <= 640px) {
+  .rp-doc-layout__doc-container:has(.fpf-doorway-home) {
+    padding: 12px 10px 48px;
+  }
+
+  .fpf-doorway-surfaces,
+  .fpf-doorway-route-grid,
+  .fpf-doorway-reference-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .fpf-doorway-surfaces a,
+  .fpf-doorway-route-grid a,
+  .fpf-doorway-reference-grid a,
+  .fpf-doorway-surfaces a:nth-child(2n),
+  .fpf-doorway-route-grid a:nth-child(2n),
+  .fpf-doorway-reference-grid a:nth-child(2n),
+  .fpf-doorway-surfaces a:nth-last-child(-n + 2),
+  .fpf-doorway-route-grid a:nth-last-child(-n + 2),
+  .fpf-doorway-reference-grid a:nth-last-child(-n + 2) {
+    min-height: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--fpf-rule);
+  }
+
+  .fpf-doorway-surfaces a:last-child,
+  .fpf-doorway-route-grid a:last-child,
+  .fpf-doorway-reference-grid a:last-child {
+    border-bottom: 0;
+  }
+
+  .fpf-doorway-hero__copy,
+  .fpf-doorway-principle,
+  .fpf-doorway-section-head,
+  .fpf-doorway-mcp > div {
+    padding: 28px;
+  }
+
+  .fpf-doorway-hero h1,
+  .fpf-doorway-section-head h2,
+  .fpf-doorway-mcp h2 {
+    max-width: 10.5ch;
+    font-size: 48px;
+    line-height: 0.94;
+  }
+
+  .fpf-doorway-principle strong,
+  .fpf-doorway-surfaces strong,
+  .fpf-doorway-route-grid strong,
+  .fpf-doorway-reference-grid strong {
+    font-size: 34px;
+  }
+
+  .rspress-doc h1,
+  .rspress-doc-container .rspress-doc-title {
+    max-width: 12ch;
+    font-size: 44px;
+    line-height: 0.96;
+  }
+
+  .rspress-doc .fpf-breadcrumb + h1 {
+    max-width: 100%;
+    font-size: 34px;
+  }
+
+  .rspress-doc :not(pre) > code {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+}
+
+html body .rp-doc-layout__container:has(> .rp-doc-layout__sidebar:empty) {
+  justify-content: center;
+}
+
+html body .rp-doc-layout__container:has(> .rp-doc-layout__sidebar:empty) > .rp-doc-layout__outline,
+html body .rp-doc-layout__container:has(> .rp-doc-layout__sidebar:empty) > .rp-doc-layout__outline-placeholder {
+  display: none !important;
+  flex: 0 0 0 !important;
+  width: 0 !important;
+}
+
+html body .rp-doc-layout__container:has(> .rp-doc-layout__sidebar:empty) > .rp-doc-layout__doc {
+  flex: 0 1 1180px !important;
+  width: min(100%, 1180px) !important;
+  max-width: min(100%, 1180px) !important;
+  margin-right: auto !important;
+  margin-left: auto !important;
+}
+
+html body .rp-doc-layout__container:has(.fpf-doorway-home) > .rp-doc-layout__doc {
+  flex: 0 1 auto !important;
+  width: 100% !important;
+  max-width: none !important;
+  margin-right: 0 !important;
+  margin-left: 0 !important;
 }

--- a/tests/docs-projection.test.ts
+++ b/tests/docs-projection.test.ts
@@ -228,44 +228,28 @@ describe('docs projection', () => {
       expect(
         await readFile(resolve(docsRoot, 'generated/patterns/index.md'), 'utf8'),
       ).toContain('# Pattern Catalog');
-      // The site root `/` is the orientation/welcome page (Rspress
-      // pageType: home with hero + 4-up feature grid). The Pattern
-      // Catalog moved to `/patterns` per FU-P2-001 so first-time
-      // visitors get an adoption surface, not a 237-link reference wall.
+      // The site root `/` is the authored Doorway orientation page. The
+      // Pattern Catalog stays at `/patterns` so first-time visitors get an
+      // adoption surface, not a 237-link reference wall.
       const rootIndex = await readFile(resolve(docsRoot, 'index.md'), 'utf8');
-      expect(rootIndex).toContain('pageType: home');
-      expect(rootIndex).toContain('title: FPF Reference');
-      // Kicker now carries brand + role per PR #72 design review.
+      expect(rootIndex).toContain('title: "FPF Reference"');
+      expect(rootIndex).not.toContain('pageType: home');
+      expect(rootIndex).toContain('class="fpf-doorway-home"');
+      expect(rootIndex).toContain('The doorway, then the source.');
       expect(rootIndex).toContain('FPF Reference');
-      expect(rootIndex).toContain('Projection of the latest published spec');
-      expect(rootIndex).toContain('Small, grounded entry points to the framework');
-      // Primary CTA verb-prefixed; secondary actions stay as plain text.
-      expect(rootIndex).toContain('Open the adoption guide');
-      expect(rootIndex).toContain('link: /start-here');
-      expect(rootIndex).toMatch(/text: Pattern Index[\s\S]*?link: \/patterns/);
-      expect(rootIndex).toContain('text: Work packets');
-      expect(rootIndex).toContain('link: /work-packets');
-      expect(rootIndex).toContain('text: MCP recipes');
-      expect(rootIndex).toContain('link: /mcp-recipes');
-      expect(rootIndex).toContain('  - title: Pattern Index');
-      // Index feature card points at the short Pattern Catalog
-      // URL `/patterns`, not the deep-link `/generated/patterns/index`.
-      expect(rootIndex).toMatch(/- title: Pattern Index[\s\S]*?link: \/patterns/);
-      expect(rootIndex).toContain('  - title: Routes');
-      expect(rootIndex).toContain('link: /generated/routes/index');
-      // Card titles dropped the "anchor" suffix per PR #72 design
-      // review (the chip already telegraphs that the title is an FPF
-      // identifier — repeating "anchor" in the label was redundant).
-      expect(rootIndex).toContain('  - title: Glossary');
-      expect(rootIndex).toContain('link: /generated/patterns/H.1');
-      expect(rootIndex).toContain('  - title: Change log');
-      expect(rootIndex).toContain('link: /generated/patterns/I.3');
-      expect(rootIndex).toContain('## Methodology');
-      expect(rootIndex).toContain('## MCP endpoint');
+      expect(rootIndex).toContain('Projection of the latest published FPF');
+      expect(rootIndex).toContain('Smallest useful surface first.');
+      expect(rootIndex).toContain('href="/start-here">Start here</a>');
+      expect(rootIndex).toContain('href="/patterns">Open the index</a>');
+      expect(rootIndex).toContain('href="/connect-mcp">Connect MCP</a>');
+      expect(rootIndex).toContain('href="/generated/routes/index"');
+      expect(rootIndex).toContain('href="/generated/routes/route_project-alignment"');
+      expect(rootIndex).toContain('href="/generated/routes/route_boundary-burden"');
+      expect(rootIndex).toContain('href="/generated/patterns/E.14"');
+      expect(rootIndex).toContain('href="/generated/patterns/E.19"');
       expect(rootIndex).toContain('fpf-memory-mcp-vercel-origin.vercel.app');
-      expect(rootIndex).toContain('https://github.com/venikman/fpf-memory#run-and-test-mcp');
-      expect(rootIndex).toContain('[Connect MCP](/connect-mcp)');
-      expect(rootIndex).toContain('[MCP recipes](/mcp-recipes)');
+      expect(rootIndex).toContain('Connect clients');
+      expect(rootIndex).toContain('Use recipes');
 
       // Pattern Catalog short-URL alias at /patterns — same content as
       // /generated/patterns/index. Carries the orientation-page back-pointer
@@ -324,13 +308,13 @@ describe('docs projection', () => {
         },
       );
 
-      // `/` is the orientation/welcome page (pageType: home with hero +
-      // feature grid). Hero copy + adoption-guide CTA should be present.
+      // `/` is the authored Doorway orientation page. Hero copy + primary
+      // CTA should be present.
       const indexHtml = await readFile(resolve(outDir, 'index.html'), 'utf8');
       expect(indexHtml).toContain('FPF Reference');
-      // Primary CTA copy now reads "Open the adoption guide" with a
-      // leading arrow per PR #72 design review.
-      expect(indexHtml).toContain('Open the adoption guide');
+      expect(indexHtml).toContain('The doorway, then the source.');
+      expect(indexHtml).toContain('Start here');
+      expect(indexHtml).toContain('Smallest useful surface first.');
 
       // `/patterns` is the short-URL Pattern Catalog. Verify it lists Part A
       // Role Taxonomy and points back at the orientation page.


### PR DESCRIPTION
## What

Apply the Doorway redesign to the real FPF docs site and hosted MCP landing page.

## Why

The docs entry path should start with a centered, human-readable doorway before sending users into generated reference pages, route IDs, or MCP setup. This keeps the full framework accessible without making the homepage feel like a prototype or an uncentered docs column.

## Type

- `docs` — documentation only

## Changes

- Replaces the Rspress stock home projection with authored Doorway homepage markup.
- Adds the warm paper, serif heading, mono label, red/green accent, and rule-based panel treatment across generated docs.
- Centers authored landing surfaces and restyles `/connect-mcp`, `/mcp-recipes`, and the hosted MCP HTML page.
- Updates docs projection tests for the new homepage output.

## Validation

- `bun run lint` passes locally: 0 lint errors, 0 type errors, 0 warnings across 127 files.
- `bun run check` passes locally.
- `bun run test` passes locally: 36 files, 283 tests passed.
- No new warnings introduced: browser validation still sees the pre-existing Rspress recoverable hydration warning `#418` from the shared header/client path.
- `bun run build` succeeds.
- `bun run docs:build` succeeds: generated 827 docs files and completed the Rspress build.
- Relevant docs updated (README, docs/, inline JSDoc if applicable): not applicable; this PR changes the docs projection and styling directly.
- End-to-end verification command + output excerpt: Playwright checked `/fpf-memory/`, `/fpf-memory/patterns`, `/fpf-memory/generated/routes/index`, `/fpf-memory/generated/routes/route_project-alignment`, `/fpf-memory/generated/patterns/E.14`, `/fpf-memory/connect-mcp`, and `/fpf-memory/mcp-recipes` at `1728x1117`, `1366x900`, and `390x844`; every route returned HTTP 200, no horizontal overflow, no detected clipping, and landing surfaces centered. Hosted MCP smoke returned HTTP 200, endpoint visible, no overflow.
- Caveats or blocker: The Rspress hydration warning is still present but outside this style-only change; rendered pages passed visual and interaction checks.

## TPR fast-track

- [ ] Enable TPR review/merge timer

Use this only for small, reversible PRs from trusted maintainers or collaborators. The timer does not fake approval or bypass branch protection:

- after 1 hour without a non-author review signal, automation comments `@codex review`;
- after 2 hours, automation enables auto-merge only when checks pass, no trusted reviewer requested changes, and at least one trusted non-author approval exists for the current head commit.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | Doorway site redesign |
| Prompt  | Implement selected Doorway style from latest main and prepare PR for deployment |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to documentation rendering and CSS/HTML styling; main risk is unintended layout regressions across breakpoints/dark mode due to large theme overrides.
> 
> **Overview**
> Switches the docs site root (`/`) from Rspress `pageType: home` frontmatter to an authored “Doorway” homepage markup, including new primary navigation CTAs and an explicit provenance line derived from the publication manifest.
> 
> Applies the Doorway visual system broadly via substantial `theme.css` overrides (new warm-paper palette, typography, viewport-centered landing pages, and wrapping fixes) and restyles the hosted MCP landing HTML to match the same treatment.
> 
> Updates docs projection/build tests to assert the new homepage output and key Doorway copy/links instead of the old home-layout expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c240658d364ed8bb39fb19e46bd45e61e2e346. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->