### PR TITLE
feat(docs): autolink canonical phrases (Start Here, Connect MCP, …)

### DIFF
--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -515,7 +515,9 @@ function buildPrefaceIndexPage(snapshot: Snapshot): GeneratedDocPage {
     '',
     '## Methodology',
     '',
-    'Use these pages when you need interpretation guidance before applying a route or pattern. For active work, return to Start Here, a route, or a work packet after the reading burden is clear.',
+    autolinkCanonicalPhrases(
+      'Use these pages when you need interpretation guidance before applying a route or pattern. For active work, return to Start Here, a route, or a work packet after the reading burden is clear.',
+    ),
   ];
 
   for (const [group, items] of groups.entries()) {
@@ -592,11 +594,17 @@ function renderPatternPage(snapshot: Snapshot, pattern: PatternRecord): string {
   appendPatternContext(lines, pattern);
 
   if (introText) {
-    lines.push('', autolinkPatternIds(snapshot, introText));
+    lines.push(
+      '',
+      autolinkCanonicalPhrases(autolinkPatternIds(snapshot, introText)),
+    );
   }
 
   if (leadExcerpt) {
-    lines.push('', autolinkPatternIds(snapshot, leadExcerpt));
+    lines.push(
+      '',
+      autolinkCanonicalPhrases(autolinkPatternIds(snapshot, leadExcerpt)),
+    );
   }
 
   if (catalogReminder) {
@@ -736,7 +744,10 @@ function renderRoutePage(snapshot: Snapshot, route: RouteRecord): string {
   }
 
   if (route.description) {
-    lines.push('', autolinkPatternIds(snapshot, route.description));
+    lines.push(
+      '',
+      autolinkCanonicalPhrases(autolinkPatternIds(snapshot, route.description)),
+    );
   }
 
   appendNodeIdList(lines, snapshot, 'Ordered steps', route.orderedIds, true);
@@ -791,7 +802,9 @@ function renderPrefacePage(snapshot: Snapshot, sectionId: string): string {
     if (anchor.text.trim()) {
       const linked = autolinkPatternIdsInTableCells(
         snapshot,
-        autolinkPatternIds(snapshot, anchor.text.trim()),
+        autolinkCanonicalPhrases(
+          autolinkPatternIds(snapshot, anchor.text.trim()),
+        ),
       );
       lines.push('', linked);
     }
@@ -834,7 +847,9 @@ function renderSection(
   if (anchor.text.trim()) {
     const linked = autolinkPatternIdsInTableCells(
       snapshot,
-      autolinkPatternIds(snapshot, anchor.text.trim()),
+      autolinkCanonicalPhrases(
+        autolinkPatternIds(snapshot, anchor.text.trim()),
+      ),
     );
     lines.push(linked, '');
   }
@@ -968,6 +983,87 @@ function autolinkPatternIdsInTableCells(
     );
   }
   return lines.join('\n');
+}
+
+/**
+ * Bare canonical phrases in prose that point to handwritten fpf-memory
+ * docs pages (those under `docs/`, not the spec-derived `/generated/`
+ * tree). Multi-word and case-sensitive on purpose: matching exactly the
+ * canonical capitalization keeps "you can start here…" prose untouched
+ * and only links references to the page by its proper name.
+ *
+ * Single-word matches like "Routes" are deliberately excluded — too
+ * many false-positive surfaces in pattern descriptions and headings.
+ */
+const CANONICAL_PHRASE_LINKS: ReadonlyArray<{ phrase: string; url: string }> = [
+  { phrase: 'Start Here', url: '/start-here' },
+  { phrase: 'Connect MCP', url: '/connect-mcp' },
+  { phrase: 'Pattern Catalog', url: '/patterns' },
+  { phrase: 'MCP Recipes', url: '/mcp-recipes' },
+  { phrase: 'Automation Playbook', url: '/automation-playbook' },
+  { phrase: 'Work Packets', url: '/work-packets' },
+  { phrase: 'Vercel MCP Hosting', url: '/vercel-hosting' },
+];
+
+const CANONICAL_PHRASE_TOKEN_PATTERN = new RegExp(
+  `\\b(?:${CANONICAL_PHRASE_LINKS.map(({ phrase }) =>
+    phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+  ).join('|')})\\b`,
+  'g',
+);
+
+/**
+ * Link the FIRST occurrence of each allow-listed canonical phrase in a
+ * markdown body to its docs page, while honoring the same guards as
+ * `autolinkPatternIds` (no rewriting inside code, existing links, or
+ * HTML attributes).
+ *
+ * First-occurrence-only — repeated mentions of the same phrase in one
+ * body skip linking so the second-and-later instances don't add link
+ * noise to prose that already pointed the reader at the page.
+ */
+function autolinkCanonicalPhrases(body: string): string {
+  if (!body) {
+    return body;
+  }
+
+  const guards: Array<[number, number]> = [];
+  const guardSources: RegExp[] = [
+    /```[\s\S]*?```/g,
+    /`[^`\n]+`/g,
+    /\[[^\]]+\]\([^)]+\)/g,
+    /<[^>]+>/g,
+  ];
+  for (const re of guardSources) {
+    for (const match of body.matchAll(re)) {
+      const start = match.index ?? 0;
+      guards.push([start, start + match[0].length]);
+    }
+  }
+  const isGuarded = (offset: number): boolean =>
+    guards.some(([start, end]) => offset >= start && offset < end);
+
+  const linked = new Set<string>();
+  return body.replace(
+    CANONICAL_PHRASE_TOKEN_PATTERN,
+    (match: string, offset: number) => {
+      if (
+        typeof offset !== 'number' ||
+        isGuarded(offset) ||
+        linked.has(match)
+      ) {
+        return match;
+      }
+      const entry = CANONICAL_PHRASE_LINKS.find(
+        ({ phrase }) => phrase === match,
+      );
+      if (!entry) {
+        return match;
+      }
+      linked.add(match);
+      return `[${match}](${entry.url})`;
+    },
+  );
 }
 
 function formatRelation(snapshot: Snapshot, relation: RelationEdge): string {

--- a/tests/docs-projection.test.ts
+++ b/tests/docs-projection.test.ts
@@ -301,6 +301,40 @@ describe('docs projection', () => {
     expect(catalog).not.toMatch(/\[[^\]]*\[[AI]\][^\]]*\]\(\/generated/);
   });
 
+  it('auto-links bare canonical phrases like "Start Here" to handwritten docs pages', () => {
+    // The Preface Catalog intro hardcodes "return to Start Here, a route, or
+    // a work packet" — that bare "Start Here" used to be plain text, leaving
+    // the reader without a navigational hint. The canonical-phrase autolinker
+    // wraps it in a link to `/start-here`, while leaving lowercase variants
+    // ("a route", "a work packet") alone so the writer's intent is preserved.
+    const projection = buildDocsProjection(snapshot);
+    const catalog =
+      projection.pagesByMarkdownPath[
+        'docs/generated/preface/index.md'
+      ]?.markdown ?? '';
+
+    expect(catalog).toMatch(/\[Start Here\]\(\/start-here\)/);
+    // Lowercase singular forms in the same sentence stay as plain text —
+    // the writer means "any route" / "any work packet", not a catalog page.
+    expect(catalog).not.toMatch(/\[a route\]\(/);
+    expect(catalog).not.toMatch(/\[a work packet\]\(/);
+  });
+
+  it('canonical-phrase autolinker links each phrase at most once per body', () => {
+    // First-occurrence-only on purpose — repeated mentions of the same
+    // canonical phrase in one body would otherwise add link noise, so the
+    // autolinker stops after the first match. The Preface Catalog intro
+    // only mentions "Start Here" once, so we expect exactly one link.
+    const projection = buildDocsProjection(snapshot);
+    const catalog =
+      projection.pagesByMarkdownPath[
+        'docs/generated/preface/index.md'
+      ]?.markdown ?? '';
+    const startHereLinks =
+      catalog.match(/\[Start Here\]\(\/start-here\)/g) ?? [];
+    expect(startHereLinks).toHaveLength(1);
+  });
+
   it('deduplicates repeated relation lines and exposes grouped navigation', () => {
     const projection = buildDocsProjection(snapshot);
     const navigation = buildDocsNavigation(snapshot);


### PR DESCRIPTION
## Summary

- Closes the deferred audit item (d): bare context-word linking, done with a small **allowlist** instead of generic word matching.
- Adds `autolinkCanonicalPhrases` — word-boundary, case-sensitive, first-occurrence-per-body — and chains it after `autolinkPatternIds` at every existing call site.
- Wraps the Preface Catalog intro's hardcoded prose so its bare "Start Here" surfaces as a link to `/start-here` instead of plain text.

The allowlist:

| Phrase | URL |
| --- | --- |
| `Start Here` | `/start-here` |
| `Connect MCP` | `/connect-mcp` |
| `Pattern Catalog` | `/patterns` |
| `MCP Recipes` | `/mcp-recipes` |
| `Automation Playbook` | `/automation-playbook` |
| `Work Packets` | `/work-packets` |
| `Vercel MCP Hosting` | `/vercel-hosting` |

## Why allowlist, not generic word match

Audit-agent flagged the false-positive risk last round (e.g., "the route maps to…"). This pass:

- Multi-word, capitalized phrases only — "Start Here" matches but "you can start here…" does not.
- Single-word "Routes" deliberately excluded — too many natural-prose surfaces.
- Lowercase variants in the same sentence ("a route", "a work packet") stay plain text — the writer means a generic route/packet, not the catalog page.
- First-occurrence-only per body — repeated mentions don't cascade into link noise.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run check` clean
- [x] `bun run test` — 308 passed (was 306; +2 new tests)
- [ ] Vercel preview shows the linked "Start Here" on the Preface Catalog page
- [ ] Spot-check that pattern-ID autolinks still work (no regression on existing autolinker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes docs markdown generation via new regex-based rewriting, which could introduce unintended links or missed matches across many generated pages despite guardrails.
> 
> **Overview**
> Adds `autolinkCanonicalPhrases` to convert the first occurrence of specific, case-sensitive multi-word doc names (e.g. `Start Here`, `Connect MCP`, `Work Packets`) into links to their handwritten `/docs` pages, while skipping code spans, existing links, and HTML.
> 
> Threads this new autolinker through existing render paths (preface index intro, pattern intros/excerpts, route descriptions, and preface section bodies) and adds tests to verify `Start Here` is linked (only once) in the Preface Catalog output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56583d1db7a92b39e13e82f237074231d539c233. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->