### PR TITLE
feat(mcp): detect output-shape requests; gate confidence on query quality

### DIFF
--- a/src/adapters/mcp/tools.ts
+++ b/src/adapters/mcp/tools.ts
@@ -308,6 +308,8 @@ export function renderAskFpfResult(result: QueryResult): AskFpfResult {
     gaps: result.gaps,
     confidence: result.confidence,
     candidateIds: result.candidateIds,
+    requestedShape: result.requestedShape,
+    shapeProduced: result.shapeProduced,
     status: result.status,
     snapshot: result.snapshot,
     groundingChain: result.groundingChain,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -330,6 +330,19 @@ export interface BuildAudit {
   artifacts: Record<string, string>;
 }
 
+/**
+ * Output shapes a caller may request in their question (e.g. "give me
+ * a checklist for…", "compare A and B", "template for FPF kickoff").
+ * Surfaced on QueryResult.requestedShape so the renderer / caller can
+ * tell whether the requested shape was honored.
+ */
+export type RequestedShape =
+  | 'template'
+  | 'checklist'
+  | 'table'
+  | 'matrix'
+  | 'compare';
+
 export interface QueryResult {
   mode: AnswerMode;
   question: string;
@@ -341,6 +354,15 @@ export interface QueryResult {
   confidence: number | null;
   gaps: string[];
   candidateIds?: string[];
+  /** Output shape detected in the question (e.g. "checklist", "table"). */
+  requestedShape?: RequestedShape;
+  /**
+   * Whether the projector produced output that matches `requestedShape`.
+   * `false` when the shape was asked for but only prose was returned —
+   * caller should treat that as a usability gap, not a satisfied
+   * answer.
+   */
+  shapeProduced?: boolean;
   snapshot: {
     sourceHash: string;
     builtAt: string;
@@ -360,6 +382,8 @@ export interface AskFpfResult {
   gaps: string[];
   confidence: number | null;
   candidateIds?: string[];
+  requestedShape?: RequestedShape;
+  shapeProduced?: boolean;
   status: AnswerStatus;
   snapshot: {
     sourceHash: string;

--- a/src/mcp/tool-contracts.ts
+++ b/src/mcp/tool-contracts.ts
@@ -202,6 +202,14 @@ export const buildAuditSchema = z
   })
   .strict();
 
+const requestedShapeSchema = z.enum([
+  'template',
+  'checklist',
+  'table',
+  'matrix',
+  'compare',
+]);
+
 export const queryResultSchema = z
   .object({
     mode: answerModeSchema,
@@ -214,6 +222,8 @@ export const queryResultSchema = z
     confidence: z.number().nullable(),
     gaps: z.array(z.string()),
     candidateIds: z.array(z.string()).optional(),
+    requestedShape: requestedShapeSchema.optional(),
+    shapeProduced: z.boolean().optional(),
     snapshot: snapshotWithRebuildSchema,
     status: answerStatusSchema,
     groundingChain: z.array(z.string()).optional(),
@@ -231,6 +241,8 @@ export const askFpfResultSchema = z
     gaps: z.array(z.string()),
     confidence: z.number().nullable(),
     candidateIds: z.array(z.string()).optional(),
+    requestedShape: requestedShapeSchema.optional(),
+    shapeProduced: z.boolean().optional(),
     status: answerStatusSchema,
     snapshot: snapshotWithRebuildSchema,
     groundingChain: z.array(z.string()).optional(),

--- a/src/runtime/answer-projector.ts
+++ b/src/runtime/answer-projector.ts
@@ -11,11 +11,79 @@ import type {
   AnswerMode,
   AnswerSlice,
   QueryResult,
+  RequestedShape,
   Snapshot,
   TraceResult,
 } from './types.js';
 
 import { MAX_SYNTHESIS_SLICES } from './constants.js';
+
+/**
+ * Detect a requested output shape in a natural-language question.
+ * Used to flag cases where a caller asks for a template / checklist
+ * / table / matrix / comparison and the projector currently returns
+ * prose. Order matters — more-specific phrasings are matched first.
+ */
+export function detectRequestedShape(
+  question: string,
+): RequestedShape | undefined {
+  const q = question.toLowerCase();
+  if (/\bdecision[\s-]?matrix\b|\beval(?:uation)?\s+matrix\b/.test(q)) {
+    return 'matrix';
+  }
+  if (
+    /\b(comparison\s+(table|chart|matrix)|side[\s-]?by[\s-]?side|compare\s+and\s+contrast)\b/
+      .test(q)
+  ) {
+    return 'compare';
+  }
+  if (/\bas\s+a\s+table\b|\bin\s+(?:a\s+)?table\b|\btable\s+of\b/.test(q)) {
+    return 'table';
+  }
+  if (/\bchecklist\b/.test(q)) {
+    return 'checklist';
+  }
+  if (/\btemplate\b/.test(q)) {
+    return 'template';
+  }
+  return undefined;
+}
+
+/**
+ * Whether the projector's prose-with-bullets answer satisfies the
+ * requested shape. Today only `checklist` is satisfied (a bullet
+ * list IS a checklist); the others surface as a gap so the caller
+ * sees the shape-mismatch instead of getting a falsely confident
+ * prose response.
+ */
+function shapeSatisfiedByDefaultProjection(
+  shape: RequestedShape | undefined,
+): boolean {
+  return shape === 'checklist' || shape === undefined;
+}
+
+/**
+ * A thin / semantically tiny question — too short to express intent,
+ * with no FPF terms detected. These should not return high-confidence
+ * answers regardless of how the retriever scored.
+ */
+export function isThinQuery(question: string, trace: TraceResult): boolean {
+  const meaningfulTokens = question
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 1);
+  if (meaningfulTokens.length < 3) {
+    return true;
+  }
+  const detected = trace.detected;
+  const recognizedAnyFpfTerm =
+    detected.ids.length > 0 ||
+    detected.lexemes.length > 0 ||
+    detected.routeNames.length > 0 ||
+    detected.familyTerms.length > 0 ||
+    detected.statusTerms.length > 0;
+  return !recognizedAnyFpfTerm && meaningfulTokens.length < 6;
+}
 
 export function buildRouteAnswer(
   question: string,
@@ -68,15 +136,27 @@ export function buildRouteAnswer(
     .filter(Boolean)
     .join(' ');
 
+  const requestedShape = detectRequestedShape(question);
+  const shapeProduced = shapeSatisfiedByDefaultProjection(requestedShape);
+  const shapeGaps =
+    requestedShape && !shapeProduced
+      ? [
+          `Requested "${requestedShape}" output shape, but the FPF projection returns prose with bullets. Open the cited pattern pages to author the ${requestedShape} from the source wording.`,
+        ]
+      : [];
+  const adjustedConfidence =
+    requestedShape && !shapeProduced ? 0.65 : 0.92;
+
   return buildResult(question, mode, rebuilt, snapshot, {
     answer,
     ids,
     relations,
     constraints,
     citations: unique(route.citations),
-    confidence: 0.92,
-    gaps: [],
+    confidence: adjustedConfidence,
+    gaps: shapeGaps,
     status: 'ok',
+    ...(requestedShape ? { requestedShape, shapeProduced } : {}),
     groundingChain:
       mode === 'proof'
         ? [
@@ -184,15 +264,25 @@ export function buildPatternAnswer(
       .map((edge) => ({ from: edge.from, relation: edge.relation, to: edge.to })),
   );
 
+  const requestedShape = detectRequestedShape(question);
+  const shapeProduced = shapeSatisfiedByDefaultProjection(requestedShape);
+  const shapeGaps =
+    requestedShape && !shapeProduced
+      ? [
+          `Requested "${requestedShape}" output shape, but the FPF projection returns prose with bullets. Open the cited pattern pages to author the ${requestedShape} from the source wording.`,
+        ]
+      : [];
+
   return buildResult(question, mode, rebuilt, snapshot, {
     answer,
     ids: patternIds,
     relations,
     constraints,
     citations,
-    confidence: confidenceFromTrace(trace),
-    gaps: gapsFromTrace(trace),
+    confidence: confidenceFromTrace(trace, question, requestedShape, shapeProduced),
+    gaps: [...gapsFromTrace(trace), ...shapeGaps],
     status: trace.status,
+    ...(requestedShape ? { requestedShape, shapeProduced } : {}),
     groundingChain:
       mode === 'proof'
         ? [
@@ -275,12 +365,36 @@ export function prepareSynthesisSlices(trace: TraceResult, snapshot: Snapshot): 
     }));
 }
 
-export function confidenceFromTrace(trace: TraceResult): number {
+export function confidenceFromTrace(
+  trace: TraceResult,
+  question?: string,
+  requestedShape?: RequestedShape,
+  shapeProduced?: boolean,
+): number {
   const top = trace.candidateScores[0]?.score ?? 0;
   const ambiguous = trace.status === 'ambiguous';
   const base = Math.min(0.98, 0.45 + top / 20);
-  const adjusted = trace.sufficient ? base : base - 0.1;
-  return ambiguous ? Math.max(0.35, adjusted - 0.2) : Math.max(0.3, adjusted);
+  let adjusted = trace.sufficient ? base : base - 0.1;
+
+  // Penalty: shape requested but the prose projection couldn't
+  // satisfy it. The retriever might have found relevant IDs, but
+  // the answer doesn't carry the shape the caller asked for.
+  if (requestedShape && shapeProduced === false) {
+    adjusted -= 0.2;
+  }
+
+  // Penalty: query is too thin / vague to express clear intent.
+  // High retrieval scores against a 2-token query are usually false
+  // confidence — the retriever picked the closest pattern, not the
+  // right one. Drop the floor so callers see "this is a guess."
+  if (question && isThinQuery(question, trace)) {
+    adjusted = Math.min(adjusted, 0.4);
+  }
+
+  if (ambiguous) {
+    return Math.max(0.2, adjusted - 0.2);
+  }
+  return Math.max(0.2, adjusted);
 }
 
 export function gapsFromTrace(trace: TraceResult): string[] {

--- a/src/runtime/query-engine.ts
+++ b/src/runtime/query-engine.ts
@@ -107,6 +107,31 @@ export class QueryEngine {
       });
     }
 
+    // Thin / vague query (audit item #3): the trace flagged the
+    // question as too tiny to express clear intent. Don't ride a
+    // high retrieval score into a confident answer; surface a
+    // clarification gap and the candidate IDs the retriever guessed
+    // at, so the caller can either refine or pick from those.
+    if (trace.status === 'unsupported') {
+      const candidateIds = trace.selectedNodeIds.slice(0, 5);
+      return this.result(question, mode, {
+        answer:
+          'The question is too short or generic to ground a confident answer. Add an FPF pattern ID, route name, or topic word, or pick a candidate ID below.',
+        ids: [],
+        relations: [],
+        constraints: [],
+        citations: [],
+        confidence: 0.2,
+        candidateIds,
+        gaps: [
+          candidateIds.length > 0
+            ? `Closest retrieval candidates: ${candidateIds.join(', ')}. Re-ask with one of these IDs or with a route / topic word.`
+            : 'Re-ask with an FPF pattern ID, route name, or topic word.',
+        ],
+        status: 'unsupported',
+      });
+    }
+
     const routeNodeId = trace.routeWins
       ? trace.selectedNodeIds.find(
           (nodeId) => this.snapshot.compiledNodes[nodeId]?.kind === 'route',
@@ -200,14 +225,35 @@ export class QueryEngine {
     const sessionReusedNodeIds = this.sessionState
       ? selectedNodeIds.filter((nodeId) => this.sessionState?.lastSelectedNodeIds.includes(nodeId))
       : [];
+    // Determine status. Two-token / no-FPF-term queries (e.g. "messy
+    // project", "?") shouldn't ride high retrieval scores into a
+    // confident "ok"; mark them `unsupported` so callers can ask the
+    // user to clarify instead of treating the closest-pattern guess
+    // as a real answer.
+    const meaningfulTokens = question
+      .trim()
+      .split(/\s+/)
+      .filter((token) => token.length > 1);
+    const recognizedFpfTerm =
+      normalized.detected.ids.length > 0 ||
+      normalized.detected.lexemes.length > 0 ||
+      normalized.detected.routeNames.length > 0 ||
+      normalized.detected.familyTerms.length > 0 ||
+      normalized.detected.statusTerms.length > 0;
+    const thinQuery =
+      meaningfulTokens.length < 3 ||
+      (!recognizedFpfTerm && meaningfulTokens.length < 6);
+
     const status =
       selectedNodeIds.length === 0
         ? 'not_found'
-        : ranking.routeWins
-          ? 'ok'
-          : isAmbiguous(question, ranking.candidates)
-            ? 'ambiguous'
-            : 'ok';
+        : thinQuery
+          ? 'unsupported'
+          : ranking.routeWins
+            ? 'ok'
+            : isAmbiguous(question, ranking.candidates)
+              ? 'ambiguous'
+              : 'ok';
 
     return {
       mode,

--- a/tests/query-contracts.test.ts
+++ b/tests/query-contracts.test.ts
@@ -1,11 +1,13 @@
 import { createHash } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
+import { copyFile, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 
-import { describe, expect, it } from '@rstest/core';
+import { afterEach, beforeEach, describe, expect, it } from '@rstest/core';
 
 import { DEFAULT_SOURCE_PATH } from '../src/core/constants.js';
 import { compileFpfSource } from '../src/runtime/compiler.js';
+import { FpfRuntime } from '../src/runtime/runtime.js';
 import { normalizeQuery } from '../src/runtime/query-normalizer.js';
 import { seedCandidates } from '../src/runtime/candidate-seeder.js';
 import { isAmbiguous, rankCandidates } from '../src/runtime/candidate-ranker.js';
@@ -1017,5 +1019,72 @@ describe('Query / Trace determinism', () => {
     const trace2 = assembleTrace('How does bounded context relate to role assignment?', 'verbose', snapshot);
 
     expect(JSON.stringify(trace1)).toBe(JSON.stringify(trace2));
+  });
+});
+
+describe('Query / Quality + shape gating', () => {
+  const canonicalSourcePath = resolve(process.cwd(), DEFAULT_SOURCE_PATH);
+  let runtime: FpfRuntime;
+  let tempRoot: string;
+  let sourcePath: string;
+  let artifactDir: string;
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(resolve(tmpdir(), 'fpf-quality-'));
+    sourcePath = resolve(tempRoot, 'FPF-spec.md');
+    artifactDir = resolve(tempRoot, 'artifacts');
+    await copyFile(canonicalSourcePath, sourcePath);
+    runtime = new FpfRuntime({ sourcePath, artifactDir });
+  });
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('returns status: "unsupported" with low confidence for a thin two-token query', async () => {
+    // Audit item #3: queries like "messy project" used to ride high
+    // retrieval scores into a confident "ok" answer. They should now
+    // surface as unsupported with a clarification gap and the closest
+    // candidate IDs so the caller can refine.
+    const result = await runtime.query('messy project');
+    expect(result.status).toBe('unsupported');
+    expect(result.confidence).not.toBeNull();
+    expect(result.confidence!).toBeLessThanOrEqual(0.3);
+    expect(result.ids).toEqual([]);
+    expect(result.gaps.length).toBeGreaterThan(0);
+    // At least one gap should mention how to re-ask.
+    expect(result.gaps.some((gap) => /re-ask|refine|candidate/i.test(gap))).toBe(true);
+  });
+
+  it('returns status: "unsupported" for a near-empty query like "?"', async () => {
+    const result = await runtime.query('?');
+    expect(result.status).toBe('unsupported');
+    expect(result.confidence!).toBeLessThanOrEqual(0.3);
+  });
+
+  it('flags requestedShape and shapeProduced when caller asks for a template', async () => {
+    // Audit item #2: caller asks for a template; default projection
+    // returns prose. The response should expose `requestedShape:
+    // "template"` and `shapeProduced: false`, surface a gap about the
+    // mismatch, and reduce confidence.
+    const result = await runtime.query(
+      'Give me a template for measurement-template work',
+      'compact',
+    );
+    expect(result.requestedShape).toBe('template');
+    expect(result.shapeProduced).toBe(false);
+    expect(result.gaps.some((gap) => /template/i.test(gap) && /shape/i.test(gap))).toBe(true);
+    expect(result.confidence!).toBeLessThanOrEqual(0.85);
+  });
+
+  it('marks a checklist request as produced because the bullet projection satisfies it', async () => {
+    // Bullet lists ARE checklists for the purposes of this surface;
+    // shapeProduced should be true and confidence should be untouched.
+    const result = await runtime.query(
+      'Give me a checklist for project alignment kickoff',
+      'compact',
+    );
+    expect(result.requestedShape).toBe('checklist');
+    expect(result.shapeProduced).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Closes audit items **#2** (answer projector ignored requested output shape) and **#3** (confidence overstated usefulness on thin queries).

## #2 — Shape detection

Detect 5 requested shapes in the question: `template`, `checklist`, `table`, `matrix`, `compare`. Set `requestedShape` and `shapeProduced` on the response. The bullet-list projection already satisfies `checklist`; for the other four the projector currently returns prose, so:

- `shapeProduced: false`
- A gap line: *"Requested 'template' output shape, but the FPF projection returns prose with bullets. Open the cited pattern pages to author the template from the source wording."*
- Confidence dropped by 0.2

This is the smaller-effort half of the fix the audit asked for: the response now SAYS when it didn't satisfy the shape, instead of pretending. Actually rendering templates / tables / matrices from the spec data is a separate, bigger piece of work.

## #3 — Confidence + thin queries

| Signal | Effect |
| --- | --- |
| Question has < 3 meaningful tokens, or < 6 tokens AND no detected FPF terms | `status: "unsupported"`, `confidence: 0.2`, empty `ids`, retriever's top 5 candidates returned in `candidateIds`, clarification gap |
| Requested shape but not produced | `confidence -= 0.2` |

Verified the audit's exact failure cases on a fresh runtime:

```
"messy project"            → unsupported, conf 0.2, candidates [route:project-alignment, A.15]
"?"                        → unsupported, conf 0.2, candidates [A.0, A.1.1]
"…template for measurement-template work" → ok, shape: template, produced: false, conf 0.78, gap
"…checklist for project alignment kickoff" → ok, shape: checklist, produced: true, conf 0.92
```

## Test plan

- [x] `bun run lint` clean
- [x] `bun run check` clean
- [x] `bun run test` — 319 passed (was 315; +4 new tests covering thin-query unsupported, near-empty unsupported, template-shape gap, checklist-shape produced)
- [x] Manual repro of the audit's vague-query and shape-request examples — all behaving as the audit asked.

## Out of scope

Actually rendering templates / tables / matrices / decision matrices is left for a future PR — the surface-the-gap behavior gives callers the signal they need today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the query result contract and modifies query/answer scoring and status classification, which can affect downstream clients and behavior for borderline queries. Logic is straightforward and covered by new tests, but impacts core answer projection paths.
> 
> **Overview**
> Adds **output-shape detection** to query responses: questions that ask for a `template`/`table`/`matrix`/`compare`/`checklist` now surface `requestedShape` plus whether that shape was actually produced (`shapeProduced`), and mismatches add a gap and reduce confidence.
> 
> Introduces **thin-query gating** so very short/vague questions return `status: "unsupported"` with low confidence and suggested `candidateIds`, rather than presenting a confident grounded answer. Contracts and MCP rendering are updated to carry the new fields, with tests covering both shape-mismatch and thin-query scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 697d60aacdcd24a34dcc7e4980ba3d020c84f1e0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->