### PR TITLE
chore(ci): reduce TPR fast-track runs

### DIFF
--- a/.github/workflows/tpr-fast-track.yml
+++ b/.github/workflows/tpr-fast-track.yml
@@ -1,10 +1,9 @@
 name: TPR Fast Track
 
 on:
-  pull_request_target:
-    types: [opened, edited, reopened, ready_for_review, synchronize]
   schedule:
-    - cron: '*/15 * * * *'
+    # Twice daily background sweep.
+    - cron: '0 6,18 * * *'
   workflow_dispatch:
     inputs:
       pr:
@@ -19,7 +18,7 @@ permissions:
   statuses: read
 
 concurrency:
-  group: tpr-fast-track-${{ github.event.pull_request.number || github.event.inputs.pr || github.event_name }}
+  group: tpr-fast-track-${{ github.event.inputs.pr || github.event_name }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## What

This PR reduces TPR Fast Track automation noise by removing PR-event triggers and limiting the background schedule to two runs per day.

## Why

The previous schedule could run up to 96 times per day, plus extra runs on PR open/edit/synchronize events. That created too much Actions activity for a timer workflow.

## Type

- `feat` — new capability
- `fix` — bug fix
- `refactor` — code restructuring
- `docs` — documentation only
- `chore` — maintenance (deps, CI, cleanup)

## Changes

- Change the scheduled TPR Fast Track sweep to `0 6,18 * * *`.
- Remove the `pull_request_target` trigger so PR events no longer start this workflow.
- Simplify the concurrency group now that PR event payloads are not used.

## Validation

- `bun run lint` not run; workflow-only scheduling change.
- `bun run check` not run; workflow-only scheduling change.
- `bun run test` not run; workflow-only scheduling change.
- No new warnings introduced: not applicable; no runtime code touched.
- `bun run build` not run; no runtime/server code touched.
- `bun run docs:build` not run; no docs touched.
- Relevant docs updated: not applicable.
- End-to-end verification command + output excerpt:
  - `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/tpr-fast-track.yml` -> `yaml ok`
  - `git diff --check` -> no output
- Caveats or blocker: GitHub schedule behavior will be confirmed after merge by observing the next scheduled run.

## TPR fast-track

- [ ] Enable TPR review/merge timer

Use this only for small, reversible PRs from trusted maintainers or collaborators. The timer does not fake approval or bypass branch protection:

- after 1 hour without a non-author review signal, automation comments `@codex review`;
- after 2 hours, automation enables auto-merge only when checks pass, no trusted reviewer requested changes, and at least one trusted non-author approval exists for the current head commit.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts`

## Agent metadata






| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | local |
| Prompt  | Reduce noisy TPR Fast Track Actions and push/create PR |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only trigger/schedule changes; main risk is reduced automation responsiveness or missed runs if the new schedule/dispatch assumptions are wrong.
> 
> **Overview**
> Reduces `TPR Fast Track` GitHub Actions noise by **removing the `pull_request_target` trigger** so PR events no longer start the workflow.
> 
> Adjusts scheduling to a **twice-daily sweep** (`0 6,18 * * *`) and simplifies the `concurrency.group` to no longer depend on PR event payload fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b78b9fe4f3c3194206070b040df3287f0577c817. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->