### PR TITLE
fix(ci): update sync PR action for checkout v6

### DIFF
--- a/.github/workflows/sync-fpf.yml
+++ b/.github/workflows/sync-fpf.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Open sync PR
         if: steps.detect.outputs.changed == 'true'
         id: pr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/sync-fpf-${{ steps.detect.outputs.short_ref }}


### PR DESCRIPTION
## Summary
- Update `peter-evans/create-pull-request` from v6 to v8 in the Sync FPF Publication workflow.
- Fixes the `Duplicate header: "Authorization"` failure observed after `actions/checkout@v6` changed credential persistence.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/sync-fpf.yml"); puts "sync-fpf.yml parsed"'`\n
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->