### PR TITLE
perf(hosted): cache origin pages at edge + add security headers

### DIFF
--- a/src/adapters/hosted/home-page.ts
+++ b/src/adapters/hosted/home-page.ts
@@ -474,7 +474,7 @@ export function renderHostedHomePage(): string {
       </section>
 
       <footer>
-        Wiki reference: <a href="https://venikman.github.io/fpf-memory/connect-mcp">Connect MCP</a>.
+        Connect another client: <a href="/connect-mcp">/connect-mcp</a>.
         Source: <a href="https://github.com/venikman/fpf-memory">github.com/venikman/fpf-memory</a>.
       </footer>
     </main>

--- a/src/composition/hosted.ts
+++ b/src/composition/hosted.ts
@@ -27,8 +27,32 @@ export function createHostedComposition(env: NodeJS.ProcessEnv) {
       : mcpComposition.fpfMemoryPublic;
 
   const app = new Hono();
+
+  // Apply baseline security headers to every response. Values are conservative
+  // for an unauthenticated public docs endpoint: the MCP API is not credentialed
+  // and the home page is fully self-contained, so DENY/no-referrer don't break
+  // legitimate flows. Per-response Cache-Control overrides are still applied
+  // on routes below.
+  app.use('*', async (c, next) => {
+    await next();
+    c.header('X-Content-Type-Options', 'nosniff');
+    c.header('Referrer-Policy', 'no-referrer');
+    c.header('X-Frame-Options', 'DENY');
+    c.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+  });
+
   for (const route of HOSTED_HOME_ROUTES) {
-    app.get(route, (c) => c.html(renderHostedHomePage()));
+    app.get(route, (c) => {
+      // Static HTML, regenerated only on deploy. Let the CDN serve it directly
+      // from the edge so the first visitor in each region doesn't pay the
+      // function cold-start tax. Vercel's deploy pipeline invalidates the
+      // cache on each new build.
+      c.header(
+        'Cache-Control',
+        'public, max-age=300, s-maxage=86400, stale-while-revalidate=604800',
+      );
+      return c.html(renderHostedHomePage());
+    });
   }
   app.get(HOSTED_FPF_STATUS_ROUTE, async (c) => {
     try {

--- a/tests/hosted-home-page.test.ts
+++ b/tests/hosted-home-page.test.ts
@@ -56,4 +56,41 @@ describe('hosted home page', () => {
     expect(html).toContain('<title>fpf-memory MCP</title>');
     expect(html).toContain(HOSTED_MCP_ENDPOINT);
   });
+
+  it('caches the home page at the edge and emits baseline security headers', async () => {
+    const { app } = createHostedComposition({
+      ...process.env,
+      PORT: '0',
+    } as NodeJS.ProcessEnv);
+
+    const response = await app.request('/');
+
+    expect(response.status).toBe(200);
+    const cacheControl = response.headers.get('Cache-Control') ?? '';
+    expect(cacheControl).toContain('public');
+    expect(cacheControl).toContain('s-maxage=86400');
+    expect(cacheControl).toContain('stale-while-revalidate=604800');
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(response.headers.get('Referrer-Policy')).toBe('no-referrer');
+    expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+    expect(response.headers.get('Strict-Transport-Security')).toContain('max-age=31536000');
+  });
+
+  it('keeps Cache-Control: no-store on the dynamic /api/fpf/status route', async () => {
+    const { app } = createHostedComposition({
+      ...process.env,
+      PORT: '0',
+    } as NodeJS.ProcessEnv);
+
+    const response = await app.request('/api/fpf/status');
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    // The freshness endpoint should still get the baseline security headers.
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+  });
+
+  it('points the footer at the same-origin connect page', () => {
+    const html = renderHostedHomePage();
+    expect(html).not.toContain('venikman.github.io/fpf-memory/connect-mcp');
+    expect(html).toContain('href="/connect-mcp"');
+  });
 });


### PR DESCRIPTION
## What

Three small, related improvements to the public Vercel origin (`fpf-memory-mcp-vercel-origin.vercel.app`):

1. **Edge-cache the home page**, so the CDN serves it from the region edge instead of every visitor paying a function cold-start (~600ms).
2. **Add baseline security headers** to every hosted response.
3. **Fix the home-page footer**, which previously linked the user off-site to `venikman.github.io/fpf-memory/connect-mcp` even though `/connect-mcp` is served by the same origin.

## Why

The home page is fully self-contained static HTML that only changes on deploy. Today it ships with `Cache-Control: public, max-age=0, must-revalidate` and `x-vercel-cache: MISS`, so every visit pays an origin round-trip and a cold-start tax. Setting `s-maxage=86400, stale-while-revalidate=604800` lets Vercel's edge serve it directly; the deploy pipeline invalidates the cache on each new build, so users always see the latest after a release.

The endpoint is unauthenticated and public-facing, but it currently sets no `nosniff`, `Referrer-Policy`, `X-Frame-Options`, or `HSTS`. None of those are exotic and none of them break legitimate flows for an MCP/docs surface (the home page is fully self-contained — DENY iframe + no-referrer is correct). Adding them is hygiene that costs nothing.

The off-site footer link is a UX papercut: `/connect-mcp` is the same page you're already on, served from the same origin. Linking to a GitHub Pages URL that may or may not stay in sync is a confusing detour for first-time visitors trying to plug FPF into their AI client.

## Type

- `perf` — performance / hygiene

## Changes

- `src/composition/hosted.ts`:
  - New `app.use('*', …)` middleware sets `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, and `Strict-Transport-Security` on every response.
  - Home routes set `Cache-Control: public, max-age=300, s-maxage=86400, stale-while-revalidate=604800`.
  - The `/api/fpf/status` route keeps its existing `Cache-Control: no-store` override (it's freshness data and shouldn't be cached).
- `src/adapters/hosted/home-page.ts`: footer link "Wiki reference: `…github.io/fpf-memory/connect-mcp`" → "Connect another client: `/connect-mcp`".
- `tests/hosted-home-page.test.ts`: three new assertions covering the cache header, the security headers, the `no-store` override on `/api/fpf/status`, and the same-origin footer.

## Validation

- `bun run lint` passes locally: 0 lint errors, 0 type errors, 0 warnings (130 files).
- `bun run check` passes locally.
- `bun run test` passes locally: 300 tests passed, 0 failed (297 prior + 3 new in this PR).
- No new warnings introduced.
- `bun run build` succeeds (if runtime/server code touched): not separately exercised; covered by typecheck and the existing test suite.
- `bun run docs:build` succeeds (if docs touched): not applicable.
- Relevant docs updated (README, docs/, inline JSDoc if applicable): inline comments in `hosted.ts` explain the cache and security-header reasoning.
- End-to-end verification command + output excerpt: header behavior is asserted directly via `app.request('/')` in tests; cache will be observable via `x-vercel-cache: HIT` after the production deploy.
- Caveats or blocker: cache lifetime assumes deploys invalidate Vercel's CDN automatically (they do). If a header value needs adjusting, the middleware is one place; no per-route changes required.

## TPR fast-track

- [ ] Enable TPR review/merge timer

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Claude Code (Opus 4.7) |
| Session | Hosted MCP / website / security exploration |
| Prompt  | Investigate and ship hosted speed/security improvements |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP caching and security headers for all hosted routes, which can affect client behavior (embedding/iframes, referrers) and cache freshness if misconfigured. Logic is small and covered by new tests, but it impacts every response on the hosted surface.
> 
> **Overview**
> Improves the hosted origin by **edge-caching the static home/connect page** via an explicit `Cache-Control` policy (`s-maxage` + `stale-while-revalidate`) to reduce cold-start/origin hits.
> 
> Adds **baseline security headers** (`nosniff`, `no-referrer`, `X-Frame-Options: DENY`, and HSTS) across all hosted responses while preserving `Cache-Control: no-store` for the dynamic `/api/fpf/status` endpoint.
> 
> Updates the home page footer to link to the same-origin `/connect-mcp` page instead of the external GitHub Pages URL, and extends tests to assert the new cache/security headers and footer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abb59ff7dcd75db3e8512e35875aa8419f77cf26. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->