### PR TITLE
fix(runtime): restore route extraction after spec vocabulary rename

### DIFF
--- a/published/current/manifest.json
+++ b/published/current/manifest.json
@@ -1,10 +1,10 @@
 {
   "channel": "latest-published",
   "sourceHash": "sha256:c0301013b2013260608b6cf61e512e87a9bc76e16bc371abd6630b4ac1e6aaa5",
-  "compilerFingerprint": "sha256:d4c4b2448a4eb84498a0f41989c51134a8df25f575ec9e985ef7865dee1541bc",
+  "compilerFingerprint": "sha256:47785270db5aad42c9eb464babb3eb050f59e32e2d58bfd30da5ecf8ec0503d4",
   "upstreamRef": "fbe6e291a53bef8136d76509ccd8e10e263ea0b7",
   "specPath": "published/current/FPF-Spec.md",
   "snapshotPath": "published/current/fpf-index/snapshot.json",
   "specBytes": 6392758,
-  "publishedAt": "2026-05-09T15:13:28.882Z"
+  "publishedAt": "2026-05-09T22:14:40.873Z"
 }

--- a/src/docs/generated-search-id-registry.ts
+++ b/src/docs/generated-search-id-registry.ts
@@ -1242,5 +1242,71 @@ export const SEARCH_ID_REGISTRY: SearchIdRegistry = {
       "staticPath": "/generated/patterns/K.3"
     }
   ],
-  "routes": []
+  "routes": [
+    {
+      "slug": "boundary-unpacking",
+      "title": "boundary unpacking",
+      "staticPath": "/generated/routes/route_boundary-unpacking"
+    },
+    {
+      "slug": "boundary-unpacking-claim-routing",
+      "title": "Boundary unpacking / claim routing",
+      "staticPath": "/generated/routes/route_boundary-unpacking-claim-routing"
+    },
+    {
+      "slug": "causal-use-counterfactual-support-repair",
+      "title": "Causal-use / counterfactual-support repair",
+      "staticPath": "/generated/routes/route_causal-use-counterfactual-support-repair"
+    },
+    {
+      "slug": "generator-sota-portfolio-kit",
+      "title": "Generator / SoTA / portfolio kit",
+      "staticPath": "/generated/routes/route_generator-sota-portfolio-kit"
+    },
+    {
+      "slug": "lawful-comparison-pool-selection-selected-set-publication",
+      "title": "lawful comparison / pool / selection / selected-set publication",
+      "staticPath": "/generated/routes/route_lawful-comparison-pool-selection-selected-set-publication"
+    },
+    {
+      "slug": "partly-said-language-state-discovery",
+      "title": "partly-said / language-state discovery",
+      "staticPath": "/generated/routes/route_partly-said-language-state-discovery"
+    },
+    {
+      "slug": "project-alignment",
+      "title": "project alignment",
+      "staticPath": "/generated/routes/route_project-alignment"
+    },
+    {
+      "slug": "reusable-generator-sota-portfolio-kit",
+      "title": "reusable generator / SoTA / portfolio kit",
+      "staticPath": "/generated/routes/route_reusable-generator-sota-portfolio-kit"
+    },
+    {
+      "slug": "same-entity-rewrite-explanation-comparative-reading",
+      "title": "Same-entity rewrite / explanation / comparative reading",
+      "staticPath": "/generated/routes/route_same-entity-rewrite-explanation-comparative-reading"
+    },
+    {
+      "slug": "same-entity-rewrite-explanation-representation-change-repair-or-bounded-comparative-reading",
+      "title": "same-entity rewrite, explanation, representation change, repair, or bounded comparative reading",
+      "staticPath": "/generated/routes/route_same-entity-rewrite-explanation-representation-change-repair-or-bounded-comparative-reading"
+    },
+    {
+      "slug": "temporal-claim-adequacy-under-effort-window-resistance",
+      "title": "Temporal claim adequacy under effort/window/resistance",
+      "staticPath": "/generated/routes/route_temporal-claim-adequacy-under-effort-window-resistance"
+    },
+    {
+      "slug": "why",
+      "title": "why",
+      "staticPath": "/generated/routes/route_why"
+    },
+    {
+      "slug": "writing-or-reviewing-patterns",
+      "title": "writing or reviewing patterns",
+      "staticPath": "/generated/routes/route_writing-or-reviewing-patterns"
+    }
+  ]
 };

--- a/src/runtime/graph-compiler.ts
+++ b/src/runtime/graph-compiler.ts
@@ -309,39 +309,24 @@ function parsePrefaceRoutes(
 ): RouteRecord[] {
   const routes: RouteRecord[] = [];
   let inPrefaceRouteList = false;
+  let currentBullet: string | null = null;
 
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (trimmed === '**Where to start**') {
-      inPrefaceRouteList = true;
-      continue;
+  const finalizeBullet = (bullet: string | null): void => {
+    if (!bullet) return;
+    // Accept either legacy ("start with") or current ("inspect") verbs.
+    if (!bullet.includes('start with') && !bullet.includes('inspect')) {
+      return;
     }
-    if (!inPrefaceRouteList) {
-      continue;
-    }
-    if (trimmed.startsWith('Everything in the Core')) {
-      break;
-    }
-    if (!trimmed.startsWith('- ')) {
-      continue;
-    }
-    if (!trimmed.includes('start with')) {
-      continue;
-    }
-
-    const routeName = derivePrefaceRouteName(trimmed);
-    if (!routeName) {
-      continue;
-    }
-
+    const routeName = derivePrefaceRouteName(bullet);
+    if (!routeName) return;
     const id = routeKey(routeName);
-    const orderedIds = extractOrderedIds(trimmed);
-    const landingIds = extractLandingIds(trimmed);
-    const allIds = extractIds(trimmed);
+    const orderedIds = extractOrderedIds(bullet);
+    const landingIds = extractLandingIds(bullet);
+    const allIds = extractIds(bullet);
     routes.push({
       id,
       name: routeName,
-      description: cleanMarkdown(trimmed.replace(/^- /, '')),
+      description: cleanMarkdown(bullet.replace(/^- /, '')),
       firstHonestBurden: undefined,
       orderedIds,
       optionalIds: allIds.filter(
@@ -353,21 +338,75 @@ function parsePrefaceRoutes(
       reroutes: [],
       citations: [PREFACE_ROUTE_CITATION],
       anchorIds: anchorMap[PREFACE_ROUTE_CITATION] ? [PREFACE_ROUTE_CITATION] : [],
-      searchableText: cleanMarkdown(trimmed),
+      searchableText: cleanMarkdown(bullet),
       constraints: [],
     });
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === '**Where to start**') {
+      inPrefaceRouteList = true;
+      continue;
+    }
+    if (!inPrefaceRouteList) {
+      continue;
+    }
+    if (trimmed.startsWith('Everything in the Core')) {
+      finalizeBullet(currentBullet);
+      currentBullet = null;
+      break;
+    }
+
+    if (trimmed.startsWith('- ')) {
+      // New bullet — finalize the previous one (if any) and start collecting.
+      finalizeBullet(currentBullet);
+      currentBullet = trimmed;
+      continue;
+    }
+
+    if (currentBullet !== null) {
+      // Indented continuation lines belong to the current bullet. The spec
+      // wraps long preface bullets across multiple lines (e.g. for "project
+      // alignment"), so we need to glue them back together before scanning
+      // for the verb / IDs.
+      if (line.startsWith(' ') || line.startsWith('\t')) {
+        currentBullet = `${currentBullet} ${trimmed}`;
+        continue;
+      }
+      // Blank line or non-indented prose: bullet ended.
+      finalizeBullet(currentBullet);
+      currentBullet = null;
+    }
   }
+
+  // Tail bullet, if the section runs to EOF without the "Everything in the
+  // Core" terminator.
+  finalizeBullet(currentBullet);
 
   return routes;
 }
+
+// Either heading is valid: the spec was renamed from "Route Index" to
+// "Neighborhood Index" but the table shape (≥6 columns, name in cell 0,
+// burden in cell 1, candidates in cell 2, description in cell 3) is unchanged.
+const J4_HEADING_PREFIXES = [
+  '## J.4 - First Practical Entry Route Index',
+  '## J.4 - First Practical Entry Neighborhood Index',
+];
+// Header-row first cells we should skip — both the old "Route" header and
+// the new "Entry neighborhood" header. Compared via `normalizeForLookup`
+// so casing/whitespace differences don't leak through.
+const J4_HEADER_CELL_VALUES = new Set(['route', 'entry neighborhood']);
 
 function parseJ4Routes(
   lines: string[],
   anchorMap: Record<string, AnchorRef>,
 ): RouteRecord[] {
-  const headingIndex = lines.findIndex((line) =>
-    line.trim().startsWith('## J.4 - First Practical Entry Route Index'),
-  );
+  const headingIndex = lines.findIndex((line) => {
+    const trimmed = line.trim();
+    return J4_HEADING_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
+  });
   if (headingIndex < 0) {
     return [];
   }
@@ -396,7 +435,7 @@ function parseJ4Routes(
     if (cells.length < 6 || isMarkdownSeparatorRow(cells)) {
       continue;
     }
-    if (normalizeForLookup(cells[0] ?? '') === 'route') {
+    if (J4_HEADER_CELL_VALUES.has(normalizeForLookup(cells[0] ?? ''))) {
       continue;
     }
     const name = normalizeLabel(cells[0] ?? '');

--- a/src/runtime/source-parser.ts
+++ b/src/runtime/source-parser.ts
@@ -788,18 +788,37 @@ export function derivePrefaceRouteName(line: string): string | undefined {
   return normalizeLabel(candidate);
 }
 
+// Recent FPF spec revisions renamed the preface verbs ("start with" →
+// "inspect") and route-table heading ("Route Index" → "Neighborhood Index").
+// The compiler accepts both wordings so route extraction survives spec
+// vocabulary churn. If the upstream phrasing changes again, extend these
+// arrays rather than swapping them — the older form may still appear in
+// archived snapshots that get replayed for drift checks.
+const ORDERED_LIST_VERBS = ['inspect', 'start with'];
+const ADDITIONAL_LIST_VERBS = ['Consider', 'Land on'];
+
+function findFirstIndex(line: string, needles: string[]): number {
+  let earliest = -1;
+  for (const needle of needles) {
+    const index = line.indexOf(needle);
+    if (index < 0) continue;
+    if (earliest < 0 || index < earliest) earliest = index;
+  }
+  return earliest;
+}
+
 export function extractOrderedIds(line: string): string[] {
-  const startWithIndex = line.indexOf('start with');
-  if (startWithIndex < 0) {
+  const startIndex = findFirstIndex(line, ORDERED_LIST_VERBS);
+  if (startIndex < 0) {
     return [];
   }
-  const endIndex = line.indexOf('Land on');
-  const segment = line.slice(startWithIndex, endIndex > 0 ? endIndex : undefined);
+  const endIndex = findFirstIndex(line, ADDITIONAL_LIST_VERBS);
+  const segment = line.slice(startIndex, endIndex > startIndex ? endIndex : undefined);
   return extractIds(segment);
 }
 
 export function extractLandingIds(line: string): string[] {
-  const landingIndex = line.indexOf('Land on');
+  const landingIndex = findFirstIndex(line, ADDITIONAL_LIST_VERBS);
   if (landingIndex < 0) {
     return [];
   }


### PR DESCRIPTION
## What

Fix the route parser so it extracts routes from the current published FPF spec. Three coordinated changes, plus a regenerated published snapshot.

## Why

Recent upstream spec revisions renamed two markers the route parser keys off:

- **Preface bullets:** verb switched from \`"start with"\` → \`"inspect"\`, and the follow-on list verb from \`"Land on"\` → \`"Consider"\`.
- **J.4 heading:** \`"## J.4 - First Practical Entry Route Index"\` → \`"## J.4 - First Practical Entry Neighborhood Index"\`, and the first table column header from \`"Route"\` → \`"Entry neighborhood"\`.

The compiler matched both with exact \`startsWith\` / \`indexOf\` checks, so every snapshot since the rename reported \`parsedRoutes: 0\`. The Route Catalog page on the docs site rendered "Generated pages: 0" (visible in the screenshot you shared), and queries that should resolve to \`route:project-alignment\` had no route node to score against — that's the long-standing \`bun run smoke:mcp:http\` failure on \`query_fpf_spec\` we've been carrying.

A separate but compounding bug: the new spec wraps long preface bullets across multiple lines (e.g. for "project alignment"). The previous loop scanned line-by-line, only ever saw the first line of a wrapped bullet, and dropped the part containing the verb and pattern IDs.

## Type

- \`fix\` — silent regression caused by external spec churn

## Changes

- \`src/runtime/source-parser.ts\`: \`extractOrderedIds\` and \`extractLandingIds\` accept either verb pair via shared \`ORDERED_LIST_VERBS\` / \`ADDITIONAL_LIST_VERBS\` constants. Future renames are one-line additions.
- \`src/runtime/graph-compiler.ts\`:
  - \`parseJ4Routes\` accepts either heading prefix and either header-cell label (kept in \`J4_HEADING_PREFIXES\` / \`J4_HEADER_CELL_VALUES\`).
  - \`parsePrefaceRoutes\` joins indented continuation lines into a single bullet before scanning. The bullet collector finalises on the next bullet, blank line, or end of the \"Where to start\" section.
- \`published/current/fpf-index/snapshot.json\` and \`published/current/manifest.json\`: regenerated via \`FPF_PUBLISH_SOURCE_PATH=published/current/FPF-Spec.md FPF_UPSTREAM_REF=fbe6e291a53bef8136d76509ccd8e10e263ea0b7 bun run publish:current\` so the staged seed matches the new compilerFingerprint.
- \`src/docs/generated-search-id-registry.ts\`: picks up the 13 newly-extracted route slugs.

## Validation

- \`bun run lint\` passes locally: 0 lint errors, 0 type errors, 0 warnings (130 files).
- \`bun run check\` passes locally.
- \`bun run test\` passes locally: **301 tests passed**, 0 failed. Before this fix, F01–F05 in \`tests/fpf-spec-runtime.test.ts\` / \`tests/hosted-status.test.ts\` / \`tests/mcp-server.test.ts\` were failing against the stale snapshot.
- No new warnings introduced.
- \`bun run build\` succeeds: not separately exercised; covered by typecheck + tests.
- \`bun run docs:build\` succeeds: exercised indirectly via the existing rspress-build test in the suite.
- Relevant docs updated (README, docs/, inline JSDoc if applicable): inline comments document the parser tolerance and the bullet-collection logic.
- End-to-end verification command + output excerpt:

  \`\`\`
  routes: 13
  project-alignment ordered: [ "A.1.1", "A.15", "A.15.2", "A.15.3", "B.5.1" ]
  project-alignment optional/landing: [] [ "F.11", "F.9", "F.17" ]
  \`\`\`

  And the bundled smoke (\`bun run smoke:mcp:http\`) will satisfy its \`query_fpf_spec\` assertion that \`route:project-alignment\` is in the returned IDs once this is deployed.
- Caveats or blocker: the snapshot diff is large (~93k lines) because it serializes the full snapshot JSON. That's expected given the compiler change adds 13 new route nodes plus their relations to the snapshot; review the parser logic in \`graph-compiler.ts\` and \`source-parser.ts\`, not the snapshot bytes.

## TPR fast-track

- [ ] Enable TPR review/merge timer

## Boundary check

- Runtime remains a single spec file via \`FPF_SPEC_SOURCE_PATH\` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in \`src/mcp/tool-contracts.ts\`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Claude Code (Opus 4.7) |
| Session | Routes:0 investigation triggered by user screenshot |
| Prompt  | Investigate Route Catalog showing 0 routes; fix end-to-end |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the runtime spec parser/compiler to tolerate upstream spec wording/format changes; mistakes here could silently change which routes/relations get indexed and shipped in the published snapshot.
> 
> **Overview**
> Restores route extraction from the FPF spec by making the compiler tolerant to upstream vocabulary/format changes in the preface route list and the `J.4` route table.
> 
> `extractOrderedIds`/`extractLandingIds` now accept multiple verb variants, `parsePrefaceRoutes` stitches wrapped multi-line bullets before scanning for IDs, and `parseJ4Routes` matches either `J.4` heading/header wording. Regenerates the published `manifest.json`/snapshot and updates the docs `SEARCH_ID_REGISTRY` to include the newly extracted route slugs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ce8b3dd84ae36b694e12c84373f3b81ba5da383. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->