### PR TITLE
fix: round-2 audit follow-ups (stale routes, link escapes, nav, MCP framing)

### DIFF
--- a/docs/connect-mcp.md
+++ b/docs/connect-mcp.md
@@ -16,6 +16,16 @@ https://mcp.fpf.sh/api/mcp/fpf_memory/mcp
 
 This endpoint is the direct Vercel-hosted MCP origin over streamable HTTP. It exposes the public fpf-memory tools for catalog browsing, search, compact answers, exact generated doc reads, and index health.
 
+It is a JSON-RPC endpoint, not a web page. A bare browser GET returns **406 Not Acceptable** because the MCP server requires `Accept: application/json, text/event-stream`. Paste the URL into your client's MCP config; do not open it in a tab.
+
+For a browser-readable health check, use the freshness page instead:
+
+```txt
+https://mcp.fpf.sh/api/fpf/status
+```
+
+It returns JSON the browser will render — source hash, snapshot age, and the upstream ref the index was built from.
+
 Public tools:
 
 - `browse_fpf_catalog`

--- a/published/current/manifest.json
+++ b/published/current/manifest.json
@@ -1,10 +1,10 @@
 {
   "channel": "latest-published",
   "sourceHash": "sha256:c0301013b2013260608b6cf61e512e87a9bc76e16bc371abd6630b4ac1e6aaa5",
-  "compilerFingerprint": "sha256:dfbd54260896c9a1654d552625a8946890dd8fdd086d342097725e1c941fe6de",
+  "compilerFingerprint": "sha256:e5e223748a8dc55445d59d1d8e5d95292f30306c471a5fdcd10478a11e8fa713",
   "upstreamRef": "fbe6e291a53bef8136d76509ccd8e10e263ea0b7",
   "specPath": "published/current/FPF-Spec.md",
   "snapshotPath": "published/current/fpf-index/snapshot.json",
   "specBytes": 6392758,
-  "publishedAt": "2026-05-09T22:24:28.796Z"
+  "publishedAt": "2026-05-10T04:28:39.529Z"
 }

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -308,7 +308,27 @@ document.addEventListener('keydown',function(e){
       {
         text: 'Reference',
         items: [
-          { text: 'Routes', link: '/generated/routes/index' },
+          // Direct route links — the four routes named on Start Here so
+          // a reader who already knows the work-shape skips the Route
+          // Catalog. Order matches Start Here's table.
+          {
+            text: 'Project alignment',
+            link: '/generated/routes/route_project-alignment',
+          },
+          {
+            text: 'Writing / reviewing patterns',
+            link: '/generated/routes/route_writing-or-reviewing-patterns',
+          },
+          {
+            text: 'Boundary unpacking',
+            link: '/generated/routes/route_boundary-unpacking-claim-routing',
+          },
+          {
+            text: 'Lawful comparison',
+            link: '/generated/routes/route_lawful-comparison-pool-selection-selected-set-publication',
+          },
+          { text: 'All routes', link: '/generated/routes/index' },
+          { text: 'Preface', link: '/generated/preface/index' },
           { text: 'Glossary', link: '/generated/patterns/H.1' },
           { text: 'Change log', link: '/generated/patterns/I.3' },
         ],

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -59,7 +59,8 @@ export const PREFACE_ROUTE_CITATION = 'Preface/Where to start';
 export const ROUTE_INDEX_CITATION = 'J.4';
 
 export const PROJECT_ALIGNMENT_ROUTE_NAME = 'project alignment';
-export const BOUNDARY_BURDEN_ROUTE_NAME = 'boundary burden';
+export const BOUNDARY_UNPACKING_CLAIM_ROUTING_ROUTE_NAME =
+  'boundary unpacking / claim routing';
 
 export const MAX_HOPS = 6;
 export const MAX_SELECTED_ANCHORS = 12;

--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -1421,11 +1421,19 @@ function inlineCode(value: string): string {
   return `\`${value}\``;
 }
 
-// Escape `[` and `]` inside markdown link text so titles that contain
-// bracket labels (e.g. "C.3.A:Annex A [A/I]") render as a single anchor
-// instead of unbalanced markdown.
+// Replace `[` and `]` inside markdown link text with `(` and `)` so
+// titles that contain bracket labels (e.g. "C.3.A:Annex A [A/I]")
+// render as a single anchor.
+//
+// Backslash-escapes (`\[`, `\]`) — what CommonMark prescribes — and
+// numeric HTML entities (`&#91;` / `&#93;`) both fail to round-trip
+// through Rspress's MDX pipeline: the parser breaks the link text at
+// the inner `[` (backslash form) or HTML-escapes the leading `&`
+// (entity form), each producing visibly broken output. Parens carry
+// the same "this is a label" cue, are unambiguous to the markdown
+// parser inside link text, and pass through to HTML unchanged.
 function escapeMarkdownLinkText(text: string): string {
-  return text.replace(/\[/g, '\\[').replace(/\]/g, '\\]');
+  return text.replace(/\[/g, '(').replace(/\]/g, ')');
 }
 
 function stripRepeatedLeadMetadata(text: string): string {

--- a/src/runtime/answer-projector.ts
+++ b/src/runtime/answer-projector.ts
@@ -26,11 +26,16 @@ export function buildRouteAnswer(
   rebuilt: boolean,
 ): QueryResult {
   const route = snapshot.routeGraph.nodes[routeNodeId]!;
+  // Include routeSurfaces alongside the ordered/optional/landing lists.
+  // Some routes (e.g. boundary-unpacking-claim-routing) only declare
+  // surfaces; without this fallback the structured `ids` response would
+  // be just the route ID, hiding the patterns the answer prose names.
   const ids = unique([
     routeNodeId,
     ...route.orderedIds,
     ...route.optionalIds,
     ...route.landingIds,
+    ...route.routeSurfaces,
   ]);
   const idSet = new Set(ids);
   const relations = ids.flatMap((id) =>
@@ -98,7 +103,7 @@ function routeAcceptanceCheck(
   switch (routeNodeId) {
     case 'route:project-alignment':
       return 'a shared kickoff packet names the bounded context, actor roles, role/method/work split, first work-plan item, evidence to collect, and UTS-ready terms';
-    case 'route:boundary-burden':
+    case 'route:boundary-unpacking-claim-routing':
       return 'the boundary text is decomposed into layer-correct claims with named API/contract/protocol obligations, acceptance evidence, and owner handoff';
     case 'route:boundary-unpacking':
       return 'mixed boundary statements have stable claim IDs in a claim register and each atomic claim routes to one owner layer';
@@ -116,7 +121,7 @@ function routeNextMove(
   switch (routeNodeId) {
     case 'route:project-alignment':
       return 'read A.1.1 and A.15 first, draft the kickoff worksheet, then add A.15.2/A.15.3 only when the plan/run split must be made explicit';
-    case 'route:boundary-burden':
+    case 'route:boundary-unpacking-claim-routing':
       return 'read A.6, A.6.B, and A.6.C against the concrete boundary sentence before deciding whether A.6.P/A.6.Q/A.6.A is needed';
     case 'route:boundary-unpacking':
       return 'create the claim register first, then open exact pattern pages only for claims whose owner layer remains unclear';

--- a/src/runtime/compiler.ts
+++ b/src/runtime/compiler.ts
@@ -12,7 +12,7 @@
  */
 
 import {
-  BOUNDARY_BURDEN_ROUTE_NAME,
+  BOUNDARY_UNPACKING_CLAIM_ROUTING_ROUTE_NAME,
   PROJECT_ALIGNMENT_ROUTE_NAME,
 } from './constants.js';
 import {
@@ -246,7 +246,7 @@ function buildHeuristicSeedRules(
   }
 
   const boundaryRoute = Object.values(routeNodes).find(
-    (r) => r.name.toLowerCase() === BOUNDARY_BURDEN_ROUTE_NAME,
+    (r) => r.name.toLowerCase() === BOUNDARY_UNPACKING_CLAIM_ROUTING_ROUTE_NAME,
   );
   const boundaryNodeIds = ['A.6', 'A.6.B', 'A.6.C', 'A.6.P', 'A.6.Q', 'A.6.A'].filter(
     (id) => id in patternNodes || id in routeNodes,

--- a/src/runtime/query-helpers.ts
+++ b/src/runtime/query-helpers.ts
@@ -179,8 +179,8 @@ function scoreAdoptionRouteIntent(normalizedQuestion: string, route: RouteRecord
   switch (route.id) {
     case 'route:project-alignment':
       return scoreProjectAlignmentIntent(normalizedQuestion);
-    case 'route:boundary-burden':
-      return scoreBoundaryBurdenIntent(normalizedQuestion);
+    case 'route:boundary-unpacking-claim-routing':
+      return scoreBoundaryUnpackingClaimRoutingIntent(normalizedQuestion);
     case 'route:boundary-unpacking':
       return scoreBoundaryUnpackingIntent(normalizedQuestion);
     case 'route:writing-or-reviewing-patterns':
@@ -234,7 +234,7 @@ function scoreProjectAlignmentIntent(normalizedQuestion: string): number {
   return 0;
 }
 
-function scoreBoundaryBurdenIntent(normalizedQuestion: string): number {
+function scoreBoundaryUnpackingClaimRoutingIntent(normalizedQuestion: string): number {
   if (hasBoundaryReviewNegation(normalizedQuestion)) {
     return 0;
   }

--- a/tests/docs-projection.test.ts
+++ b/tests/docs-projection.test.ts
@@ -284,20 +284,23 @@ describe('docs projection', () => {
     ).toBe(true);
   });
 
-  it('escapes bracket labels in preface catalog link titles', () => {
+  it('rewrites bracket labels to parens in preface catalog link titles', () => {
     // Some published preface section titles include "[I]" / "[A/I]"
-    // labels. Markdown link grammar can't nest unescaped brackets,
-    // so the catalog rendered those rows as literal text. The titles
-    // must now appear with escaped brackets inside link text.
+    // labels. Markdown link grammar can't nest unescaped brackets, so
+    // the catalog rendered those rows as a malformed anchor with a
+    // dangling `]</a>` and the inner `[A/I]` orphaned. Backslash
+    // escapes and HTML entities both fail to round-trip Rspress's
+    // MDX pipeline; rewriting the brackets to parens keeps the label
+    // legible and the link as a single anchor.
     const projection = buildDocsProjection(snapshot);
     const catalog =
       projection.pagesByMarkdownPath[
         'docs/generated/preface/index.md'
       ]?.markdown ?? '';
-    // Round-trip a known offending title shape (we don't hardcode the
-    // exact title — just assert the escape pattern is present).
-    expect(catalog).toMatch(/\\\[[AI]\\\]/);
-    // And no unescaped `[I]` / `[A/I]` labels remain inside link text.
+    // The "(A/I)" / "(I)" label survives inside link text.
+    expect(catalog).toMatch(/\([AI](?:\/I)?\)\]\(\/generated/);
+    // No bracket labels remain inside link text — those would have
+    // produced malformed nested anchors.
     expect(catalog).not.toMatch(/\[[^\]]*\[[AI]\][^\]]*\]\(\/generated/);
   });
 

--- a/tests/fpf-spec-runtime.test.ts
+++ b/tests/fpf-spec-runtime.test.ts
@@ -284,11 +284,11 @@ describe('FpfRuntime', () => {
     expect(trace.sufficient).toBe(true);
   });
 
-  it('returns the boundary-burden route for PR reviewer API contract prompts', async () => {
+  it('returns the boundary unpacking / claim routing route for PR reviewer API contract prompts', async () => {
     await runtime.refresh();
     const routes = await runtime.browse({ kind: 'route' });
     const routeIds = new Set(routes.entries.map((entry) => entry.id));
-    if (!routeIds.has('route:boundary-burden')) {
+    if (!routeIds.has('route:boundary-unpacking-claim-routing')) {
       const route = await runtime.query(
         'For a PR/code reviewer checking an API contract change, return exact route or pattern IDs and acceptance checks without pasting the full FPF.',
         'compact',
@@ -303,30 +303,34 @@ describe('FpfRuntime', () => {
 
     expect(route.status).toBe('ok');
     expect(route.ids.slice(0, 4)).toEqual([
-      'route:boundary-burden',
+      'route:boundary-unpacking-claim-routing',
       'A.6',
       'A.6.B',
       'A.6.C',
     ]);
-    expect(route.ids).toEqual(expect.arrayContaining(['A.6.P', 'A.6.Q', 'A.6.A']));
-    expect(route.answer).toContain('route:boundary-burden');
+    // The route names A.6.P/A.6.Q/A.6.A as conditional additions in
+    // answer prose ("…before deciding whether A.6.P/A.6.Q/A.6.A is
+    // needed") rather than structured IDs, so they appear in `answer`
+    // but not in `ids`.
+    expect(route.answer).toContain('A.6.P/A.6.Q/A.6.A');
+    expect(route.answer).toContain('route:boundary-unpacking-claim-routing');
     expect(route.constraints).toContain(
       'Do not open the whole FPF; read exact pattern pages only when a finding depends on wording.',
     );
 
     const ask = renderAskFpfResult(route);
     expect(ask.ids.slice(0, 4)).toEqual([
-      'route:boundary-burden',
+      'route:boundary-unpacking-claim-routing',
       'A.6',
       'A.6.B',
       'A.6.C',
     ]);
-    expect(ask.markdown).toContain('route:boundary-burden');
+    expect(ask.markdown).toContain('route:boundary-unpacking-claim-routing');
 
     const trace = await runtime.trace(question, 'compact');
     expect(trace.status).toBe('ok');
     expect(trace.routeWins).toBe(true);
-    expect(trace.selectedNodeIds).toContain('route:boundary-burden');
+    expect(trace.selectedNodeIds).toContain('route:boundary-unpacking-claim-routing');
   });
 
   // This test chains `refresh()` (full snapshot build, ~16–18s on GitHub

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -334,15 +334,17 @@ describe('direct MCP server', () => {
     const readBoundaryRouteDoc = await harness.request('tools/call', {
       name: 'read_fpf_doc',
       arguments: {
-        selector: 'route:boundary-burden',
+        selector: 'route:boundary-unpacking-claim-routing',
         kind: 'route',
       },
     });
     const readBoundaryRouteDocPayload = asToolPayload(readBoundaryRouteDoc);
-    if (routeIds.has('route:boundary-burden')) {
+    if (routeIds.has('route:boundary-unpacking-claim-routing')) {
       expect(readBoundaryRouteDocPayload.resolvedAs).toBe('route');
-      expect(readBoundaryRouteDocPayload.nodeId).toBe('route:boundary-burden');
-      expect(readBoundaryRouteDocPayload.markdown).toContain('# boundary burden');
+      expect(readBoundaryRouteDocPayload.nodeId).toBe('route:boundary-unpacking-claim-routing');
+      expect(readBoundaryRouteDocPayload.markdown).toContain(
+        '# Boundary unpacking / claim routing',
+      );
     } else {
       expect(readBoundaryRouteDocPayload.status).toBe('not_found');
       expect(readBoundaryRouteDocPayload.resolvedAs).toBe('not_found');
@@ -358,14 +360,14 @@ describe('direct MCP server', () => {
     });
     const reviewerQueryPayload = asToolPayload(reviewerQuery);
     expect(reviewerQueryPayload.status).toBe('ok');
-    if (routeIds.has('route:boundary-burden')) {
+    if (routeIds.has('route:boundary-unpacking-claim-routing')) {
       expect((reviewerQueryPayload.ids as string[]).slice(0, 4)).toEqual([
-        'route:boundary-burden',
+        'route:boundary-unpacking-claim-routing',
         'A.6',
         'A.6.B',
         'A.6.C',
       ]);
-      expect(reviewerQueryPayload.answer).toContain('route:boundary-burden');
+      expect(reviewerQueryPayload.answer).toContain('route:boundary-unpacking-claim-routing');
     } else {
       expect((reviewerQueryPayload.ids as string[]).every((id) => !id.startsWith('route:'))).toBe(
         true,
@@ -397,14 +399,14 @@ describe('direct MCP server', () => {
       },
     });
     const reviewerAskPayload = asToolPayload(reviewerAsk);
-    if (routeIds.has('route:boundary-burden')) {
+    if (routeIds.has('route:boundary-unpacking-claim-routing')) {
       expect((reviewerAskPayload.ids as string[]).slice(0, 4)).toEqual([
-        'route:boundary-burden',
+        'route:boundary-unpacking-claim-routing',
         'A.6',
         'A.6.B',
         'A.6.C',
       ]);
-      expect(reviewerAskPayload.markdown).toContain('route:boundary-burden');
+      expect(reviewerAskPayload.markdown).toContain('route:boundary-unpacking-claim-routing');
     } else {
       expect((reviewerAskPayload.ids as string[]).every((id) => !id.startsWith('route:'))).toBe(
         true,

--- a/tests/query-contracts.test.ts
+++ b/tests/query-contracts.test.ts
@@ -140,8 +140,8 @@ function addRouteFixtures(baseSnapshot: Snapshot): Snapshot {
     ['F.17'],
   );
   addRoute(
-    'route:boundary-burden',
-    'boundary burden',
+    'route:boundary-unpacking-claim-routing',
+    'boundary unpacking / claim routing',
     'First route for API boundary, contract, protocol, and reviewer work.',
     ['A.6', 'A.6.B', 'A.6.C'],
     ['A.6.P', 'A.6.Q', 'A.6.A'],
@@ -169,7 +169,7 @@ function addRouteFixtures(baseSnapshot: Snapshot): Snapshot {
       seedScore: 20,
       seedOrigin: 'lexical',
       initialNodeIds: [],
-      routeId: 'route:boundary-burden',
+      routeId: 'route:boundary-unpacking-claim-routing',
       routeScore: 95,
     },
   ];
@@ -332,7 +332,7 @@ describe('Query / Seed coverage stage', () => {
     );
     const seeding = seedCandidates(normalized, snapshot);
 
-    const routeCandidate = seeding.candidateMap.get('route:boundary-burden');
+    const routeCandidate = seeding.candidateMap.get('route:boundary-unpacking-claim-routing');
     expect(routeCandidate).toBeDefined();
     expect(routeCandidate!.reasons).toContain('burden:boundary-review');
     expect(routeCandidate!.score).toBeGreaterThanOrEqual(90);
@@ -346,7 +346,7 @@ describe('Query / Seed coverage stage', () => {
     );
     const seeding = seedCandidates(normalized, snapshot);
 
-    const routeCandidate = seeding.candidateMap.get('route:boundary-burden');
+    const routeCandidate = seeding.candidateMap.get('route:boundary-unpacking-claim-routing');
     expect(routeCandidate?.reasons ?? []).not.toContain('burden:boundary-review');
   });
 
@@ -358,7 +358,7 @@ describe('Query / Seed coverage stage', () => {
     );
     const seeding = seedCandidates(normalized, snapshot);
 
-    const routeCandidate = seeding.candidateMap.get('route:boundary-burden');
+    const routeCandidate = seeding.candidateMap.get('route:boundary-unpacking-claim-routing');
     expect(routeCandidate?.reasons ?? []).not.toContain('burden:boundary-review');
   });
 
@@ -509,7 +509,7 @@ describe('Query / Ranker stage', () => {
     expect(ranking.initialNodeIds).toEqual(['route:writing-or-reviewing-patterns']);
   });
 
-  it('selects boundary burden for API boundary kickoff questions', async () => {
+  it('selects boundary unpacking / claim routing for API boundary kickoff questions', async () => {
     const snapshot = await getSnapshotWithRouteFixtures();
     const question =
       'As a project lead, what small FPF route should I use to run a 30-minute project kickoff about an API boundary decision?';
@@ -518,7 +518,7 @@ describe('Query / Ranker stage', () => {
     const ranking = rankCandidates(question, seeding.candidateMap, snapshot);
 
     expect(ranking.routeWins).toBe(true);
-    expect(ranking.initialNodeIds).toEqual(['route:boundary-burden']);
+    expect(ranking.initialNodeIds).toEqual(['route:boundary-unpacking-claim-routing']);
   });
 
   it('selects the boundary route for PR reviewer API contract prompts', async () => {
@@ -530,7 +530,7 @@ describe('Query / Ranker stage', () => {
     const ranking = rankCandidates(question, seeding.candidateMap, snapshot);
 
     expect(ranking.routeWins).toBe(true);
-    expect(ranking.initialNodeIds).toEqual(['route:boundary-burden']);
+    expect(ranking.initialNodeIds).toEqual(['route:boundary-unpacking-claim-routing']);
   });
 
   it('selects C.16 for measurement template characteristic scale evidence prompts', async () => {
@@ -787,7 +787,7 @@ describe('Query / Projection stability stage', () => {
     expect(trace.selectedNodeIds[0]).toBe('route:writing-or-reviewing-patterns');
   });
 
-  it('does not fast-route generic compliance review wording to boundary burden', async () => {
+  it('does not fast-route generic compliance review wording to boundary unpacking / claim routing', async () => {
     const snapshot = await getSnapshotWithRouteFixtures();
     const engine = new QueryEngine(snapshot, false);
     const questions = [
@@ -800,8 +800,8 @@ describe('Query / Projection stability stage', () => {
       const trace = engine.trace(question, 'compact');
 
       expect(trace.routeWins).toBe(false);
-      expect(trace.selectedNodeIds[0]).not.toBe('route:boundary-burden');
-      expect(trace.candidateScores[0]?.nodeId).not.toBe('route:boundary-burden');
+      expect(trace.selectedNodeIds[0]).not.toBe('route:boundary-unpacking-claim-routing');
+      expect(trace.candidateScores[0]?.nodeId).not.toBe('route:boundary-unpacking-claim-routing');
     }
   });
 


### PR DESCRIPTION
## Summary

Second-round audit fixes focused on user-visible breakage and structural staleness.

| Audit finding | Fix |
| --- | --- |
| `route:boundary-burden` is stale and not in snapshot but still in runtime + 3 test files | Rename case branches + constants to `route:boundary-unpacking-claim-routing` (the successor per current docs) |
| `route:lawful-comparison-or-portfolio-selection` was reported in `docs/start-here.md:30` | Already cleaned up in main; no action needed |
| Preface catalog list rows render as malformed nested anchors because `\[A/I\]` escape doesn't survive Rspress MDX | Rewrite `[`/`]` in link text to `(`/`)` — parens carry the same "label" cue and pass through cleanly |
| Public docs reach routes only via the generic `/generated/routes/index` | Add direct route + Preface links to the Reference nav dropdown |
| Browser-facing MCP endpoint returns 406 on bare GET | Reframe in `connect-mcp.md` as a JSON-RPC config endpoint; point to `/api/fpf/status` for browser-readable health |

Bonus runtime UX fix: `buildRouteAnswer` now includes `route.routeSurfaces` in the structured `ids` response. Some routes (the new boundary route) declare only surfaces, so without this fallback `ids` would have just the route ID while the prose mentioned patterns the caller couldn't programmatically reach.

## Why parens, not entities

Tried in order:

- `\[…\]` (CommonMark backslash escape) → Rspress's MDX parser still breaks link text at the inner `[`, producing `<a>…</a>` with the trailing `]` outside the anchor.
- `&#91;` / `&#93;` (numeric HTML entities) → Rspress HTML-escapes the leading `&` before parsing entities, so output renders as literal `&#91;`.
- `(`/`)` (rewrite) → Renders as a single anchor; label semantics preserved; no parser conflict.

## Out of scope (audit findings deferred)

- **Snapshot graph unresolved relations** (32 distinct, 51 edges): hyphenated IDs truncated, anchor-only targets, pseudo-IDs. Needs a graph-policy decision (treat as compiler-fix vs spec-fix) before code change.
- **Duplicate source headings** (`A.14:8.5`, `C.16:5.3.1`, `E.18:10`, `E.10:9.1` parent mismatch): looks like upstream-spec duplicates surfaced by the index. Same — needs policy on whether to disambiguate vs flag as spec lint.
- **Multiline backtick autolink guard**: investigated, the only real instances trace to upstream-spec malformed fences (an unclosed ` ``` ` on one preface page), not generator bugs. The fix would be to filter/repair source on parse, not change autolinker guards.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run check` — clean
- [x] `bun run check:boundaries` — clean
- [x] `bun run test` — 308 passed (was 307)
- [x] `bun run validate:published` — clean
- [x] `bun run docs:build` + spot-checked `doc_build/generated/preface/index.html` — bracket-label rows render as a single `<a>…(A/I)</a>` instead of the broken nested-anchor shape
- [ ] Vercel preview: nav dropdown shows the four routes + Preface; `/connect-mcp` shows the JSON-RPC clarification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly documentation/navigation fixes plus route-id alignment and a small runtime `ids` projection change; main risk is subtle behavior changes in route selection/returned IDs for boundary-review queries.
> 
> **Overview**
> Fixes stale boundary-route wiring by switching runtime heuristics, query intent scoring, and tests from `route:boundary-burden` to the current `route:boundary-unpacking-claim-routing`, and adds explicit constraints for that route in the compiled snapshot.
> 
> Improves reviewer/tooling UX by including `routeSurfaces` in `buildRouteAnswer()`’s structured `ids`, and updates the published snapshot/manifest accordingly.
> 
> Repairs docs rendering and discoverability by rewriting bracketed labels in preface catalog link text to parentheses (to survive Rspress MDX), adding direct route + Preface links to the `Reference` nav dropdown, and clarifying `connect-mcp.md` that the hosted MCP URL is a JSON-RPC endpoint (with a separate browser-friendly status URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a35f344107ad850851e3fb4f8590423ef337f697. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->