### PR TITLE
fix(hosted): disable Vercel body helpers for MCP transport

### DIFF
--- a/src/build/vercel-origin-build.ts
+++ b/src/build/vercel-origin-build.ts
@@ -98,7 +98,12 @@ async function writeFunctionConfig(functionDir: string): Promise<void> {
     regions: ['iad1'],
     supportsResponseStreaming: true,
     launcherType: 'Nodejs',
-    shouldAddHelpers: true,
+    // Vercel's launcher consumes the request body to populate `req.body`
+    // when helpers are enabled. The MCP Streamable HTTP transport reads the
+    // raw IncomingMessage stream itself, so a pre-consumed body leaves it
+    // waiting forever and the function hits maxDuration (504). Keep helpers
+    // off so the request stream stays readable for the transport.
+    shouldAddHelpers: false,
     shouldAddSourcemapSupport: true,
   });
 }


### PR DESCRIPTION
## What

Turn off Vercel's `shouldAddHelpers` flag on the hosted MCP function so the request stream stays readable for the MCP Streamable HTTP transport.

## Why

Production runtime logs show every `POST /api/mcp/fpf_memory/mcp` returning **504 Vercel Runtime Timeout Error** — `curl` confirms the request hangs without sending any bytes back. Root cause: Vercel's Node launcher consumes the request body to populate `req.body` when helpers are enabled, but the SDK transport (`StreamableHTTPServerTransport.handleRequest`) reads the raw `IncomingMessage` stream itself via `@hono/node-server`'s `Readable.toWeb(incoming)`. With the body already drained, the SDK's `await req.json()` blocks indefinitely until the function hits its 300s `maxDuration` and Vercel returns 504.

The handler does not use any of Vercel's helpers (`req.body`, `res.json()`, etc.), and the Hono branch in `src/entrypoints/vercel-function.ts` likewise converts the request stream itself. Turning helpers off removes the body-side-effect with no functional loss.

## Type

- `fix` — bug fix

## Changes

- `src/build/vercel-origin-build.ts`: set `shouldAddHelpers: false` in the function `.vc-config.json`. Comment explains why.

## Validation

- `bun run lint` passes locally: 0 lint errors, 0 type errors, 0 warnings (129 files).
- `bun run check` passes locally.
- `bun run test` passes locally: 288 passed, 0 failed.
- No new warnings introduced.
- `bun run build` succeeds (if runtime/server code touched): not applicable; this is a function-config change, no runtime/server code touched.
- `bun run docs:build` succeeds (if docs touched): not applicable.
- Relevant docs updated (README, docs/, inline JSDoc if applicable): not applicable; behavior is internal to the Vercel function. Inline comment added explaining the reason for the flag.
- End-to-end verification command + output excerpt: will smoke-test the Vercel preview with `FPF_MCP_SMOKE_URL=<preview-url>/api/mcp/fpf_memory/mcp bun run smoke:mcp:http` and report results in a follow-up comment before merge.
- Caveats or blocker: change only takes effect on the next Vercel deploy. The fix needs preview verification before merging to production.

## TPR fast-track

- [ ] Enable TPR review/merge timer

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Claude Code (Opus 4.7) |
| Session | Hosted MCP 504 investigation |
| Prompt  | Investigate hosted MCP 504 timeouts and fix them |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Vercel function runtime configuration to stop automatic request-body consumption; low code complexity but it affects how all requests to the hosted MCP endpoint are processed and could impact any code relying on Vercel helper behavior.
> 
> **Overview**
> Prevents hosted MCP requests from hanging by writing `.vc-config.json` with `shouldAddHelpers: false` for the Vercel function, avoiding the Node launcher’s request-body helper behavior that drains the stream.
> 
> Adds an inline comment documenting the 504 timeout failure mode and why helpers must stay disabled for the Streamable HTTP transport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c608096cc6c286d62b2d8d6f4b28e83276fb3514. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->