### PR TITLE
fix(security): cap tool input sizes to prevent DoS

### DIFF
--- a/src/mcp/tool-contracts.ts
+++ b/src/mcp/tool-contracts.ts
@@ -1,5 +1,16 @@
 import { z } from 'zod';
 
+// Public, unauthenticated MCP tools accept user-supplied strings; without
+// caps a single 4 MB payload can drive the runtime into Vercel's 5-minute
+// `maxDuration` ceiling. These limits are generous for legitimate use
+// (a 2000-character question is far longer than anything a person types)
+// and refuse pathological input at the schema boundary.
+const MAX_QUESTION_LENGTH = 2_000;
+const MAX_SEARCH_QUERY_LENGTH = 1_000;
+const MAX_SELECTOR_LENGTH = 256;
+const MAX_FILTER_LENGTH = 64;
+const MAX_CITATION_COUNT = 50;
+
 export const answerModeSchema = z.enum(['compact', 'verbose', 'proof']);
 export const nodeKindSchema = z.enum(['pattern', 'route', 'lexeme']);
 export const selectorKindSchema = z.enum(['auto', 'id', 'route', 'lexeme']);
@@ -438,19 +449,19 @@ export const refreshFpfIndexInputSchema = z
 
 export const queryFpfSpecInputSchema = z
   .object({
-    question: z.string().min(1),
+    question: z.string().min(1).max(MAX_QUESTION_LENGTH),
     mode: answerModeSchema.optional(),
     forceRefresh: z.boolean().optional(),
-    sessionId: z.string().min(1).optional(),
+    sessionId: z.string().min(1).max(MAX_SELECTOR_LENGTH).optional(),
   })
   .strict();
 
 export const askFpfInputSchema = z
   .object({
-    question: z.string().min(1),
+    question: z.string().min(1).max(MAX_QUESTION_LENGTH),
     mode: answerModeSchema.optional(),
     forceRefresh: z.boolean().optional(),
-    sessionId: z.string().min(1).optional(),
+    sessionId: z.string().min(1).max(MAX_SELECTOR_LENGTH).optional(),
   })
   .strict();
 
@@ -458,7 +469,7 @@ export const getFpfIndexStatusInputSchema = z.object({}).strict();
 
 export const inspectFpfNodeInputSchema = z
   .object({
-    selector: z.string().min(1),
+    selector: z.string().min(1).max(MAX_SELECTOR_LENGTH),
     kind: selectorKindSchema.optional(),
     forceRefresh: z.boolean().optional(),
   })
@@ -466,7 +477,7 @@ export const inspectFpfNodeInputSchema = z
 
 export const readFpfDocInputSchema = z
   .object({
-    selector: z.string().min(1),
+    selector: z.string().min(1).max(MAX_SELECTOR_LENGTH),
     kind: selectorKindSchema.optional(),
     forceRefresh: z.boolean().optional(),
   })
@@ -474,24 +485,27 @@ export const readFpfDocInputSchema = z
 
 export const inspectFpfAnchorInputSchema = z
   .object({
-    anchorId: z.string().min(1),
+    anchorId: z.string().min(1).max(MAX_SELECTOR_LENGTH),
     forceRefresh: z.boolean().optional(),
   })
   .strict();
 
 export const expandFpfCitationsInputSchema = z
   .object({
-    citationIds: z.array(z.string().min(1)).min(1),
+    citationIds: z
+      .array(z.string().min(1).max(MAX_SELECTOR_LENGTH))
+      .min(1)
+      .max(MAX_CITATION_COUNT),
     forceRefresh: z.boolean().optional(),
   })
   .strict();
 
 export const traceFpfPathInputSchema = z
   .object({
-    question: z.string().min(1),
+    question: z.string().min(1).max(MAX_QUESTION_LENGTH),
     mode: answerModeSchema.optional(),
     forceRefresh: z.boolean().optional(),
-    sessionId: z.string().min(1).optional(),
+    sessionId: z.string().min(1).max(MAX_SELECTOR_LENGTH).optional(),
   })
   .strict();
 
@@ -523,8 +537,8 @@ export const catalogEntrySchema = z
 
 export const browseFpfCatalogInputSchema = z
   .object({
-    part: z.string().optional(),
-    status: z.string().optional(),
+    part: z.string().max(MAX_FILTER_LENGTH).optional(),
+    status: z.string().max(MAX_FILTER_LENGTH).optional(),
     kind: nodeKindSchema.optional(),
     limit: z.number().int().min(1).max(500).optional(),
     forceRefresh: z.boolean().optional(),
@@ -571,7 +585,7 @@ export const searchHitSchema = z
 
 export const searchFpfInputSchema = z
   .object({
-    query: z.string().min(1),
+    query: z.string().min(1).max(MAX_SEARCH_QUERY_LENGTH),
     kind: nodeKindSchema.optional(),
     limit: z.number().int().min(1).max(100).optional(),
     forceRefresh: z.boolean().optional(),

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -410,7 +410,9 @@ export class FpfRuntime {
 
     // Tokenize the raw query first so camelCase splits (e.g. BoundedContext →
     // bounded + context) are preserved; tokenize() handles lowercasing internally.
-    const queryTokens = tokenize(query);
+    // Cap the token count so a pathological query can't drive scoreOverlap into
+    // O(tokens × nodes × textLen) on the public unauthenticated endpoint.
+    const queryTokens = tokenize(query).slice(0, SEARCH_MAX_QUERY_TOKENS);
     const limit = Math.min(options.limit ?? 20, 100);
 
     const hits: SearchHit[] = [];
@@ -860,6 +862,9 @@ function nodeToCatalogEntry(
 }
 
 const SEARCH_TITLE_TOKEN_WEIGHT = 5;
+// Schema caps the query string at 1000 chars; even pathological tokenizations
+// won't exceed this token count for a legitimate query.
+const SEARCH_MAX_QUERY_TOKENS = 64;
 const SNIPPET_RADIUS = 80;
 
 function extractSnippet(searchableText: string, queryTokens: string[]): string {

--- a/tests/tool-input-caps.test.ts
+++ b/tests/tool-input-caps.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from '@rstest/core';
+
+import {
+  askFpfInputSchema,
+  browseFpfCatalogInputSchema,
+  expandFpfCitationsInputSchema,
+  inspectFpfAnchorInputSchema,
+  inspectFpfNodeInputSchema,
+  queryFpfSpecInputSchema,
+  readFpfDocInputSchema,
+  searchFpfInputSchema,
+  traceFpfPathInputSchema,
+} from '../src/mcp/tool-contracts.js';
+
+const big = (size: number) => 'a'.repeat(size);
+
+describe('public MCP tool input caps', () => {
+  it('queryFpfSpec rejects question over 2000 chars', () => {
+    expect(queryFpfSpecInputSchema.safeParse({ question: big(2001) }).success).toBe(false);
+    expect(queryFpfSpecInputSchema.safeParse({ question: big(2000) }).success).toBe(true);
+  });
+
+  it('askFpf rejects question over 2000 chars and sessionId over 256', () => {
+    expect(askFpfInputSchema.safeParse({ question: big(2001) }).success).toBe(false);
+    expect(
+      askFpfInputSchema.safeParse({ question: 'ok', sessionId: big(257) }).success,
+    ).toBe(false);
+    expect(
+      askFpfInputSchema.safeParse({ question: 'ok', sessionId: big(256) }).success,
+    ).toBe(true);
+  });
+
+  it('traceFpfPath rejects question over 2000 chars', () => {
+    expect(traceFpfPathInputSchema.safeParse({ question: big(2001) }).success).toBe(false);
+  });
+
+  it('searchFpf rejects query over 1000 chars', () => {
+    expect(searchFpfInputSchema.safeParse({ query: big(1001) }).success).toBe(false);
+    expect(searchFpfInputSchema.safeParse({ query: big(1000) }).success).toBe(true);
+  });
+
+  it('browseFpfCatalog rejects part/status over 64 chars', () => {
+    expect(browseFpfCatalogInputSchema.safeParse({ part: big(65) }).success).toBe(false);
+    expect(browseFpfCatalogInputSchema.safeParse({ status: big(65) }).success).toBe(false);
+    expect(browseFpfCatalogInputSchema.safeParse({ part: big(64), status: big(64) }).success).toBe(
+      true,
+    );
+  });
+
+  it('readFpfDoc and inspectFpfNode reject selectors over 256 chars', () => {
+    expect(readFpfDocInputSchema.safeParse({ selector: big(257) }).success).toBe(false);
+    expect(inspectFpfNodeInputSchema.safeParse({ selector: big(257) }).success).toBe(false);
+  });
+
+  it('inspectFpfAnchor rejects anchorId over 256 chars', () => {
+    expect(inspectFpfAnchorInputSchema.safeParse({ anchorId: big(257) }).success).toBe(false);
+  });
+
+  it('expandFpfCitations rejects more than 50 citations', () => {
+    const citations51 = Array.from({ length: 51 }, () => 'A.1');
+    const citations50 = Array.from({ length: 50 }, () => 'A.1');
+    expect(expandFpfCitationsInputSchema.safeParse({ citationIds: citations51 }).success).toBe(
+      false,
+    );
+    expect(expandFpfCitationsInputSchema.safeParse({ citationIds: citations50 }).success).toBe(
+      true,
+    );
+  });
+
+  it('expandFpfCitations rejects an individual citation id over 256 chars', () => {
+    expect(
+      expandFpfCitationsInputSchema.safeParse({ citationIds: [big(257)] }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Cap the user-facing string and array inputs on every public MCP tool with a `z.string().max(...)` / `z.array(...).max(...)` clause, plus a defensive token cap inside the search runtime.

## Why

The hosted MCP endpoint is **public and unauthenticated**. Without input caps, a single 4 MB `question` (under Vercel's 4.5 MB body ceiling) flows into `tokenize()` / `scoreOverlap()` at `O(query × nodes × textLen)` and drives the function near `maxDuration: 300` — roughly five minutes of paid compute per request. A coordinated trickle of such requests is a cheap DoS / cost-amplification vector.

Two changes harden this at independent layers:
- **Schema layer**: every tool's `question`, `selector`, `anchorId`, `sessionId`, citation array, browse filter, and search query are capped at sensible limits (2 KB for natural-language questions, 256 chars for IDs, 64 chars for filters, 50 citations max).
- **Runtime layer**: `search()` slices tokens to 64 before the per-node loop, so even an in-process caller cannot drive `scoreOverlap` into the pathological regime.

## Type

- `fix` — bug fix (security hardening)

## Changes

- `src/mcp/tool-contracts.ts`: add a small block of `MAX_*` constants with reasoning, apply `.max()` to all public tool input fields.
- `src/runtime/runtime.ts`: cap query tokens at `SEARCH_MAX_QUERY_TOKENS = 64` in `search()`.
- `tests/tool-input-caps.test.ts`: lock the caps in with focused tests on every schema.

## Validation

- `bun run lint` passes locally: 0 lint errors, 0 type errors, 0 warnings (130 files).
- `bun run check` passes locally.
- `bun run test` passes locally: **297 tests passed**, 0 failed (288 prior + 9 new).
- No new warnings introduced.
- `bun run build` succeeds (if runtime/server code touched): not separately exercised; covered by the typecheck and test passes.
- `bun run docs:build` succeeds (if docs touched): not applicable.
- Relevant docs updated (README, docs/, inline JSDoc if applicable): inline comments document the caps and the reasoning at both layers.
- End-to-end verification command + output excerpt: schema caps are unit-tested directly. Runtime cap is logically independent — token slice happens before any heavy work.
- Caveats or blocker: legitimate prompts well above 2000 characters would now be rejected. That is intentional — questions that long should be split or summarized client-side. If you have a real use-case requiring longer questions, raise `MAX_QUESTION_LENGTH` rather than dropping the cap.

## TPR fast-track

- [ ] Enable TPR review/merge timer

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Claude Code (Opus 4.7) |
| Session | Hosted MCP / website / security exploration |
| Prompt  | Investigate MCP, website, security; ship small focused PRs |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces stricter input validation on public tool endpoints and a search token cap, which is security-positive but can be user-visible/breaking for clients sending larger payloads and may change search behavior for extremely long queries.
> 
> **Overview**
> Hardens the public, unauthenticated MCP surface against cost/DoS amplification by **adding explicit size limits** to user-controlled inputs at the Zod schema boundary (questions, queries, selectors/IDs, filters, and citation arrays).
> 
> Adds a **defensive runtime guard** in `FpfRuntime.search()` to cap the number of query tokens processed per request, and introduces unit tests (`tool-input-caps.test.ts`) to lock in the new validation limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70cdee26664273030054ceff76d52f125e95d296. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->