### PR TITLE
feat(docs): vim-style keyboard navigation with persistent toggle

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -172,6 +172,63 @@ observer.observe(document.body||document.documentElement,{childList:true,subtree
 window.addEventListener('resize',fixSidebarInert);
 window.addEventListener('transitionend',fixSidebarInert);
 })();</script>`,
+    // Vim-style keyboard navigation. Bare keys, never with Cmd/Ctrl/Alt,
+    // and ignored while focus is in any input. Emitted as a raw-string
+    // <script> entry like the existing accessibility shim — rspress's
+    // 3-tuple `['script', attrs, body]` shape isn't supported by the
+    // head config type, so a string is the only path for inline scripts.
+    //
+    // PR #105's earlier attempt got its opening <script> tag stripped
+    // somewhere in the head emit pipeline. The smoking gun was almost
+    // certainly an `el.innerHTML = '<...>'` literal HTML inside the JS
+    // string body, which an over-eager HTML pre-processor parsed as real
+    // tags. This rewrite uses createElement / setAttribute / textContent
+    // exclusively — no embedded HTML markup inside the JS source — so
+    // there's nothing for the pre-processor to misread, and the new
+    // `tests/e2e/keybindings.spec.ts` would fail loud if it regresses.
+    //
+    // Bindings:
+    //   h / l        previous / next page (clicks .rp-prev-next-page__prev/next)
+    //   j / k        scroll down / up (80px steps)
+    //   g g          jump to top of page (smooth scroll)
+    //   G            jump to bottom (smooth scroll)
+    //   /            focus search (clicks the .rp-search-button trigger)
+    //   ?            toggle help overlay
+    //   Esc          close help overlay (always works, even when toggle is off)
+    //
+    // The Enabled/Disabled toggle lives inside the help overlay and persists
+    // in localStorage under "fpf:vim-keys" (default "1" = on). When the
+    // toggle is off, only ? and Esc fire — every navigation key is dormant.
+    `<script>(function(){
+var STORE_KEY='fpf:vim-keys';
+function readEnabled(){try{var v=localStorage.getItem(STORE_KEY);return v===null?true:v==='1';}catch(e){return true;}}
+function writeEnabled(on){try{localStorage.setItem(STORE_KEY,on?'1':'0');}catch(e){}}
+var enabled=readEnabled();
+function isEditable(el){if(!el)return false;var t=el.tagName;if(t==='INPUT'||t==='TEXTAREA'||t==='SELECT')return true;if(el.isContentEditable)return true;return false;}
+function focusSearch(){var btn=document.querySelector('.rp-search-button');if(btn){btn.click();requestAnimationFrame(function(){var input=document.querySelector('[role="dialog"] input, .rp-search-input, input[placeholder*="earch"]');if(input)input.focus();});}}
+function clickNav(direction){var sel=direction==='prev'?'.rp-prev-next-page__prev':'.rp-prev-next-page__next';var link=document.querySelector(sel);if(link){link.click();return true;}return false;}
+var HELP_ID='fpf-keyhelp';
+function hideHelp(){var el=document.getElementById(HELP_ID);if(el)el.remove();}
+function renderToggleButton(){var btn=document.createElement('button');btn.id='fpf-keyhelp-toggle';btn.type='button';btn.setAttribute('aria-pressed',enabled?'true':'false');btn.textContent=enabled?'Enabled':'Disabled';btn.style.cssText='appearance:none;cursor:pointer;font:inherit;padding:6px 12px;border-radius:6px;border:1px solid var(--rp-c-divider,#ccc);background:'+(enabled?'var(--rp-c-brand,#2466ff)':'var(--rp-c-bg-soft,#f4f4f4)')+';color:'+(enabled?'#fff':'var(--rp-c-text-1,#111)');btn.addEventListener('click',function(){enabled=!enabled;writeEnabled(enabled);btn.setAttribute('aria-pressed',enabled?'true':'false');btn.textContent=enabled?'Enabled':'Disabled';btn.style.background=enabled?'var(--rp-c-brand,#2466ff)':'var(--rp-c-bg-soft,#f4f4f4)';btn.style.color=enabled?'#fff':'var(--rp-c-text-1,#111)';});return btn;}
+function showHelp(){if(document.getElementById(HELP_ID)){hideHelp();return;}var rows=[['h','previous page'],['l','next page'],['j','scroll down'],['k','scroll up'],['g g','jump to top'],['G','jump to bottom'],['/','focus search'],['?','toggle this help'],['Esc','close']];var overlay=document.createElement('div');overlay.id=HELP_ID;overlay.setAttribute('role','dialog');overlay.setAttribute('aria-modal','true');overlay.setAttribute('aria-label','Keyboard shortcuts');overlay.style.cssText='position:fixed;inset:0;background:rgba(0,0,0,0.55);z-index:99999;display:grid;place-items:center;font:14px/1.45 system-ui,-apple-system,sans-serif;';var panel=document.createElement('div');panel.style.cssText='background:var(--rp-c-bg,#fff);color:var(--rp-c-text-1,#111);padding:24px 28px;border-radius:10px;max-width:440px;box-shadow:0 8px 32px rgba(0,0,0,0.25);';var head=document.createElement('div');head.style.cssText='display:flex;align-items:center;justify-content:space-between;gap:16px;margin:0 0 16px;';var title=document.createElement('h2');title.textContent='Keyboard shortcuts';title.style.cssText='margin:0;font-size:16px;font-weight:600;';head.appendChild(title);head.appendChild(renderToggleButton());panel.appendChild(head);var table=document.createElement('table');table.style.cssText='width:100%;border-collapse:collapse;';for(var i=0;i<rows.length;i++){var r=rows[i];var tr=document.createElement('tr');var k=document.createElement('td');k.style.cssText='padding:5px 0;width:96px;';var kbd=document.createElement('kbd');kbd.textContent=r[0];kbd.style.cssText='font-family:ui-monospace,monospace;background:var(--rp-c-bg-soft,#f4f4f4);padding:2px 8px;border-radius:4px;border:1px solid var(--rp-c-divider,#ddd);';k.appendChild(kbd);var d=document.createElement('td');d.textContent=r[1];d.style.cssText='padding:5px 0;color:var(--rp-c-text-2,#555);';tr.appendChild(k);tr.appendChild(d);table.appendChild(tr);}panel.appendChild(table);var hint=document.createElement('p');hint.textContent='Bindings ignore typing in inputs. Press ? again or Esc to close. The toggle persists across sessions.';hint.style.cssText='margin:18px 0 0;font-size:12px;color:var(--rp-c-text-3,#888);';panel.appendChild(hint);overlay.appendChild(panel);overlay.addEventListener('click',function(e){if(e.target===overlay)hideHelp();});document.body.appendChild(overlay);}
+var lastG=0;
+document.addEventListener('keydown',function(e){
+  if(e.metaKey||e.ctrlKey||e.altKey)return;
+  if(e.key==='Escape'){hideHelp();return;}
+  if(isEditable(document.activeElement))return;
+  var k=e.key;
+  if(k==='?'){e.preventDefault();showHelp();return;}
+  if(!enabled)return;
+  if(k==='g'&&!e.shiftKey){var now=Date.now();if(now-lastG<500){lastG=0;e.preventDefault();window.scrollTo({top:0,behavior:'smooth'});}else{lastG=now;}return;}
+  lastG=0;
+  if(k==='G'){e.preventDefault();window.scrollTo({top:document.documentElement.scrollHeight,behavior:'smooth'});return;}
+  if(k==='h'){if(clickNav('prev'))e.preventDefault();return;}
+  if(k==='l'){if(clickNav('next'))e.preventDefault();return;}
+  if(k==='j'){e.preventDefault();window.scrollBy({top:80,behavior:'auto'});return;}
+  if(k==='k'){e.preventDefault();window.scrollBy({top:-80,behavior:'auto'});return;}
+  if(k==='/'){e.preventDefault();focusSearch();return;}
+});
+})();</script>`,
   ],
   route: {
     cleanUrls: true,

--- a/tests/e2e/keybindings.spec.ts
+++ b/tests/e2e/keybindings.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+
+// Catches the PR #105 regression: rspress's head pipeline stripped the
+// raw-string `<script>` wrapper and leaked the JS body as text in <head>.
+// Asserting the localStorage key string isn't visible in body text is a
+// lightweight proxy: if the script body was inadvertently rendered as
+// content, the literal "fpf:vim-keys" would appear inside <body>.
+test('vim-keys script loads as a real <script>, not as <head> text', async ({
+  page,
+}) => {
+  await page.goto('/');
+  // Visible body text must NOT contain the localStorage sentinel.
+  const visibleText = await page.locator('body').innerText();
+  expect(visibleText).not.toContain('fpf:vim-keys');
+  // The script must have actually executed — the listener is attached to
+  // document and `?` opens the help overlay.
+  await page.keyboard.press('?');
+  await expect(page.locator('#fpf-keyhelp')).toBeVisible();
+  await expect(
+    page.locator('#fpf-keyhelp [aria-label="Keyboard shortcuts"], #fpf-keyhelp[aria-label="Keyboard shortcuts"]'),
+  ).toBeAttached();
+});
+
+test('Esc closes the help overlay', async ({ page }) => {
+  await page.goto('/');
+  await page.keyboard.press('?');
+  await expect(page.locator('#fpf-keyhelp')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#fpf-keyhelp')).toHaveCount(0);
+});
+
+test('toggle button persists Disabled state in localStorage', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await page.keyboard.press('?');
+  const toggle = page.locator('#fpf-keyhelp-toggle');
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+  await expect(toggle).toHaveText('Enabled');
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+  await expect(toggle).toHaveText('Disabled');
+
+  const stored = await page.evaluate(() => localStorage.getItem('fpf:vim-keys'));
+  expect(stored).toBe('0');
+
+  // Reload — the disabled state must persist.
+  await page.reload();
+  await page.keyboard.press('?');
+  await expect(page.locator('#fpf-keyhelp-toggle')).toHaveText('Disabled');
+
+  // ? still opens the overlay even when keys are off, so users can
+  // re-enable from any page.
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#fpf-keyhelp')).toHaveCount(0);
+  await page.keyboard.press('?');
+  await expect(page.locator('#fpf-keyhelp')).toBeVisible();
+
+  // Cleanup: re-enable so the next spec runs against the default state.
+  await page.locator('#fpf-keyhelp-toggle').click();
+});


### PR DESCRIPTION
## What

Re-attempt of PR #105 (which was rolled back when its `<script>` opening tag got stripped and JS leaked into `<head>` as text). This version is hardened against the same failure and has a Playwright spec to keep it that way.

## Why the previous attempt broke

PR #105's smoking gun was almost certainly an \`el.innerHTML = '<...>'\` literal HTML inside the JS string body. An HTML pre-processor in rspress's head emit pipeline saw the literal tags inside the JS source as real markup and stripped the opening \`<script>\` wrapper.

This rewrite uses \`createElement\` / \`setAttribute\` / \`textContent\` exclusively — no embedded HTML markup inside the JS source — so the pre-processor has nothing to misread.

PR #107's \`tests/e2e/head-shape.spec.ts\` would also fail loud if a future edit ever reintroduces the same shape, so the regression is locked in two ways now.

## Type

- \`feat\` — additive UX, opt-out via toggle

## Bindings (toggle on)

| Key | Action |
|---|---|
| \`h\` / \`l\` | previous / next page (clicks rspress's \`.rp-prev-next-page__prev/next\`) |
| \`j\` / \`k\` | scroll down / up (80 px steps) |
| \`g g\` | jump to top of page (smooth) |
| \`G\` | jump to bottom (smooth) |
| \`/\` | focus search (clicks \`.rp-search-button\` trigger) |
| \`?\` | toggle help overlay |
| \`Esc\` | close help overlay (always works) |

## Toggle

- Enabled/Disabled button inside the help overlay header.
- Persists in \`localStorage\` under \`fpf:vim-keys\` (default \`\"1\"\` = on).
- When off, only \`?\` and \`Esc\` fire — every navigation key is dormant.
- \`aria-pressed\` on the button mirrors state.

## Changes

- \`rspress.config.ts\`: ~50 lines of inline JS appended after the existing accessibility shim. createElement-only DOM construction.
- \`tests/e2e/keybindings.spec.ts\`: 3 specs that run against the Vercel preview URL via the preview-e2e workflow:
  - vim-keys script loads as a real \`<script>\`, not as \`<head>\` text; pressing \`?\` opens the overlay (the script must have executed).
  - \`Esc\` closes the overlay.
  - Toggle persists \`Disabled\` state across reloads; \`?\` still opens the overlay when keys are off; localStorage stores \`\"0\"\`.

## Validation

- \`bun run lint\`: 0 errors, 0 warnings (136 files including the new spec).
- \`bun run check\`: clean.
- \`bun run test\`: 303 passed, 0 failed.
- \`bun run docs:build\` locally: succeeded; built \`doc_build/index.html\` head opens with proper \`<head><meta><meta><title><link><link><script>...</script><script>(function(){var STORE_KEY='fpf:vim-keys';...\` — vim-keys script is the second \`<script>\` after the a11y shim, properly wrapped.
- End-to-end verification: PR's own preview deploy + the preview-e2e workflow runs \`tests/e2e/keybindings.spec.ts\` against the live preview. That's the proof.
- Caveats: keyboard handlers can't be exercised by the unit-test suite. Coverage comes from Playwright via the preview-e2e workflow PR #107 added.

## TPR fast-track

- [ ] Enable TPR review/merge timer

## Boundary check

- Runtime remains a single spec file via \`FPF_SPEC_SOURCE_PATH\` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in \`src/mcp/tool-contracts.ts\`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Claude Code (Opus 4.7) |
| Session | Vim keys redux after PR #105 rollback |
| Prompt  | Re-attempt vim keys with proper rspress head shape |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a site-wide keydown handler and DOM-injected help overlay, which could interfere with existing shortcuts/focus behavior across pages if selectors or event filtering are off. E2E coverage reduces regression risk but the change still impacts runtime UX globally.
> 
> **Overview**
> Adds **vim-style keyboard navigation** to the docs site via a new inline `<script>` in `rspress.config.ts`, including `h/l` prev/next, `j/k` scrolling, `gg/G` top/bottom, `/` search focus, and a `?` help overlay with a persistent `localStorage` toggle (`fpf:vim-keys`).
> 
> Hardens the inline script against rspress head-pipeline stripping by building the overlay purely with `createElement`/`textContent` (no embedded HTML strings), and adds `tests/e2e/keybindings.spec.ts` to assert the script executes (not leaked as head/body text), `Esc` closes the overlay, and the toggle persists across reloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b18489b8069f44eadfbcc4348ccc10d20a5a20f9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->