### PR TITLE
fix(mcp): demote lexeme hits in default search + expose linkedNodeIds

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -652,6 +652,14 @@ export interface SearchHit {
   part?: string;
   score: number;
   snippet: string;
+  /**
+   * For `kind: "lexeme"` hits, the pattern / route IDs the lexeme is
+   * linked to. Lexemes are vocabulary entries — readers that find a
+   * lexeme in search results need a path to the actionable pattern
+   * page, otherwise the hit is a dead-end. Undefined on non-lexeme
+   * hits.
+   */
+  linkedNodeIds?: string[];
 }
 
 export interface SearchResult {

--- a/src/mcp/tool-contracts.ts
+++ b/src/mcp/tool-contracts.ts
@@ -581,6 +581,7 @@ export const searchHitSchema = z
     part: z.string().optional(),
     score: z.number(),
     snippet: z.string(),
+    linkedNodeIds: z.array(z.string()).optional(),
   })
   .strict();
 

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -431,12 +431,25 @@ export class FpfRuntime {
         continue;
       }
 
-      const score =
+      const rawScore =
         scoreOverlap(queryTokens, node.searchableText)
         + scoreOverlap(queryTokens, node.title) * SEARCH_TITLE_TOKEN_WEIGHT;
-      if (score <= 0) {
+      if (rawScore <= 0) {
         continue;
       }
+      const score =
+        node.kind === 'lexeme' && options.kind !== 'lexeme'
+          ? rawScore * SEARCH_LEXEME_DEFAULT_PENALTY
+          : rawScore;
+
+      // Lexeme hits expose the linked pattern/route IDs so a reader
+      // who lands on a vocabulary entry can jump to the actionable
+      // page. Pattern/route hits don't need this — the hit ID is
+      // already the actionable target.
+      const linkedNodeIds =
+        node.kind === 'lexeme'
+          ? (node.details as { linkedNodeIds?: string[] }).linkedNodeIds
+          : undefined;
 
       hits.push({
         id: node.id,
@@ -446,6 +459,9 @@ export class FpfRuntime {
         part: node.part,
         score,
         snippet: extractSnippet(node.searchableText, queryTokens),
+        ...(linkedNodeIds && linkedNodeIds.length > 0
+          ? { linkedNodeIds }
+          : {}),
       });
     }
 
@@ -896,6 +912,13 @@ function nodeToCatalogEntry(
 }
 
 const SEARCH_TITLE_TOKEN_WEIGHT = 5;
+// Lexemes are vocabulary entries; in default search they kept crowding
+// out actionable pattern/route hits because their `searchableText`
+// concatenates many usage examples. When the caller hasn't asked for
+// lexemes specifically (`kind: "lexeme"`), multiply their score by
+// this factor so they rank below pattern/route matches of comparable
+// strength but still appear if nothing else matches the query.
+const SEARCH_LEXEME_DEFAULT_PENALTY = 0.3;
 // Schema caps the query string at 1000 chars; even pathological tokenizations
 // won't exceed this token count for a legitimate query.
 const SEARCH_MAX_QUERY_TOKENS = 64;

--- a/tests/discovery-layer.test.ts
+++ b/tests/discovery-layer.test.ts
@@ -167,6 +167,58 @@ describe('Discovery layer', () => {
       expect(result.hits.length).toBeLessThanOrEqual(2);
     });
 
+    it('penalizes lexeme hits in default search so patterns/routes win on natural-language queries', async () => {
+      // Lexeme `searchableText` concatenates many usage examples, so
+      // without a penalty a single huge lexeme like
+      // `lex:text-use-this-pattern-when-boundary-facing-language…`
+      // outranks `route:boundary-unpacking` for the natural-language
+      // query "boundary burden". The default search should keep the
+      // first non-lexeme hit ahead of every lexeme hit.
+      const result = await runtime.search('boundary burden', { limit: 15 });
+      const firstNonLexemeIdx = result.hits.findIndex(
+        (h) => h.kind !== 'lexeme',
+      );
+      const firstLexemeIdx = result.hits.findIndex((h) => h.kind === 'lexeme');
+      expect(firstNonLexemeIdx).toBeGreaterThanOrEqual(0);
+      // If any lexeme hit appears at all, it must come AFTER every
+      // pattern/route hit of comparable strength.
+      if (firstLexemeIdx >= 0) {
+        expect(firstLexemeIdx).toBeGreaterThan(firstNonLexemeIdx);
+      }
+    });
+
+    it('exposes linkedNodeIds on lexeme hits so readers have a path to the pattern page', async () => {
+      // A lexeme on its own is a vocabulary entry, not an actionable
+      // page. Including the linked pattern/route IDs alongside the
+      // hit lets the caller jump straight to the actionable surface.
+      const result = await runtime.search('boundary', {
+        kind: 'lexeme',
+        limit: 5,
+      });
+      const lexemeHit = result.hits.find((h) => h.kind === 'lexeme');
+      expect(lexemeHit).toBeDefined();
+      if (!lexemeHit) return;
+      expect(Array.isArray(lexemeHit.linkedNodeIds)).toBe(true);
+      expect(lexemeHit.linkedNodeIds!.length).toBeGreaterThan(0);
+    });
+
+    it('does not apply the lexeme penalty when the caller explicitly asks for kind:"lexeme"', async () => {
+      // When the search filter is `kind: "lexeme"`, the caller wants
+      // raw lexeme ranking (e.g. an MCP tool exploring vocabulary).
+      const penalized = await runtime.search('boundary burden', { limit: 5 });
+      const raw = await runtime.search('boundary burden', {
+        kind: 'lexeme',
+        limit: 5,
+      });
+      const penalizedTopLexeme = penalized.hits.find((h) => h.kind === 'lexeme');
+      const rawTopLexeme = raw.hits[0];
+      if (penalizedTopLexeme && rawTopLexeme && penalizedTopLexeme.id === rawTopLexeme.id) {
+        // Same lexeme in both result sets — the raw score must be
+        // higher than the penalized score for the same hit.
+        expect(rawTopLexeme.score).toBeGreaterThan(penalizedTopLexeme.score);
+      }
+    });
+
     it('returns zero hits for nonsense query', async () => {
       const result = await runtime.search('zqqxvwjkf');
       expect(result.hits.length).toBe(0);


### PR DESCRIPTION
## Summary

Audit item #1: `search_fpf("boundary burden")` was ranking a 1000-char `lex:text-use-this-pattern-...` lexeme above `route:boundary-unpacking` and `route:boundary-unpacking-claim-routing` because lexeme `searchableText` concatenates many usage examples. Lexemes were a dead-end UX — callers had no path from a lexeme hit to the actionable page.

Two surgical changes:

| Change | Effect |
| --- | --- |
| **Score ×0.3 for lexeme hits in default search** | The lexeme that previously dominated for "boundary burden" now ranks 8th, behind 4 routes and 3 patterns. Penalty is suppressed when caller passes `kind: "lexeme"` so vocabulary-focused queries keep raw ranking. |
| **`linkedNodeIds` field on lexeme `SearchHit`** | A reader who does land on a lexeme hit can jump straight to the linked pattern / route page (lifted from `LexiconEntry.linkedNodeIds`). Optional on the schema, omitted on pattern/route hits since the hit ID is already the actionable target. |

## Before / after

```
search_fpf("boundary burden")
─ Before ─                              ─ After ─
1. lex:text-use-this-pattern-... (100)  1. C.26.1                       (20)
2. lex:assurancelane-...         (44)   2. G.10                         (20)
3. lex:and-the-relevant-...      (38)   3. route:boundary-unpacking     (20)
…                                       4. route:boundary-unpacking-claim-routing (20)
                                        5. A.6                          (18)
                                        6. A.6.B                        (18)
                                        7. C.26.3                       (18)
                                        8. lex:text-use-this-pattern-...  (9)  ← penalized
```

## Test plan

- [x] `bun run lint` clean
- [x] `bun run check` clean
- [x] `bun run test` — 318 passed (was 315; +3 new tests covering penalty applied, `linkedNodeIds` populated, and explicit `kind:"lexeme"` opt-out)
- [x] Manual repro of the audit's exact query — confirmed first 7 results are all patterns/routes

## Out of scope

Per the original audit, items #2-#5 (output shape, confidence, `read_fpf_doc` size options, text fallback enrichment) follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public search response shape and ranking logic, which could affect downstream consumers and relevance expectations, but is limited to discovery-layer search behavior.
> 
> **Overview**
> Default `search()` now **demotes `lexeme` hits** by applying a score penalty unless the caller explicitly filters with `kind: "lexeme"`, so natural-language queries preferentially surface actionable pattern/route pages.
> 
> Search hits gain an optional `linkedNodeIds` field (wired through the MCP `searchHitSchema`) and the runtime now populates it for lexeme hits to provide direct navigation targets; new discovery-layer tests cover the penalty behavior, the opt-out when filtering for lexemes, and presence of `linkedNodeIds`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2d804865c441b6a29e5ff8bbe35844b4bf33f9c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->