### PR TITLE
feat(mcp): expose candidateIds when query status is "ambiguous"

### DIFF
--- a/src/runtime/answer-projector.ts
+++ b/src/runtime/answer-projector.ts
@@ -273,6 +273,17 @@ export function buildPatternAnswer(
         ]
       : [];
 
+  // Audit follow-up D: when the retrieval came back ambiguous, the
+  // selected `ids` are the multiple winners that scored within the
+  // tie band — but the trace also has the surrounding ranked
+  // candidates that the caller may want to consider when picking
+  // among them. Surface the top of `candidateScores` so the caller
+  // can disambiguate without a second round-trip.
+  const ambiguousCandidateIds =
+    trace.status === 'ambiguous' && trace.candidateScores.length > 0
+      ? trace.candidateScores.slice(0, 6).map((candidate) => candidate.nodeId)
+      : undefined;
+
   return buildResult(question, mode, rebuilt, snapshot, {
     answer,
     ids: patternIds,
@@ -282,6 +293,7 @@ export function buildPatternAnswer(
     confidence: confidenceFromTrace(trace, question, requestedShape, shapeProduced),
     gaps: [...gapsFromTrace(trace), ...shapeGaps],
     status: trace.status,
+    ...(ambiguousCandidateIds ? { candidateIds: ambiguousCandidateIds } : {}),
     ...(requestedShape ? { requestedShape, shapeProduced } : {}),
     groundingChain:
       mode === 'proof'

--- a/tests/query-contracts.test.ts
+++ b/tests/query-contracts.test.ts
@@ -1087,4 +1087,31 @@ describe('Query / Quality + shape gating', () => {
     expect(result.requestedShape).toBe('checklist');
     expect(result.shapeProduced).toBe(true);
   });
+
+  it('returns candidateIds when status is "ambiguous" so callers can disambiguate', async () => {
+    // Audit follow-up D: ambiguous trace selects multiple winners
+    // within a tie band, but the caller usually wants to see the
+    // surrounding ranked candidates too — pick from a wider pool
+    // without a second round-trip. The top of `candidateScores`
+    // (~6 ids) is exposed via `candidateIds` whenever status is
+    // ambiguous.
+    const result = await runtime.query(
+      'How does role assignment relate to bounded context and capability?',
+      'compact',
+    );
+    if (result.status !== 'ambiguous') {
+      // Snapshot drift may make the question unambiguous on this
+      // particular spec; skip the assertion in that case rather than
+      // fail brittly.
+      return;
+    }
+    expect(Array.isArray(result.candidateIds)).toBe(true);
+    expect(result.candidateIds!.length).toBeGreaterThan(0);
+    expect(result.candidateIds!.length).toBeLessThanOrEqual(6);
+    // The selected (ambiguous-winner) ids must be a subset of the
+    // wider candidate set the caller is shown.
+    for (const id of result.ids) {
+      expect(result.candidateIds).toContain(id);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Audit follow-up **D** from the second-round MCP review. When `query_fpf_spec` returns `status: "ambiguous"` (multiple patterns scored within the tie band), the response now also returns up to 6 `candidateIds` from the wider ranked pool — so the caller can disambiguate without a second round-trip.

Mirrors PR #118's existing behavior for `unsupported`.

## Before / after

```
Q: "How does role assignment relate to bounded context and capability?"
─ Before ──────────────────────────  ─ After ──────────────────────────
status: ambiguous                    status: ambiguous
ids: [A.2.1, F.6]                    ids: [A.2.1, F.6]
                                     candidateIds: [A.2.1, F.6, A.1.1, A.2.7, F.3, A.2]
```

The selected ids stay a subset of `candidateIds` (same `trace.candidateScores` source, just a wider slice).

## Test plan

- [x] `bun run lint` clean
- [x] `bun run check` clean
- [x] `bun run test` — 325 passed (+1 new test for ambiguous → candidateIds)
- [x] Manual repro on the snapshot — confirmed exact "How does role assignment relate to bounded context and capability?" returns ambiguous + 6 candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `candidateIds` field to the projected query result only when `status` is `ambiguous`, plus a targeted contract test; no retrieval/ranking logic changes.
> 
> **Overview**
> When a query returns `status: "ambiguous"`, the response now also includes up to 6 `candidateIds` from the top of `trace.candidateScores` so callers can disambiguate without an extra query.
> 
> Adds a contract test that conditionally asserts `candidateIds` is present/limited when ambiguity occurs and that the selected `ids` remain a subset of the returned candidates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b91e744b58145e6c4df3b4a4ed6a6c521f752336. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->