### PR TITLE
fix(runtime): make compiler-fingerprint check work in bundled hosting

### DIFF
--- a/src/composition/runtime.ts
+++ b/src/composition/runtime.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { FpfRuntime } from '../runtime/runtime.js';
 import {
   createSynthesizerFromConfig,
@@ -12,6 +14,12 @@ import {
   getRuntimeObservability,
   getRuntimeObservabilitySummary,
 } from '../adapters/infra/observability/runtime-observability.js';
+import { publishCurrentManifestSchema } from '../build/published-surface.js';
+import {
+  HOSTED_STAGED_MANIFEST_PATH,
+  PUBLISHED_MANIFEST_PATH,
+} from '../core/constants.js';
+import { resolveRuntimePath } from '../runtime/path-resolution.js';
 
 export interface RuntimeComposition {
   runtime: FpfRuntime;
@@ -26,6 +34,7 @@ export function createConfiguredRuntime(
   const observabilityConfig = parseObservabilityConfig(env);
   const lmStudioConfig = parseLmStudioConfig(env);
   const observability = getRuntimeObservability(observabilityConfig);
+  const compilerFingerprint = readPublishedCompilerFingerprint();
 
   return {
     runtime: new FpfRuntime({
@@ -34,6 +43,7 @@ export function createConfiguredRuntime(
       artifactSeedDir: runtimeConfig.artifactSeedDir,
       maxSessions: runtimeConfig.maxSessions,
       persistSessionCache: runtimeConfig.persistSessionCache,
+      compilerFingerprint,
       synthesizer: lmStudioConfig.enabled
         ? createSynthesizerFromConfig({
             baseUrl: lmStudioConfig.baseUrl,
@@ -54,4 +64,30 @@ export function createConfiguredRuntime(
       timeoutMs: lmStudioConfig.timeoutMs,
     },
   };
+}
+
+// In bundled environments (Vercel function) the compiler TypeScript source
+// isn't on disk, so the runtime's default `computeCompilerFingerprint()` path
+// silently returns undefined and compiler-drift detection becomes a no-op. The
+// staged or published manifest already records the correct fingerprint at
+// build time — read it once at composition and pass it through so the runtime
+// can refuse to serve a snapshot that was compiled by a different version.
+function readPublishedCompilerFingerprint(): string | undefined {
+  for (const candidate of [HOSTED_STAGED_MANIFEST_PATH, PUBLISHED_MANIFEST_PATH]) {
+    const resolved = resolveRuntimePath(candidate, { kind: 'file' });
+    if (!resolved.existed) {
+      continue;
+    }
+    try {
+      const parsed = publishCurrentManifestSchema.parse(
+        JSON.parse(readFileSync(resolved.path, 'utf8')),
+      );
+      return parsed.compilerFingerprint;
+    } catch {
+      // Manifest exists but is malformed — fall through to the next candidate
+      // rather than crashing composition; the runtime will still rebuild from
+      // source if it can derive the fingerprint that way.
+    }
+  }
+  return undefined;
 }

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -50,6 +50,13 @@ export interface FpfRuntimeOptions {
   maxSessions?: number;
   persistSessionCache?: boolean;
   observability?: RuntimeStatus['observability'];
+  /**
+   * Pre-computed compiler fingerprint to use instead of attempting to derive
+   * one from on-disk source files. Required in bundled environments (e.g. the
+   * Vercel function) where the compiler source is not on disk and the default
+   * `computeCompilerFingerprint()` path would otherwise fail silently.
+   */
+  compilerFingerprint?: string;
 }
 
 interface SourceFingerprint {
@@ -65,6 +72,8 @@ export class FpfRuntime {
   private readonly synthesizer?: LocalAnswerSynthesizer;
   private readonly sessionCache: SessionCache;
   private readonly observabilitySummary: RuntimeStatus['observability'];
+  private readonly configuredCompilerFingerprint?: string;
+  private snapshotIntegrityVerified = false;
   private cachedSnapshot?: Snapshot;
   private cachedAudit?: BuildAudit;
   private cachedSourceFingerprint?: SourceFingerprint;
@@ -106,6 +115,7 @@ export class FpfRuntime {
       }
     }
     this.synthesizer = options.synthesizer;
+    this.configuredCompilerFingerprint = options.compilerFingerprint;
     this.observabilitySummary =
       options.observability ?? {
         configured: false,
@@ -150,7 +160,7 @@ export class FpfRuntime {
     const currentCompilerFingerprint =
       typeof options === 'object' && Object.hasOwn(options, 'compilerFingerprint')
         ? options.compilerFingerprint
-        : await readCurrentCompilerFingerprint();
+        : await this.readCurrentCompilerFingerprint();
     await this.loadSessionCacheOnce(currentSourceHash);
     const existingSnapshot = await this.loadSnapshot();
     const staleSnapshotShape = existingSnapshot
@@ -279,7 +289,7 @@ export class FpfRuntime {
 
   async status(): Promise<RuntimeStatus> {
     let existingSnapshot = await this.loadSnapshot();
-    const currentCompilerFingerprint = await readCurrentCompilerFingerprint();
+    const currentCompilerFingerprint = await this.readCurrentCompilerFingerprint();
     if (!existingSnapshot || snapshotNeedsRebuild(existingSnapshot, currentCompilerFingerprint)) {
       await this.refresh(false, { compilerFingerprint: currentCompilerFingerprint }).catch(
         (error) => {
@@ -495,6 +505,13 @@ export class FpfRuntime {
     return this.readJsonFile(this.artifactPaths.indexingView);
   }
 
+  private async readCurrentCompilerFingerprint(): Promise<string | undefined> {
+    if (this.configuredCompilerFingerprint) {
+      return this.configuredCompilerFingerprint;
+    }
+    return readSourceCompilerFingerprint();
+  }
+
   private async requireSnapshot(): Promise<Snapshot> {
     if (this.cachedSnapshot && !snapshotNeedsRebuild(this.cachedSnapshot)) {
       return this.cachedSnapshot;
@@ -503,8 +520,25 @@ export class FpfRuntime {
     if (!snapshot) {
       throw new Error('Compiled snapshot is missing after refresh.');
     }
+    this.assertSnapshotMatchesConfiguredFingerprint(snapshot);
     this.cachedSnapshot = snapshot;
     return snapshot;
+  }
+
+  private assertSnapshotMatchesConfiguredFingerprint(snapshot: Snapshot): void {
+    if (
+      this.snapshotIntegrityVerified ||
+      !this.configuredCompilerFingerprint ||
+      !snapshot.compilerFingerprint
+    ) {
+      return;
+    }
+    if (snapshot.compilerFingerprint !== this.configuredCompilerFingerprint) {
+      throw new Error(
+        `Compiled snapshot compilerFingerprint ${snapshot.compilerFingerprint} does not match the configured fingerprint ${this.configuredCompilerFingerprint}. Refusing to serve a snapshot built by a different compiler.`,
+      );
+    }
+    this.snapshotIntegrityVerified = true;
   }
 
   private rememberSnapshot(
@@ -653,7 +687,7 @@ function refreshReasonForRebuild(params: {
   throw new Error('refreshReasonForRebuild called without a rebuild reason');
 }
 
-async function readCurrentCompilerFingerprint(): Promise<string | undefined> {
+async function readSourceCompilerFingerprint(): Promise<string | undefined> {
   try {
     return await computeCompilerFingerprint();
   } catch {


### PR DESCRIPTION
## What

Wire the staged manifest's `compilerFingerprint` through to the runtime so the hosted MCP can detect compiler drift, and add a one-shot snapshot integrity check that turns a silently-served wrong snapshot into a loud startup error.

## Why

In the Vercel function bundle, the compiler TypeScript source isn't on disk, so `computeCompilerFingerprint()` (which derives the fingerprint from `src/runtime/compiler.ts` etc.) throws every time and the wrapper swallows the error to `undefined`. The downstream effect: `snapshotCompilerFingerprintChanged()` always returns `false` on hosted, and the compiler-drift check is a silent no-op. If a snapshot baked by a different compiler version ever ends up in `.vercel/output`, the hosted runtime would happily serve it.

The staged manifest at `HOSTED_STAGED_MANIFEST_PATH` already records the correct fingerprint at build time (it's how the publish-validation gate works). Reading it once at composition is cheap, makes the check actually run, and gives us a free integrity check to assert the on-disk snapshot matches.

## Type

- `fix` — bug fix (silent adaptiveness regression on hosted)

## Changes

- `src/runtime/runtime.ts`:
  - `FpfRuntimeOptions` accepts `compilerFingerprint?: string`.
  - New private `readCurrentCompilerFingerprint()` method prefers the configured value, falls back to source-derivation otherwise.
  - Renamed the free function to `readSourceCompilerFingerprint` to match its actual role.
  - Added `assertSnapshotMatchesConfiguredFingerprint()` — fired once on first `requireSnapshot()`, throws clearly on mismatch instead of serving the wrong snapshot.
- `src/composition/runtime.ts`: read `HOSTED_STAGED_MANIFEST_PATH` (or `PUBLISHED_MANIFEST_PATH`) at composition, parse it through `publishCurrentManifestSchema`, and pass `compilerFingerprint` into `FpfRuntime`. Malformed manifests fall back to source-derivation rather than crashing composition.

## Validation

- `bun run lint` passes locally: 0 lint errors, 0 type errors, 0 warnings (129 files).
- `bun run check` passes locally.
- `bun run test` passes locally: 288 tests passed, 0 failed.
- No new warnings introduced.
- `bun run build` succeeds (if runtime/server code touched): not separately exercised here; covered by typecheck and the existing test suite.
- `bun run docs:build` succeeds (if docs touched): not applicable.
- Relevant docs updated (README, docs/, inline JSDoc if applicable): inline JSDoc explains `FpfRuntimeOptions.compilerFingerprint` and the composition helper; commit body explains the bundled-hosting motivation.
- End-to-end verification command + output excerpt: behavior is observable on `/api/fpf/status` (which already verifies manifest ↔ snapshot fingerprint consistency); production verification will land with the deploy.
- Caveats or blocker: in-bundle code paths now refuse to serve a snapshot whose `compilerFingerprint` differs from the manifest's. That's the desired behavior, but if a stale-but-equivalent snapshot is ever staged on purpose (it shouldn't be), the function will throw on first request rather than silently serving stale content.

## TPR fast-track

- [ ] Enable TPR review/merge timer

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Claude Code (Opus 4.7) |
| Session | Hosted MCP / website / security exploration |
| Prompt  | Investigate and ship adaptiveness/integrity fixes |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime snapshot selection/validation by wiring a build-time `compilerFingerprint` into `FpfRuntime` and throwing when a bundled snapshot’s fingerprint mismatches, which could surface as new startup/request failures if staged artifacts are inconsistent.
> 
> **Overview**
> Fixes compiler-drift detection in bundled/serverless deployments by **reading `compilerFingerprint` from the hosted/published manifest at composition time** and passing it into `FpfRuntime`.
> 
> Updates the runtime to **prefer the configured fingerprint over source-derived fingerprinting** and adds a **one-time integrity assertion** that refuses to serve a snapshot whose `compilerFingerprint` doesn’t match the configured value (instead of silently serving a potentially incompatible snapshot).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d29d1e4aa8dd19b5221e9b4f7e6f000a5f933496. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->