### PR TITLE
feat(mcp): add preview mode + maxChars to read_fpf_doc; richer text fallback

### DIFF
--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -125,10 +125,87 @@ function renderToolContent(
 
   const nodeId = structuredContent.nodeId;
   if (toolId === 'read_fpf_doc' && typeof nodeId === 'string') {
-    return `read_fpf_doc returned markdown for ${nodeId} in structuredContent.markdown.`;
+    return renderReadFpfDocFallback(structuredContent);
   }
 
   const status = structuredContent.status;
   const summary = status ? ` status=${String(status)}` : '';
   return `${toolId} returned structured content.${summary}`;
+}
+
+/**
+ * Build the text-content fallback for `read_fpf_doc`. Earlier this
+ * was a single sentence pointing at structuredContent.markdown;
+ * callers reading only the text channel got nothing actionable.
+ *
+ * The fallback now mirrors the structured payload: title, node ID,
+ * canonical doc paths, full markdown size, and the first few
+ * outline headings so a reader can decide whether to fetch the
+ * full body or follow the docRef link.
+ */
+function renderReadFpfDocFallback(
+  structuredContent: Record<string, unknown>,
+): string {
+  const nodeId = stringField(structuredContent.nodeId);
+  const title = stringField(structuredContent.title);
+  const status = stringField(structuredContent.status);
+
+  if (!nodeId || status === 'not_found') {
+    return `read_fpf_doc: selector did not resolve to a known FPF node.${
+      status ? ` status=${status}` : ''
+    }`;
+  }
+
+  const docRef = (structuredContent.docRef ?? {}) as Record<string, unknown>;
+  const staticPath = stringField(docRef.staticPath);
+  const markdownPath = stringField(docRef.markdownPath);
+  const markdownChars = numberField(structuredContent.markdownChars);
+  const truncated = structuredContent.truncated === true;
+  const headings = arrayOfStrings(structuredContent.headings);
+  const preview = stringField(structuredContent.preview);
+
+  const lines: string[] = [];
+  lines.push(`# ${title ?? nodeId}`);
+  const meta: string[] = [`node \`${nodeId}\``];
+  if (staticPath) meta.push(`page \`${staticPath}\``);
+  if (markdownPath) meta.push(`markdown \`${markdownPath}\``);
+  if (markdownChars !== undefined) {
+    meta.push(`${markdownChars} chars${truncated ? ' (truncated)' : ''}`);
+  }
+  lines.push(meta.join(' · '));
+
+  if (headings && headings.length > 0) {
+    lines.push('');
+    lines.push('Outline:');
+    for (const heading of headings.slice(0, 8)) {
+      lines.push(`- ${heading}`);
+    }
+    if (headings.length > 8) {
+      lines.push(`- … (${headings.length - 8} more)`);
+    }
+  }
+
+  if (preview) {
+    lines.push('');
+    lines.push(preview);
+  } else {
+    lines.push('');
+    lines.push('Full markdown is in `structuredContent.markdown`.');
+  }
+
+  return lines.join('\n');
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function numberField(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function arrayOfStrings(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const filtered = value.filter((item): item is string => typeof item === 'string');
+  return filtered.length > 0 ? filtered : undefined;
 }

--- a/src/adapters/mcp/tools.ts
+++ b/src/adapters/mcp/tools.ts
@@ -157,14 +157,16 @@ export function createMcpTools(dependencies: McpToolDependencies) {
   const readFpfDocTool = createFpfMcpTool({
     id: 'read_fpf_doc',
     description:
-      'Resolve one FPF selector to the canonical generated markdown page and return exact text plus stable markdown/static paths.',
+      'Resolve one FPF selector to the canonical generated markdown page and return exact text plus stable markdown/static paths. Pass `mode: "preview"` for headings + size + a short snippet without the full markdown body.',
     inputSchema: readFpfDocInputSchema,
     outputSchema: readDocResultSchema,
-    execute: async ({ selector, kind, forceRefresh }) =>
+    execute: async ({ selector, kind, mode, maxChars, forceRefresh }) =>
       unwrapOutcome(
         await dependencies.inspectAppService.readDoc({
           selector,
           kind: kind ?? 'auto',
+          mode,
+          maxChars,
           forceRefresh: forceRefresh ?? false,
         }),
       ),

--- a/src/app/commands/index.ts
+++ b/src/app/commands/index.ts
@@ -38,6 +38,10 @@ export interface InspectFpfNodeCommand {
 export interface ReadFpfDocCommand {
   selector: string;
   kind?: 'auto' | 'id' | 'route' | 'lexeme';
+  /** Default 'full'; 'preview' omits markdown, returns headings + preview snippet. */
+  mode?: 'preview' | 'full';
+  /** Cap returned markdown length (UTF-16 code units). */
+  maxChars?: number;
   forceRefresh?: boolean;
 }
 

--- a/src/app/ports/runtime-port.ts
+++ b/src/app/ports/runtime-port.ts
@@ -36,7 +36,11 @@ export interface RuntimeQueryPort {
   readDoc(
     selector: string,
     kind?: 'auto' | 'id' | 'route' | 'lexeme',
-    forceRefresh?: boolean,
+    options?: {
+      mode?: 'preview' | 'full';
+      maxChars?: number;
+      forceRefresh?: boolean;
+    },
   ): Promise<ReadDocResult>;
   inspectAnchor(anchorId: string, forceRefresh?: boolean): Promise<InspectAnchorResult>;
   expandCitations(

--- a/src/app/services/inspect-app-service.ts
+++ b/src/app/services/inspect-app-service.ts
@@ -48,11 +48,11 @@ export class InspectAppService {
 
     try {
       return success(
-        await this.runtime.readDoc(
-          selector,
-          command.kind ?? 'auto',
-          command.forceRefresh ?? false,
-        ),
+        await this.runtime.readDoc(selector, command.kind ?? 'auto', {
+          mode: command.mode,
+          maxChars: command.maxChars,
+          forceRefresh: command.forceRefresh ?? false,
+        }),
       );
     } catch (error) {
       return runtimeError(error);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -479,7 +479,16 @@ export interface ReadDocResult {
   nodeId?: string;
   title?: string;
   docRef?: DocRef;
+  /** Page markdown. Omitted in preview mode; truncated when maxChars set. */
   markdown?: string;
+  /** Full character count of the page markdown, before truncation. */
+  markdownChars?: number;
+  /** Whether `markdown` was truncated to fit a caller-supplied maxChars. */
+  truncated?: boolean;
+  /** H2 / H3 heading text in document order, for outline navigation. */
+  headings?: string[];
+  /** Short text-content preview, set when mode: "preview". */
+  preview?: string;
   snapshot: {
     sourceHash: string;
     builtAt: string;

--- a/src/mcp/tool-contracts.ts
+++ b/src/mcp/tool-contracts.ts
@@ -393,7 +393,31 @@ export const readDocResultSchema = z
     nodeId: z.string().optional(),
     title: z.string().optional(),
     docRef: docRefSchema.optional(),
+    /**
+     * Page markdown. Omitted when `mode: "preview"`; truncated when
+     * `maxChars` is set (signaled by `truncated: true`).
+     */
     markdown: z.string().optional(),
+    /**
+     * Full character count of the page's markdown — independent of
+     * truncation, so callers know the original size before deciding
+     * whether to re-fetch with a higher `maxChars` or follow the
+     * `docRef` link.
+     */
+    markdownChars: z.number().int().nonnegative().optional(),
+    /** Whether `markdown` was truncated to fit `maxChars`. */
+    truncated: z.boolean().optional(),
+    /**
+     * H2 / H3 heading text in document order. Lets a caller see
+     * the page's outline without paying for the full markdown.
+     */
+    headings: z.array(z.string()).optional(),
+    /**
+     * Short text-content preview suitable for an MCP fallback
+     * surface or a search-result hover card. Set when
+     * `mode: "preview"` is requested; empty otherwise.
+     */
+    preview: z.string().optional(),
     snapshot: z
       .object({
         sourceHash: z.string(),
@@ -480,6 +504,25 @@ export const readFpfDocInputSchema = z
   .object({
     selector: z.string().min(1).max(MAX_SELECTOR_LENGTH),
     kind: selectorKindSchema.optional(),
+    /**
+     * `"preview"`: omit full markdown; return headings, char count,
+     *   and a short preview snippet.
+     * `"full"` (default): return the full markdown; still includes the
+     *   metadata fields (headings, markdownChars).
+     */
+    mode: z.enum(['preview', 'full']).optional(),
+    /**
+     * Cap returned `markdown` to this many UTF-16 code units. Doc
+     * pages can run >100 KB; default-mode callers exploring a
+     * catalog usually want a bounded slice. When truncated,
+     * `truncated: true` is set and a `…` marker is appended.
+     */
+    maxChars: z
+      .number()
+      .int()
+      .min(100)
+      .max(200000)
+      .optional(),
     forceRefresh: z.boolean().optional(),
   })
   .strict();

--- a/src/runtime/query-engine.ts
+++ b/src/runtime/query-engine.ts
@@ -354,6 +354,7 @@ export class QueryEngine {
   readDoc(
     selector: string,
     kind: 'auto' | 'id' | 'route' | 'lexeme' = 'auto',
+    options: { mode?: 'preview' | 'full'; maxChars?: number } = {},
   ): ReadDocResult {
     const resolved = this.resolveNode(selector, kind);
     if (!resolved) {
@@ -369,6 +370,33 @@ export class QueryEngine {
       return this.notFoundReadDoc(selector, resolvedAs);
     }
 
+    const fullMarkdown = page.markdown;
+    const markdownChars = fullMarkdown.length;
+    const headings = extractMarkdownHeadings(fullMarkdown);
+    const mode = options.mode ?? 'full';
+
+    if (mode === 'preview') {
+      return {
+        selector,
+        resolvedAs,
+        status: 'ok',
+        nodeId: docTarget.nodeId,
+        title: docTarget.title,
+        docRef: docTarget.docRef,
+        markdownChars,
+        headings,
+        preview: extractMarkdownPreview(fullMarkdown),
+        snapshot: this.snapshotRef(),
+      };
+    }
+
+    let markdown = fullMarkdown;
+    let truncated = false;
+    if (typeof options.maxChars === 'number' && options.maxChars < markdownChars) {
+      markdown = `${fullMarkdown.slice(0, options.maxChars)}\n\n…`;
+      truncated = true;
+    }
+
     return {
       selector,
       resolvedAs,
@@ -376,7 +404,10 @@ export class QueryEngine {
       nodeId: docTarget.nodeId,
       title: docTarget.title,
       docRef: docTarget.docRef,
-      markdown: page.markdown,
+      markdown,
+      markdownChars,
+      ...(truncated ? { truncated: true } : {}),
+      headings,
       snapshot: this.snapshotRef(),
     };
   }
@@ -636,4 +667,57 @@ function shouldUseDeterministicRouteFastPath(
   trace: TraceResult,
 ): boolean {
   return mode === 'compact' && trace.routeWins && trace.status === 'ok';
+}
+
+const MARKDOWN_PREVIEW_MAX_CHARS = 320;
+
+/**
+ * Walk the markdown body, collecting H2 / H3 heading text in document
+ * order. Skips fenced code blocks so a `## Example` line inside a
+ * code sample isn't mistaken for a real heading. Stops at the
+ * frontmatter block — the page's H1 is its title (returned
+ * separately on ReadDocResult.title) so we don't include it here.
+ */
+function extractMarkdownHeadings(markdown: string): string[] {
+  const headings: string[] = [];
+  const lines = markdown.split('\n');
+  let inFence = false;
+  for (const line of lines) {
+    if (/^[ ]{0,3}```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const match = /^(#{2,3})\s+(.+?)\s*$/.exec(line);
+    if (!match) continue;
+    headings.push(match[2]!);
+    if (headings.length >= 50) break;
+  }
+  return headings;
+}
+
+/**
+ * Build a short text-content preview suitable for an MCP fallback
+ * surface or a search-result hover card. Strips frontmatter, the
+ * leading H1, breadcrumb / byline HTML, and code fences; flattens
+ * whitespace; caps the result around MARKDOWN_PREVIEW_MAX_CHARS at a
+ * word boundary so the snippet doesn't end mid-word.
+ */
+function extractMarkdownPreview(markdown: string): string {
+  let text = markdown;
+  text = text.replace(/^---\n[\s\S]*?\n---\n/, '');
+  text = text.replace(/^<nav[^>]*>[\s\S]*?<\/nav>\n*/m, '');
+  text = text.replace(/^# .*\n/m, '');
+  text = text.replace(/^<p[^>]*>[\s\S]*?<\/p>\n*/m, '');
+  text = text.replace(/^[ ]{0,3}```[\s\S]*?^[ ]{0,3}```/gm, '');
+  text = text.replace(/<[^>]+>/g, '');
+  text = text.replace(/\s+/g, ' ').trim();
+
+  if (text.length <= MARKDOWN_PREVIEW_MAX_CHARS) {
+    return text;
+  }
+  const cut = text.slice(0, MARKDOWN_PREVIEW_MAX_CHARS);
+  const lastSpace = cut.lastIndexOf(' ');
+  const trimmed = lastSpace > 0 ? cut.slice(0, lastSpace) : cut;
+  return `${trimmed}…`;
 }

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -271,9 +271,13 @@ export class FpfRuntime {
   async readDoc(
     selector: string,
     kind: 'auto' | 'id' | 'route' | 'lexeme' = 'auto',
-    forceRefresh = false,
+    options: { mode?: 'preview' | 'full'; maxChars?: number; forceRefresh?: boolean } = {},
   ): Promise<ReadDocResult> {
-    return (await this.createEngine(forceRefresh)).readDoc(selector, kind);
+    const engine = await this.createEngine(options.forceRefresh ?? false);
+    return engine.readDoc(selector, kind, {
+      mode: options.mode,
+      maxChars: options.maxChars,
+    });
   }
 
   async inspectAnchor(anchorId: string, forceRefresh = false): Promise<InspectAnchorResult> {

--- a/tests/fpf-spec-runtime.test.ts
+++ b/tests/fpf-spec-runtime.test.ts
@@ -365,6 +365,30 @@ describe('FpfRuntime', () => {
     expect(readById.nodeId).toBe('A.1.1');
     expect(readById.docRef?.markdownPath).toBe('docs/generated/patterns/A.1.1.md');
     expect(readById.markdown).toContain('# U.BoundedContext: The Semantic Frame');
+    // Default-mode response carries metadata so callers can decide
+    // whether to re-fetch with maxChars or follow the docRef link.
+    expect(readById.markdownChars).toBe(readById.markdown!.length);
+    expect(Array.isArray(readById.headings)).toBe(true);
+    expect(readById.headings!.length).toBeGreaterThan(0);
+
+    // Preview mode omits the full body, exposes a short text snippet
+    // and the same headings outline.
+    const previewById = await runtime.readDoc('A.1.1', 'id', { mode: 'preview' });
+    expect(previewById.status).toBe('ok');
+    expect(previewById.markdown).toBeUndefined();
+    expect(previewById.markdownChars).toBe(readById.markdownChars);
+    expect(previewById.headings).toEqual(readById.headings);
+    expect(typeof previewById.preview).toBe('string');
+    expect(previewById.preview!.length).toBeGreaterThan(0);
+    expect(previewById.preview!.length).toBeLessThanOrEqual(400);
+
+    // maxChars truncates the body, signals truncation, and keeps
+    // markdownChars as the FULL pre-truncation size.
+    const cappedById = await runtime.readDoc('A.1.1', 'id', { maxChars: 500 });
+    expect(cappedById.status).toBe('ok');
+    expect(cappedById.markdown!.length).toBeLessThanOrEqual(550);
+    expect(cappedById.truncated).toBe(true);
+    expect(cappedById.markdownChars).toBe(readById.markdown!.length);
 
     const routes = await runtime.browse({ kind: 'route' });
     const routeIds = new Set(routes.entries.map((entry) => entry.id));

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -300,6 +300,38 @@ describe('direct MCP server', () => {
     const readDocPayload = asToolPayload(readDoc);
     expect(readDocPayload.nodeId).toBe('A.1.1');
     expect(readDocPayload.markdown).toContain('# U.BoundedContext: The Semantic Frame');
+    expect(typeof readDocPayload.markdownChars).toBe('number');
+    expect(Array.isArray(readDocPayload.headings)).toBe(true);
+
+    // Text-content fallback (audit item #5): readers on the text
+    // channel should see title + node ID + paths + size + outline
+    // headings, not the old single-line "markdown is in
+    // structuredContent" placeholder.
+    const readDocResult = (readDoc.result ?? {}) as {
+      content?: Array<{ type?: string; text?: string }>;
+    };
+    const textContent = readDocResult.content?.find(
+      (item) => item.type === 'text',
+    )?.text;
+    expect(typeof textContent).toBe('string');
+    expect(textContent).toContain('A.1.1');
+    expect(textContent).toContain('chars');
+    expect(textContent).toContain('Outline:');
+
+    // Preview mode (audit item #4): omit the full markdown body but
+    // still surface headings + a short preview snippet.
+    const readDocPreview = await harness.request('tools/call', {
+      name: 'read_fpf_doc',
+      arguments: {
+        selector: 'A.1.1',
+        mode: 'preview',
+      },
+    });
+    const previewPayload = asToolPayload(readDocPreview);
+    expect(previewPayload.markdown).toBeUndefined();
+    expect(typeof previewPayload.preview).toBe('string');
+    expect((previewPayload.preview as string).length).toBeGreaterThan(0);
+    expect(previewPayload.markdownChars).toBe(readDocPayload.markdownChars);
 
     const routeCatalog = await harness.request('tools/call', {
       name: 'browse_fpf_catalog',


### PR DESCRIPTION
## Summary

Addresses audit items **#4** (read_fpf_doc returns too much by default) and **#5** (MCP text fallback for doc reads is too thin).

## Input options

| Option | Default | Effect |
| --- | --- | --- |
| `mode: "preview" \| "full"` | `"full"` | `"preview"` omits the markdown body and returns just the outline + a short snippet. |
| `maxChars: number` | unset | Truncate the body. `truncated: true` is reported, and `markdownChars` always reports the full pre-truncation size. |

Default behavior with no options is unchanged — backward compatible.

## Output additions

- `markdownChars: number` — full size, set on every ok response.
- `headings: string[]` — H2/H3 outline in document order.
- `truncated?: boolean` — set when `maxChars` clipped the body.
- `preview?: string` — short text preview (preview mode only).

## Text-content fallback

Was:
> `read_fpf_doc returned markdown for A.1.1 in structuredContent.markdown.`

Now:
```
# U.BoundedContext: The Semantic Frame
node `A.1.1` · page `/generated/patterns/A.1.1` · markdown `docs/generated/patterns/A.1.1.md` · 51847 chars

Outline:
- About this pattern
- How to use this pattern
- Keywords
- Relations
- … (24 more)

Full markdown is in `structuredContent.markdown`.
```

Readers on the text channel can see the page outline + size at a glance and decide whether to fetch the full body or follow the docRef link.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run check` clean
- [x] `bun run test` — 315 passed (added inline assertions in existing readDoc / mcp-server tests covering preview / maxChars / fallback shape)
- [x] Manual sanity check via `runtime.readDoc('A.6', 'auto', { mode: 'preview' })` — preview snippet ~316 chars, headings extracted (28), markdown body omitted as expected.

## Out of scope

Audit item #2 (output-shape detection for query/ask) and #3 (confidence) follow as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the `read_fpf_doc` API contract and runtime `readDoc` behavior (preview/truncation), which could affect downstream tool consumers expecting full markdown or specific output shapes.
> 
> **Overview**
> Adds `mode: "preview" | "full"` and `maxChars` options to `read_fpf_doc`, allowing callers to omit the full markdown body or receive a truncated slice.
> 
> Extends `ReadDocResult` with `markdownChars`, `headings`, optional `preview`, and `truncated`, and updates the runtime to compute headings/preview from markdown while preserving backward-compatible default `full` behavior.
> 
> Improves MCP text-channel fallback for `read_fpf_doc` to include title/node metadata, doc paths, size, outline headings, and preview when available; updates schemas and tests to cover the new options and fallback output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5614184f96803fef5a61fb342d787e3cfef601b0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->