### PR TITLE
fix: surface silent compiler validation gaps (deferred audit items)

### DIFF
--- a/published/current/manifest.json
+++ b/published/current/manifest.json
@@ -1,10 +1,10 @@
 {
   "channel": "latest-published",
   "sourceHash": "sha256:c0301013b2013260608b6cf61e512e87a9bc76e16bc371abd6630b4ac1e6aaa5",
-  "compilerFingerprint": "sha256:e5e223748a8dc55445d59d1d8e5d95292f30306c471a5fdcd10478a11e8fa713",
+  "compilerFingerprint": "sha256:b12373bd05d194480b2e615f0a1c26c1fcc1e793dffed4e87e127ba50671b43c",
   "upstreamRef": "fbe6e291a53bef8136d76509ccd8e10e263ea0b7",
   "specPath": "published/current/FPF-Spec.md",
   "snapshotPath": "published/current/fpf-index/snapshot.json",
   "specBytes": 6392758,
-  "publishedAt": "2026-05-10T04:28:39.529Z"
+  "publishedAt": "2026-05-10T04:42:50.187Z"
 }

--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -913,7 +913,14 @@ function autolinkPatternIds(snapshot: Snapshot, body: string): string {
   const guards: Array<[number, number]> = [];
   const guardSources: RegExp[] = [
     /```[\s\S]*?```/g, // fenced code blocks
-    /`[^`\n]+`/g, // inline code spans
+    // Inline code spans. CommonMark allows code-span content to span
+    // newlines (newlines render as spaces inside the span); the source
+    // spec uses this pattern frequently, e.g.
+    //   `F.17 / F.18 /\n  E.10`
+    // The `[^`]+?` body catches these multi-line spans so pattern IDs
+    // inside intended-code text aren't autolinked. Single-line spans
+    // are still matched as a strict subset.
+    /`[^`]+?`/g,
     /\[[^\]]+\]\([^)]+\)/g, // existing markdown links [text](url)
     /<[^>]+>/g, // HTML tags (don't link inside attributes)
   ];
@@ -1030,7 +1037,7 @@ function autolinkCanonicalPhrases(body: string): string {
   const guards: Array<[number, number]> = [];
   const guardSources: RegExp[] = [
     /```[\s\S]*?```/g,
-    /`[^`\n]+`/g,
+    /`[^`]+?`/g, // inline code spans, multi-line allowed
     /\[[^\]]+\]\([^)]+\)/g,
     /<[^>]+>/g,
   ];

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -193,6 +193,15 @@ export interface BuildValidation {
   missingRequiredFields: number;
   unresolvedReferences: string[];
   duplicateIds: string[];
+  /**
+   * Section IDs encountered more than once during index-map
+   * construction — the second-and-later occurrences silently
+   * overwrote the first, so the index resolves to the last writer.
+   * Currently non-zero in published spec snapshots; surfacing the
+   * count here keeps the silent merges visible without changing
+   * the merge behavior.
+   */
+  duplicateHeadings: string[];
   brokenRoutes: string[];
 }
 

--- a/src/mcp/tool-contracts.ts
+++ b/src/mcp/tool-contracts.ts
@@ -182,6 +182,7 @@ export const buildAuditSchema = z
         missingRequiredFields: z.number(),
         unresolvedReferences: z.array(z.string()),
         duplicateIds: z.array(z.string()),
+        duplicateHeadings: z.array(z.string()),
         brokenRoutes: z.array(z.string()),
       })
       .strict(),

--- a/src/runtime/index-projector.ts
+++ b/src/runtime/index-projector.ts
@@ -29,10 +29,12 @@ export function buildIndexMap(
 ): {
   roots: string[];
   nodes: Record<string, IndexMapNode>;
+  duplicateHeadings: string[];
 } {
   const { sections, catalogDescriptions } = ir;
   const nodes: Record<string, IndexMapNode> = {};
   const roots: string[] = [];
+  const duplicateHeadings = new Set<string>();
   const routeBearingPatternIds = new Set(
     Object.values(routeNodes).flatMap((route) => [
       ...route.orderedIds,
@@ -46,6 +48,9 @@ export function buildIndexMap(
   for (const section of sections) {
     const pattern = section.patternId ? patternNodes[section.patternId] : undefined;
     const description = describeIndexNode(section, catalogDescriptions, pattern);
+    if (Object.hasOwn(nodes, section.id)) {
+      duplicateHeadings.add(section.id);
+    }
     nodes[section.id] = {
       id: section.id,
       title: section.heading,
@@ -72,7 +77,7 @@ export function buildIndexMap(
       roots.push(section.id);
     }
   }
-  return { roots, nodes };
+  return { roots, nodes, duplicateHeadings: Array.from(duplicateHeadings) };
 }
 
 export function buildLexicon(

--- a/src/runtime/validation-runner.ts
+++ b/src/runtime/validation-runner.ts
@@ -14,7 +14,11 @@ export function buildValidation(
   patternNodes: Record<string, PatternRecord>,
   routeNodes: Record<string, RouteRecord>,
   lexicon: Record<string, LexiconEntry>,
-  indexMap: { roots: string[]; nodes: Record<string, IndexMapNode> },
+  indexMap: {
+    roots: string[];
+    nodes: Record<string, IndexMapNode>;
+    duplicateHeadings: string[];
+  },
   relationGraph: RelationEdge[],
 ): BuildValidation {
   const duplicateIds = findDuplicateIds([
@@ -24,7 +28,17 @@ export function buildValidation(
   const unresolvedReferences = unique(
     relationGraph
       .map((edge) => edge.to)
-      .filter((target) => !compiledNodes[target]),
+      .filter((target) => !compiledNodes[target])
+      // A target that lives in `indexMap.nodes` is a section anchor
+      // (e.g. `A.19:0`, `E.18:5.9`) — it has a parent pattern + a
+      // line range, so it's resolvable to `parent#anchor`. Treat
+      // those as resolved instead of polluting the unresolved bucket.
+      .filter((target) => !indexMap.nodes[target])
+      // Filter `.x` / `.y` placeholder IDs (e.g. `B.1.x`, `E.10.y`)
+      // — they are spec-source pseudo-IDs marking unwritten extension
+      // points, not unresolved references. Counting them here drowned
+      // out real forward-ref findings.
+      .filter((target) => !/\.[xy]$/.test(target)),
   );
   const missingRequiredFields = Object.values(patternNodes).reduce((count, pattern) => {
     const requiredFields = [
@@ -53,6 +67,7 @@ export function buildValidation(
     missingRequiredFields,
     unresolvedReferences,
     duplicateIds,
+    duplicateHeadings: indexMap.duplicateHeadings,
     brokenRoutes,
   };
 }

--- a/tests/compiler-contracts.test.ts
+++ b/tests/compiler-contracts.test.ts
@@ -177,6 +177,35 @@ describe('Compiler / Graph closure stage', () => {
     );
   });
 
+  it('exposes section IDs that two source headings collided on', async () => {
+    const { snapshot } = await getCompilerOutput();
+    const { validation } = snapshot;
+
+    // The FPF source authors a few section IDs twice; the index-map
+    // build silently keeps the last writer. Surfacing those collisions
+    // lets the validation reader see the silent merges instead of
+    // having to diff line numbers by hand. Stays small in the current
+    // spec; pin it as bounded rather than empty so a regression that
+    // hides the surface (e.g. losing the field on the schema) shows up.
+    expect(Array.isArray(validation.duplicateHeadings)).toBe(true);
+    expect(validation.duplicateHeadings.length).toBeGreaterThan(0);
+    expect(validation.duplicateHeadings.length).toBeLessThan(20);
+  });
+
+  it('does not count `.x` / `.y` placeholders or section anchors as unresolved', async () => {
+    const { snapshot } = await getCompilerOutput();
+    const { validation } = snapshot;
+
+    // Pseudo-IDs (`B.1.x`, `E.10.y`) mark unwritten extension points
+    // in the spec; section-anchor IDs (`A.19:0`, `E.18:5.9`) live in
+    // indexMap with full position info. Both used to drown out real
+    // forward-ref findings — neither should appear in unresolved.
+    for (const target of validation.unresolvedReferences) {
+      expect(target).not.toMatch(/\.[xy]$/);
+      expect(snapshot.indexMap[target]).toBeUndefined();
+    }
+  });
+
   it('has no broken routes', async () => {
     const { snapshot } = await getCompilerOutput();
     const { validation } = snapshot;

--- a/tests/docs-projection.test.ts
+++ b/tests/docs-projection.test.ts
@@ -235,6 +235,41 @@ describe('docs projection', () => {
     expect(a69Page).not.toMatch(/\(\/generated\/patterns\/heading:/);
   });
 
+  it('does not autolink pattern IDs inside multi-line single-backtick code spans', () => {
+    // CommonMark allows inline code-span content to span newlines.
+    // The FPF source uses this pattern, e.g. `F.17 / F.18 /
+    //   E.10`. Before tightening the autolinker guard from
+    // `[^`\n]+` to `[^`]+?`, pattern IDs inside multi-line spans got
+    // autolinked, leaking `](/generated/patterns/...)` markup into
+    // intended-code text.
+    //
+    // Find one well-formed multi-line span in the generated docs and
+    // assert it survived without an autolink inside. We pick the
+    // E.11 span ` `F.17 / F.18 / E.10` ` — the docs generator
+    // collapses the newline so the span renders single-line, BUT
+    // earlier spec lines (e.g. `E.20:1`'s reasoning blocks) preserve
+    // multi-line `…` spans with pattern IDs. Sample one such page
+    // and check the body prose for a multi-line span that still
+    // contains a pattern-ID token (the guard's job): zero `/generated/`
+    // links inside it.
+    const projection = buildDocsProjection(snapshot);
+    let foundCleanMultilineSpan = false;
+    for (const page of projection.pages) {
+      const re = /`([A-Z]\.\d[^`]*?\n[^`]*?)`/g;
+      let match;
+      while ((match = re.exec(page.markdown)) !== null) {
+        // Span that starts with what looks like a pattern-ID-bearing
+        // sequence and crosses a newline. Should NOT contain a link.
+        if (!match[1]!.includes('](/generated/')) {
+          foundCleanMultilineSpan = true;
+          break;
+        }
+      }
+      if (foundCleanMultilineSpan) break;
+    }
+    expect(foundCleanMultilineSpan).toBe(true);
+  });
+
   it('auto-links code-spanned pattern IDs inside markdown table cells', () => {
     // The J.4 entry-point table renders one inline-code pattern ID per
     // cell. The general autolinker skips `<code>` spans in prose, so


### PR DESCRIPTION
## Summary

Three small surgical fixes that take the validation surface from "silently merging" to "loudly counted" — addresses the deferred items from round-2 review.

| Audit item | Before | After |
| --- | --- | --- |
| Unresolved relation targets | 32 distinct / 51 edges (drowning in pseudo-IDs and section anchors) | 19 distinct (real forward refs to unwritten patterns: `A.22…A.45`, `A.19.SURF/SUPPORT`, etc.) |
| Section anchors (`A.19:0`, `E.18:5.9`, `C.2:4.1`, …) | counted as unresolved despite living in `indexMap` | counted as resolved (navigable to `parent#anchor`) |
| Pseudo-ID placeholders (`B.1.x`, `E.10.y`, …) | counted as unresolved despite being known-not-real | filtered |
| Heading collisions (`A.14:8.5`, `C.16:5.3.1`, `E.18:10`, `E.10:9.1`) | silently last-write-wins, invisible | exposed via new `validation.duplicateHeadings: string[]` |
| Autolinker inside multi-line single-backtick code spans (e.g. `` `F.17 / F.18 /\n  E.10` ``) | leaked autolinks into intended-code text | guarded |

## Why no spec edits

The remaining unresolved 19 are genuine forward refs to patterns the upstream spec hasn't written yet (`A.22…A.45`), spec typos (`E.6.1` should be `E.6:1`), member shorthand (`E.10.U1`), or extension scaffolds (`G.4:Ext.EvidenceGraphWiring`). All of those need spec authoring, not generator changes.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run check` clean
- [x] `bun run test` — 311 passed (up from 308; +3 new tests)
- [ ] Vercel preview confirms generated docs render unchanged outside the autolinker fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler validation and docs autolinking logic, changing what the build reports and how generated markdown is rewritten; mistakes could hide real validation findings or introduce incorrect links in generated docs.
> 
> **Overview**
> **Validation output is made more actionable.** `buildValidation` now excludes section-anchor IDs (present in `indexMap`) and `.x`/`.y` placeholder IDs from `unresolvedReferences`, and the index projector records heading-ID collisions as a new `validation.duplicateHeadings` field.
> 
> **Schemas/tests and published artifacts are updated accordingly.** The MCP `buildAudit` schema and compiler contract tests assert the new field/filters, docs projection tests cover multi-line inline-code spans, and the committed published `manifest.json`/snapshot validation block are regenerated (new fingerprint/timestamps, updated unresolved list, and `duplicateHeadings` included).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d023222d417e8204fd1a50bb8edfde8707c479f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->