### PR TITLE
fix(docs): show snapshot publishedAt as "Last Updated" instead of stale git timestamp

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -390,7 +390,14 @@ document.addEventListener('keydown',function(e){
       ],
     },
     search: true,
-    lastUpdated: true,
+    // Disable rspress's git-based lastUpdated. Generated docs aren't
+    // tracked in git (PR #1f8c744d), so the plugin would either show
+    // nothing or — worse — show the timestamp of the commit that
+    // *removed* them from tracking. The build pipeline appends a
+    // "Last Updated: <publishedAt>" line to each generated page from
+    // `published/current/manifest.json`, which is the truthful
+    // per-snapshot signal.
+    lastUpdated: false,
     enableScrollToTop: true,
     footer: {
       message: 'Projection of the latest published FPF.',

--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -92,12 +92,59 @@ export function buildDocsProjection(
     buildRootIndexPage(snapshot, manifest),
   ];
 
+  // Stamp every generated page with the published-snapshot date as
+  // the truthful per-snapshot freshness signal. Generated pages
+  // aren't tracked in git, so rspress's git-based lastUpdated is
+  // disabled; we render the date ourselves as a small footer line
+  // and also expose it in frontmatter for search/SEO consumers.
+  if (manifest) {
+    for (const page of pages) {
+      page.markdown = stampPublishedDate(page.markdown, manifest.publishedAt);
+    }
+  }
+
   return {
     pages,
     pagesByMarkdownPath: Object.fromEntries(
       pages.map((page) => [page.markdownPath, page] as const),
     ),
   };
+}
+
+function stampPublishedDate(
+  markdown: string,
+  publishedAt: string,
+): string {
+  return appendLastUpdatedFooter(
+    injectLastUpdatedFrontmatter(markdown, publishedAt),
+    publishedAt,
+  );
+}
+
+function injectLastUpdatedFrontmatter(
+  markdown: string,
+  publishedAt: string,
+): string {
+  const match = markdown.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!match) return markdown;
+  const existingFrontmatter = match[1]!;
+  // Don't double-stamp if a builder already set its own value.
+  if (/^\s*lastUpdated\s*:/m.test(existingFrontmatter)) {
+    return markdown;
+  }
+  const newFrontmatter = `${existingFrontmatter}\nlastUpdated: ${JSON.stringify(publishedAt)}`;
+  return `---\n${newFrontmatter}\n---\n${markdown.slice(match[0].length)}`;
+}
+
+function appendLastUpdatedFooter(
+  markdown: string,
+  publishedAt: string,
+): string {
+  // Render the date in the same compact yyyy-mm-dd shape as the home
+  // page's manifest line; full ISO is in frontmatter for tools that
+  // want it.
+  const formatted = formatPublishedDate(publishedAt);
+  return `${markdown.replace(/\n+$/, '')}\n\n---\n\n*Last Updated: ${formatted} (FPF snapshot publish date)*\n`;
 }
 
 export function resolveDocTarget(

--- a/tests/docs-projection.test.ts
+++ b/tests/docs-projection.test.ts
@@ -562,4 +562,44 @@ describe('docs projection', () => {
       await rm(tempRoot, { recursive: true, force: true });
     }
   }, 360_000);
+
+  it('stamps generated pages with the manifest publishedAt date', () => {
+    // Generated docs aren't tracked in git, so rspress's default git-based
+    // "Last Updated" reads back the timestamp of the commit that stopped
+    // tracking them — stale. Pages built with a manifest must instead
+    // surface the snapshot's publishedAt, both in frontmatter (for SEO /
+    // search consumers) and as a visible footer line at the page bottom.
+    const projection = buildDocsProjection(snapshot, {
+      channel: 'latest-published',
+      sourceHash: 'sha256:test',
+      upstreamRef: 'fbe6e29',
+      publishedAt: '2026-05-10T04:28:39.529Z',
+    });
+    const samples = [
+      'docs/generated/patterns/A.6.md',
+      'docs/generated/routes/index.md',
+      'docs/generated/preface/index.md',
+    ];
+    for (const path of samples) {
+      const body = projection.pagesByMarkdownPath[path]?.markdown ?? '';
+      expect(body, `expected ${path} to be projected`).not.toBe('');
+      // ISO timestamp lives in frontmatter.
+      expect(body).toMatch(/^lastUpdated: "2026-05-10T04:28:39.529Z"$/m);
+      // Compact yyyy-mm-dd date lives in the visible footer line.
+      expect(body).toMatch(
+        /\*Last Updated: 2026-05-10 \(FPF snapshot publish date\)\*/,
+      );
+    }
+  });
+
+  it('omits the publishedAt stamp when no manifest is provided', () => {
+    // Runtime callers (e.g. query-engine) call buildDocsProjection
+    // without a manifest. Those rendered bodies are read directly by
+    // tools, not by the docs site, so they shouldn't carry the
+    // human-targeted footer line.
+    const projection = buildDocsProjection(snapshot);
+    const body = projection.pagesByMarkdownPath['docs/generated/patterns/A.6.md']?.markdown ?? '';
+    expect(body).not.toMatch(/\*Last Updated: /);
+    expect(body).not.toMatch(/^lastUpdated:/m);
+  });
 });


### PR DESCRIPTION
## Summary

The `Last Updated:` footer at the bottom of every generated docs page was either empty or showing a misleading stale date (Apr 15, 2026 — the timestamp of [1f8c744d](https://github.com/venikman/fpf-memory/commit/1f8c744d) which removed generated docs from git tracking). Rspress's default `Last Updated` plugin reads from `git log`, but generated docs aren't in git after that commit.

**Fix:** disable rspress's git-based plugin and stamp pages from the snapshot manifest's `publishedAt` instead — the same date the home page already shows as "Published 2026-05-10".

| Surface | Before | After |
| --- | --- | --- |
| Pattern page footer | `Last Updated:` (empty) or `Apr 15, 2026` | `*Last Updated: 2026-05-10 (FPF snapshot publish date)*` |
| Page frontmatter | no `lastUpdated` field | `lastUpdated: "2026-05-10T04:28:39.529Z"` (ISO, for search/SEO) |
| Runtime-rendered pages (no manifest) | unchanged | unchanged — stamp only applies when manifest is passed |

## Tradeoff

Per-page freshness is lost — every generated page shows the same snapshot publish date, not when its content last changed in the spec. This is the truthful answer for an FPF projection: the spec is published as a unit, so "this page is from snapshot X" is the right statement. If we ever want per-section freshness, we'd need to plumb section-level git timestamps from the upstream FPF repo, which is well out of scope.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run check` clean
- [x] `bun run test` — 310 passed (was 308; +2 new tests)
- [x] `bun run docs:build` — confirmed `<p><em>Last Updated: 2026-05-10 (FPF snapshot publish date)</em></p>` renders at the bottom of generated pattern/route/preface pages
- [ ] Vercel preview spot-check shows the footer line on a few pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: disables rspress’s git-based `lastUpdated` and replaces it with deterministic stamping from the publication manifest, affecting only generated markdown rendering and docs-site metadata.
> 
> **Overview**
> **Replaces rspress’s git-derived “Last Updated” with the snapshot’s publication date.** The docs config turns off `lastUpdated` so generated pages don’t show empty/stale timestamps.
> 
> When `buildDocsProjection` is called with a manifest, it now injects `lastUpdated: <publishedAt>` into page frontmatter and appends a visible footer line `Last Updated: yyyy-mm-dd (FPF snapshot publish date)` to every generated page; projection calls without a manifest remain unchanged. Tests add coverage for both the stamped and unstamped cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e61f64dcf7ec9ef77b334ad0b6885fccecde1075. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->