### PR TITLE
fix(mcp): route product feedback prompts to packet

### DIFF
--- a/published/current/manifest.json
+++ b/published/current/manifest.json
@@ -1,12 +1,12 @@
 {
   "channel": "latest-published",
   "sourceHash": "sha256:f86b7e00c39bb0e9b817917f807b5514048d763988c682b81a61b8190cba7158",
-  "compilerFingerprint": "sha256:fb4598cc919f65dca49d0ae696174c75c1ddd6524c541ec2942d25c1088f3dd3",
+  "compilerFingerprint": "sha256:c2fbf6866f4b84ba43f5a8885e683d8e3cee7761148ceac9d10b205ee4cf3bff",
   "upstreamRef": "16cd31387cff04ab6b0feef22717f82ac54efa8f",
   "upstreamRepoUrl": "https://github.com/ailev/FPF",
   "upstreamCommittedAt": "2026-05-31T07:57:58Z",
   "specPath": "published/current/FPF-Spec.md",
   "snapshotPath": "published/current/fpf-index/snapshot.json",
   "specBytes": 8105549,
-  "publishedAt": "2026-05-31T19:47:12.869Z"
+  "publishedAt": "2026-06-01T00:22:55.806Z"
 }

--- a/src/runtime/answer-projector.ts
+++ b/src/runtime/answer-projector.ts
@@ -3,6 +3,7 @@ import {
   getPartCDraftsByCluster,
   selectBestAnchors,
 } from './compiler.js';
+import { hasProductRoleFeedbackIntent } from './route-intent-signals.js';
 import {
   unique,
 } from './text.js';
@@ -91,12 +92,19 @@ export function buildRouteAnswer(
   rebuilt: boolean,
 ): QueryResult {
   const route = snapshot.routeGraph.nodes[routeNodeId]!;
+  const productRoleFeedbackPacket = isProductRoleFeedbackPacket(routeNodeId, question);
+  const supplementalIds = productRoleFeedbackPacket
+    ? ['E.12', 'A.1.1', 'A.15', 'A.2.2', 'A.2.3'].filter(
+        (id) => Boolean(snapshot.compiledNodes[id]),
+      )
+    : [];
   // Include routeSurfaces alongside the ordered/optional/landing lists.
   // Some routes (e.g. boundary-unpacking-claim-routing) only declare
   // surfaces; without this fallback the structured `ids` response would
   // be just the route ID, hiding the patterns the answer prose names.
   const ids = unique([
     routeNodeId,
+    ...supplementalIds,
     ...route.orderedIds,
     ...route.optionalIds,
     ...route.landingIds,
@@ -112,11 +120,20 @@ export function buildRouteAnswer(
     route.firstHonestBurden
       ? `First honest burden: ${route.firstHonestBurden}.`
       : 'Choose this route only when the stated burden matches the present problem.',
+    ...(productRoleFeedbackPacket
+      ? [
+          'Use the product-role feedback packet: E.12 plus A.1.1, A.15, A.2.2, and A.2.3 before escalating to broader spec-writing guidance.',
+          'Do not paste the whole FPF, and do not load E.8/E.19 unless the feedback is actually about writing or revising FPF pattern text.',
+        ]
+      : []),
     ...(route.constraints ?? []),
   ];
   const answer = [
     `${route.id} (${route.name}) is the matched first-practical route.`,
     route.firstHonestBurden ? `Burden: ${route.firstHonestBurden}.` : '',
+    productRoleFeedbackPacket
+      ? `Product-role feedback packet IDs: ${supplementalIds.join(', ')}.`
+      : '',
     route.orderedIds.length > 0
       ? `Ordered entry IDs: ${route.orderedIds.join(' -> ')}.`
       : '',
@@ -124,8 +141,8 @@ export function buildRouteAnswer(
       ? `Conditional additions: ${route.optionalIds.join(', ')}.`
       : '',
     route.landingIds.length > 0 ? `Landing surface: ${route.landingIds.join(', ')}.` : '',
-    `Acceptance check: ${routeAcceptanceCheck(routeNodeId, route)}.`,
-    `Next move: ${routeNextMove(routeNodeId, route)}.`,
+    `Acceptance check: ${routeAcceptanceCheck(routeNodeId, route, question)}.`,
+    `Next move: ${routeNextMove(routeNodeId, route, question)}.`,
     route.routeSurfaces.length > 0
       ? `Route-bearing surfaces: ${route.routeSurfaces.join(', ')}.`
       : '',
@@ -176,7 +193,11 @@ export function buildRouteAnswer(
 function routeAcceptanceCheck(
   routeNodeId: string,
   route: Snapshot['routeGraph']['nodes'][string],
+  question: string,
 ): string {
+  if (isProductRoleFeedbackPacket(routeNodeId, question)) {
+    return 'the role/job can be replayed by another person, the feedback points at exact evidence, and the output lands as one focused PR, issue, discussion, or no-new-feedback checkpoint';
+  }
   switch (routeNodeId) {
     case 'route:project-alignment':
       return 'a shared kickoff packet names the bounded context, actor roles, role/method/work split, first work-plan item, evidence to collect, and UTS-ready terms';
@@ -194,7 +215,11 @@ function routeAcceptanceCheck(
 function routeNextMove(
   routeNodeId: string,
   route: Snapshot['routeGraph']['nodes'][string],
+  question: string,
 ): string {
+  if (isProductRoleFeedbackPacket(routeNodeId, question)) {
+    return 'name the persona/job and surface first, use E.12 with A.1.1, A.15, A.2.2, and A.2.3 to capture one adoption friction, then stop at one proposed improvement with severity and validation path';
+  }
   switch (routeNodeId) {
     case 'route:project-alignment':
       return 'read A.1.1 and A.15 first, draft the kickoff worksheet, then add A.15.2/A.15.3 only when the plan/run split must be made explicit';
@@ -207,6 +232,10 @@ function routeNextMove(
         ? `start with ${route.orderedIds[0]} and stop when the first bounded work packet is explicit`
         : 'use the route page as the bounded packet and open exact pattern pages only as needed';
   }
+}
+
+function isProductRoleFeedbackPacket(routeNodeId: string, question: string): boolean {
+  return routeNodeId === 'route:project-alignment' && hasProductRoleFeedbackIntent(question);
 }
 
 export function buildPatternAnswer(

--- a/src/runtime/compiler.ts
+++ b/src/runtime/compiler.ts
@@ -35,6 +35,8 @@ import {
   AGENT_WORKFLOW_JOB_SIGNALS,
   BOUNDARY_BURDEN_SIGNALS,
   BOUNDARY_REVIEW_RULE_JOB_SIGNALS,
+  PRODUCT_ROLE_FEEDBACK_OUTPUT_SIGNALS,
+  PRODUCT_ROLE_FEEDBACK_ROLE_SIGNALS,
 } from './route-intent-signals.js';
 import { buildValidation } from './validation-runner.js';
 import type {
@@ -249,6 +251,20 @@ function buildHeuristicSeedRules(
       initialNodeIds: [],
       routeId: alignmentRoute.id,
       routeScore: 88,
+    });
+    const productRoleFeedbackNodeIds = ['E.12', 'A.1.1', 'A.15', 'A.2.2', 'A.2.3'].filter(
+      (id) => id in patternNodes || id in routeNodes,
+    );
+    rules.push({
+      name: 'product-role-feedback',
+      allOf: [[...PRODUCT_ROLE_FEEDBACK_ROLE_SIGNALS]],
+      anyOf: [[...PRODUCT_ROLE_FEEDBACK_OUTPUT_SIGNALS, ...AGENT_WORKFLOW_BOUNDED_RETRIEVAL_SIGNALS]],
+      seedNodeIds: productRoleFeedbackNodeIds,
+      seedScore: 20,
+      seedOrigin: 'route_expansion',
+      initialNodeIds: [],
+      routeId: alignmentRoute.id,
+      routeScore: 92,
     });
     rules.push({
       name: 'vocabulary-alignment',

--- a/src/runtime/route-intent-signals.ts
+++ b/src/runtime/route-intent-signals.ts
@@ -104,8 +104,12 @@ export function hasProductRoleFeedbackIntent(question: string): boolean {
   const hasRoleSignal = PRODUCT_ROLE_FEEDBACK_ROLE_SIGNALS.some((phrase) =>
     normalizedQuestion.includes(phrase),
   );
-  const hasOutputSignal = PRODUCT_ROLE_FEEDBACK_OUTPUT_SIGNALS.some((phrase) =>
-    normalizedQuestion.includes(phrase),
-  );
-  return hasRoleSignal && hasOutputSignal;
+  const hasQualifyingSignal =
+    PRODUCT_ROLE_FEEDBACK_OUTPUT_SIGNALS.some((phrase) =>
+      normalizedQuestion.includes(phrase),
+    ) ||
+    AGENT_WORKFLOW_BOUNDED_RETRIEVAL_SIGNALS.some((phrase) =>
+      normalizedQuestion.includes(phrase),
+    );
+  return hasRoleSignal && hasQualifyingSignal;
 }

--- a/src/runtime/route-intent-signals.ts
+++ b/src/runtime/route-intent-signals.ts
@@ -68,6 +68,25 @@ export const AGENT_WORKFLOW_BOUNDED_RETRIEVAL_SIGNALS = [
   'instead of pasting',
 ] as const;
 
+export const PRODUCT_ROLE_FEEDBACK_ROLE_SIGNALS = [
+  'product maintainer',
+  'product feedback',
+  'product-role feedback',
+  'product role feedback',
+  'role feedback',
+  'role-feedback',
+  'dogfood',
+] as const;
+
+export const PRODUCT_ROLE_FEEDBACK_OUTPUT_SIGNALS = [
+  'adoption improvement',
+  'live product smoke',
+  'discussion-ready',
+  'discussion ready',
+  'severity',
+  'validation path',
+] as const;
+
 export const WRITING_OR_REVIEWING_PATTERN_SIGNALS = [
   'spec writer',
   'spec writing',
@@ -78,4 +97,15 @@ export const WRITING_OR_REVIEWING_PATTERN_SIGNALS = [
 
 export function hasBoundaryReviewNegation(normalizedQuestion: string): boolean {
   return BOUNDARY_REVIEW_NEGATIONS.some((phrase) => normalizedQuestion.includes(phrase));
+}
+
+export function hasProductRoleFeedbackIntent(question: string): boolean {
+  const normalizedQuestion = question.toLowerCase();
+  const hasRoleSignal = PRODUCT_ROLE_FEEDBACK_ROLE_SIGNALS.some((phrase) =>
+    normalizedQuestion.includes(phrase),
+  );
+  const hasOutputSignal = PRODUCT_ROLE_FEEDBACK_OUTPUT_SIGNALS.some((phrase) =>
+    normalizedQuestion.includes(phrase),
+  );
+  return hasRoleSignal && hasOutputSignal;
 }

--- a/src/runtime/route-intent-signals.ts
+++ b/src/runtime/route-intent-signals.ts
@@ -1,3 +1,8 @@
+import {
+  normalizeForLookup,
+  tokenize,
+} from './text.js';
+
 export const BOUNDARY_REVIEW_NEGATIONS = [
   'do not treat this as an api contract review',
   'do not treat this as a contract review',
@@ -100,16 +105,31 @@ export function hasBoundaryReviewNegation(normalizedQuestion: string): boolean {
 }
 
 export function hasProductRoleFeedbackIntent(question: string): boolean {
-  const normalizedQuestion = question.toLowerCase();
+  const normalizedQuestion = normalizeForLookup(question);
+  const queryTokens = new Set(tokenize(normalizedQuestion));
   const hasRoleSignal = PRODUCT_ROLE_FEEDBACK_ROLE_SIGNALS.some((phrase) =>
-    normalizedQuestion.includes(phrase),
+    matchesIntentSignal(normalizedQuestion, queryTokens, phrase),
   );
   const hasQualifyingSignal =
     PRODUCT_ROLE_FEEDBACK_OUTPUT_SIGNALS.some((phrase) =>
-      normalizedQuestion.includes(phrase),
+      matchesIntentSignal(normalizedQuestion, queryTokens, phrase),
     ) ||
     AGENT_WORKFLOW_BOUNDED_RETRIEVAL_SIGNALS.some((phrase) =>
-      normalizedQuestion.includes(phrase),
+      matchesIntentSignal(normalizedQuestion, queryTokens, phrase),
     );
   return hasRoleSignal && hasQualifyingSignal;
+}
+
+function matchesIntentSignal(
+  normalizedQuestion: string,
+  queryTokens: Set<string>,
+  phrase: string,
+): boolean {
+  const phraseTokens = tokenize(phrase);
+  if (phraseTokens.length > 0) {
+    return phraseTokens.every((token) => queryTokens.has(token));
+  }
+
+  const normalizedPhrase = normalizeForLookup(phrase);
+  return normalizedPhrase.length > 0 && normalizedQuestion.includes(normalizedPhrase);
 }

--- a/tests/fpf-spec-runtime.test.ts
+++ b/tests/fpf-spec-runtime.test.ts
@@ -220,6 +220,49 @@ describe('FpfRuntime', () => {
     expect(agentWorkflow.answer.length).toBeGreaterThan(0);
     expect(agentWorkflow.citations.length).toBeGreaterThan(0);
 
+    const productMaintainer = await runtime.query(
+      'As a product maintainer, turn live product smoke evidence plus recurring role-feedback discussions into one adoption improvement, severity, and validation path without reading or pasting the full FPF.',
+      'compact',
+    );
+    if (routeIds.has('route:project-alignment')) {
+      expect(productMaintainer.status).toBe('ok');
+      expect(productMaintainer.ids).toEqual(
+        expect.arrayContaining([
+          'route:project-alignment',
+          'E.12',
+          'A.1.1',
+          'A.15',
+          'A.2.2',
+          'A.2.3',
+        ]),
+      );
+      expect(productMaintainer.answer).toContain('Product-role feedback packet IDs');
+    } else {
+      expect(['ok', 'ambiguous']).toContain(productMaintainer.status);
+      expect(productMaintainer.ids.every((id) => !id.startsWith('route:'))).toBe(true);
+    }
+    expect(productMaintainer.answer.length).toBeGreaterThan(0);
+    expect(productMaintainer.citations.length).toBeGreaterThan(0);
+
+    const unavailableSynthesizer = new FpfRuntime({
+      artifactDir: resolve(tempRoot, 'deterministic-artifacts'),
+      sourcePath,
+      synthesizer: {
+        isAvailable: async () => false,
+        synthesize: async () => {
+          throw new Error('deterministic fallback should skip unavailable synthesis');
+        },
+      },
+    });
+    const degradedAnswer = await unavailableSynthesizer.query(
+      'What is U.BoundedContext?',
+      'compact',
+    );
+    expect(degradedAnswer.status).toBe('degraded');
+    expect(degradedAnswer.ids).toEqual([]);
+    expect(degradedAnswer.candidateIds).toContain('A.1.1');
+    expect(degradedAnswer.confidence).toBeNull();
+
     const creativity = await runtime.query(
       'How is creativity and open-ended search represented in FPF?',
       'verbose',

--- a/tests/fpf-spec-runtime.test.ts
+++ b/tests/fpf-spec-runtime.test.ts
@@ -244,6 +244,34 @@ describe('FpfRuntime', () => {
     expect(productMaintainer.answer.length).toBeGreaterThan(0);
     expect(productMaintainer.citations.length).toBeGreaterThan(0);
 
+    const boundedProductMaintainer = await runtime.query(
+      'As a product maintainer, build a work packet without pasting the whole FPF.',
+      'compact',
+    );
+    if (routeIds.has('route:project-alignment')) {
+      expect(boundedProductMaintainer.status).toBe('ok');
+      expect(boundedProductMaintainer.ids).toEqual(
+        expect.arrayContaining([
+          'route:project-alignment',
+          'E.12',
+          'A.1.1',
+          'A.15',
+          'A.2.2',
+          'A.2.3',
+        ]),
+      );
+      expect(boundedProductMaintainer.answer).toContain(
+        'Product-role feedback packet IDs',
+      );
+    } else {
+      expect(['ok', 'ambiguous']).toContain(boundedProductMaintainer.status);
+      expect(
+        boundedProductMaintainer.ids.every((id) => !id.startsWith('route:')),
+      ).toBe(true);
+    }
+    expect(boundedProductMaintainer.answer.length).toBeGreaterThan(0);
+    expect(boundedProductMaintainer.citations.length).toBeGreaterThan(0);
+
     const unavailableSynthesizer = new FpfRuntime({
       artifactDir: resolve(tempRoot, 'deterministic-artifacts'),
       sourcePath,

--- a/tests/fpf-spec-runtime.test.ts
+++ b/tests/fpf-spec-runtime.test.ts
@@ -300,25 +300,6 @@ describe('FpfRuntime', () => {
     expect(hyphenatedProductMaintainer.answer.length).toBeGreaterThan(0);
     expect(hyphenatedProductMaintainer.citations.length).toBeGreaterThan(0);
 
-    const unavailableSynthesizer = new FpfRuntime({
-      artifactDir: resolve(tempRoot, 'deterministic-artifacts'),
-      sourcePath,
-      synthesizer: {
-        isAvailable: async () => false,
-        synthesize: async () => {
-          throw new Error('deterministic fallback should skip unavailable synthesis');
-        },
-      },
-    });
-    const degradedAnswer = await unavailableSynthesizer.query(
-      'What is U.BoundedContext?',
-      'compact',
-    );
-    expect(degradedAnswer.status).toBe('degraded');
-    expect(degradedAnswer.ids).toEqual([]);
-    expect(degradedAnswer.candidateIds).toContain('A.1.1');
-    expect(degradedAnswer.confidence).toBeNull();
-
     const creativity = await runtime.query(
       'How is creativity and open-ended search represented in FPF?',
       'verbose',

--- a/tests/fpf-spec-runtime.test.ts
+++ b/tests/fpf-spec-runtime.test.ts
@@ -272,6 +272,34 @@ describe('FpfRuntime', () => {
     expect(boundedProductMaintainer.answer.length).toBeGreaterThan(0);
     expect(boundedProductMaintainer.citations.length).toBeGreaterThan(0);
 
+    const hyphenatedProductMaintainer = await runtime.query(
+      'As a product-feedback maintainer, build a work packet without pasting the whole FPF.',
+      'compact',
+    );
+    if (routeIds.has('route:project-alignment')) {
+      expect(hyphenatedProductMaintainer.status).toBe('ok');
+      expect(hyphenatedProductMaintainer.ids).toEqual(
+        expect.arrayContaining([
+          'route:project-alignment',
+          'E.12',
+          'A.1.1',
+          'A.15',
+          'A.2.2',
+          'A.2.3',
+        ]),
+      );
+      expect(hyphenatedProductMaintainer.answer).toContain(
+        'Product-role feedback packet IDs',
+      );
+    } else {
+      expect(['ok', 'ambiguous']).toContain(hyphenatedProductMaintainer.status);
+      expect(
+        hyphenatedProductMaintainer.ids.every((id) => !id.startsWith('route:')),
+      ).toBe(true);
+    }
+    expect(hyphenatedProductMaintainer.answer.length).toBeGreaterThan(0);
+    expect(hyphenatedProductMaintainer.citations.length).toBeGreaterThan(0);
+
     const unavailableSynthesizer = new FpfRuntime({
       artifactDir: resolve(tempRoot, 'deterministic-artifacts'),
       sourcePath,

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -512,6 +512,39 @@ describe('direct MCP server', () => {
         true,
       );
     }
+    const boundedProductMaintainerQuery = await harness.request('tools/call', {
+      name: 'query_fpf_spec',
+      arguments: {
+        mode: 'compact',
+        question:
+          'As a product maintainer, build a work packet without pasting the whole FPF.',
+      },
+    });
+    const boundedProductMaintainerPayload = asToolPayload(
+      boundedProductMaintainerQuery,
+    );
+    expect(boundedProductMaintainerPayload.status).toBe('ok');
+    if (routeIds.has('route:project-alignment')) {
+      expect(boundedProductMaintainerPayload.ids).toEqual(
+        expect.arrayContaining([
+          'route:project-alignment',
+          'E.12',
+          'A.1.1',
+          'A.15',
+          'A.2.2',
+          'A.2.3',
+        ]),
+      );
+      expect(boundedProductMaintainerPayload.answer).toContain(
+        'Product-role feedback packet IDs',
+      );
+    } else {
+      expect(
+        (boundedProductMaintainerPayload.ids as string[]).every(
+          (id) => !id.startsWith('route:'),
+        ),
+      ).toBe(true);
+    }
   }, FULL_SURFACE_TEST_TIMEOUT_MS);
 
   it('defaults to public tools when FPF_MCP_SURFACE is unset', async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -484,6 +484,34 @@ describe('direct MCP server', () => {
         true,
       );
     }
+
+    const productMaintainerQuery = await harness.request('tools/call', {
+      name: 'query_fpf_spec',
+      arguments: {
+        mode: 'compact',
+        question:
+          'As a product maintainer, turn live product smoke evidence plus recurring role-feedback discussions into one adoption improvement, severity, and validation path without reading or pasting the full FPF.',
+      },
+    });
+    const productMaintainerPayload = asToolPayload(productMaintainerQuery);
+    expect(productMaintainerPayload.status).toBe('ok');
+    if (routeIds.has('route:project-alignment')) {
+      expect(productMaintainerPayload.ids).toEqual(
+        expect.arrayContaining([
+          'route:project-alignment',
+          'E.12',
+          'A.1.1',
+          'A.15',
+          'A.2.2',
+          'A.2.3',
+        ]),
+      );
+      expect(productMaintainerPayload.answer).toContain('Product-role feedback packet IDs');
+    } else {
+      expect((productMaintainerPayload.ids as string[]).every((id) => !id.startsWith('route:'))).toBe(
+        true,
+      );
+    }
   }, FULL_SURFACE_TEST_TIMEOUT_MS);
 
   it('defaults to public tools when FPF_MCP_SURFACE is unset', async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -545,6 +545,39 @@ describe('direct MCP server', () => {
         ),
       ).toBe(true);
     }
+    const hyphenatedProductMaintainerQuery = await harness.request('tools/call', {
+      name: 'query_fpf_spec',
+      arguments: {
+        mode: 'compact',
+        question:
+          'As a product-feedback maintainer, build a work packet without pasting the whole FPF.',
+      },
+    });
+    const hyphenatedProductMaintainerPayload = asToolPayload(
+      hyphenatedProductMaintainerQuery,
+    );
+    expect(hyphenatedProductMaintainerPayload.status).toBe('ok');
+    if (routeIds.has('route:project-alignment')) {
+      expect(hyphenatedProductMaintainerPayload.ids).toEqual(
+        expect.arrayContaining([
+          'route:project-alignment',
+          'E.12',
+          'A.1.1',
+          'A.15',
+          'A.2.2',
+          'A.2.3',
+        ]),
+      );
+      expect(hyphenatedProductMaintainerPayload.answer).toContain(
+        'Product-role feedback packet IDs',
+      );
+    } else {
+      expect(
+        (hyphenatedProductMaintainerPayload.ids as string[]).every(
+          (id) => !id.startsWith('route:'),
+        ),
+      ).toBe(true);
+    }
   }, FULL_SURFACE_TEST_TIMEOUT_MS);
 
   it('defaults to public tools when FPF_MCP_SURFACE is unset', async () => {

--- a/tests/query-contracts.test.ts
+++ b/tests/query-contracts.test.ts
@@ -483,6 +483,18 @@ describe('Query / Ranker stage', () => {
     expect(ranking.initialNodeIds).toEqual(['route:project-alignment']);
   });
 
+  it('selects project alignment for product-role feedback maintainer prompts', async () => {
+    const snapshot = await getSnapshotWithRouteFixtures();
+    const question =
+      'As a product maintainer, turn live product smoke evidence plus recurring role-feedback discussions into one adoption improvement, severity, and validation path without reading or pasting the full FPF.';
+    const normalized = normalizeQuery(question, snapshot);
+    const seeding = seedCandidates(normalized, snapshot);
+    const ranking = rankCandidates(question, seeding.candidateMap, snapshot);
+
+    expect(ranking.routeWins).toBe(true);
+    expect(ranking.initialNodeIds).toEqual(['route:project-alignment']);
+  });
+
   it('honors negative API-contract disambiguation for project review prompts', async () => {
     const snapshot = await getSnapshotWithRouteFixtures();
     const question =
@@ -699,6 +711,33 @@ describe('Query / Projection stability stage', () => {
     expect(result.ids).toContain('A.1.1');
     expect(result.answer).toContain('Acceptance check:');
     expect(result.answer).toContain('Next move:');
+  });
+
+  it('projects the product-role feedback packet on maintainer prompts', async () => {
+    const snapshot = await getSnapshotWithRouteFixtures();
+    const question =
+      'As a product maintainer, turn live product smoke evidence plus recurring role-feedback discussions into one adoption improvement, severity, and validation path without reading or pasting the full FPF.';
+    const trace = assembleTrace(question, 'compact', snapshot);
+
+    expect(trace.routeWins).toBe(true);
+    expect(trace.selectedNodeIds[0]).toBe('route:project-alignment');
+
+    const result = buildRouteAnswer(
+      question,
+      'compact',
+      'route:project-alignment',
+      trace,
+      snapshot,
+      false,
+    );
+
+    expect(result.ids).toEqual(
+      expect.arrayContaining(['route:project-alignment', 'E.12', 'A.1.1', 'A.15', 'A.2.2', 'A.2.3']),
+    );
+    expect(result.answer).toContain('Product-role feedback packet IDs');
+    expect(result.constraints).toContain(
+      'Do not paste the whole FPF, and do not load E.8/E.19 unless the feedback is actually about writing or revising FPF pattern text.',
+    );
   });
 
   it('uses a compact route trace shortcut for adoption kickoff queries', async () => {

--- a/tests/query-contracts.test.ts
+++ b/tests/query-contracts.test.ts
@@ -740,6 +740,39 @@ describe('Query / Projection stability stage', () => {
     );
   });
 
+  it('projects the product-role feedback packet on bounded-retrieval maintainer prompts', async () => {
+    const snapshot = await getSnapshotWithRouteFixtures();
+    const question =
+      'As a product maintainer, build a work packet without pasting the whole FPF.';
+    const trace = assembleTrace(question, 'compact', snapshot);
+
+    expect(trace.routeWins).toBe(true);
+    expect(trace.selectedNodeIds[0]).toBe('route:project-alignment');
+
+    const result = buildRouteAnswer(
+      question,
+      'compact',
+      'route:project-alignment',
+      trace,
+      snapshot,
+      false,
+    );
+
+    expect(result.ids).toEqual(
+      expect.arrayContaining([
+        'route:project-alignment',
+        'E.12',
+        'A.1.1',
+        'A.15',
+        'A.2.2',
+        'A.2.3',
+      ]),
+    );
+    expect(result.answer).toContain('Product-role feedback packet IDs');
+    expect(result.answer).toContain('Acceptance check:');
+    expect(result.answer).toContain('Next move:');
+  });
+
   it('uses a compact route trace shortcut for adoption kickoff queries', async () => {
     const snapshot = await getSnapshotWithRouteFixtures();
     const engine = new QueryEngine(snapshot, false);

--- a/tests/query-contracts.test.ts
+++ b/tests/query-contracts.test.ts
@@ -773,6 +773,39 @@ describe('Query / Projection stability stage', () => {
     expect(result.answer).toContain('Next move:');
   });
 
+  it('projects the product-role feedback packet on hyphenated maintainer prompts', async () => {
+    const snapshot = await getSnapshotWithRouteFixtures();
+    const question =
+      'As a product-feedback maintainer, build a work packet without pasting the whole FPF.';
+    const trace = assembleTrace(question, 'compact', snapshot);
+
+    expect(trace.routeWins).toBe(true);
+    expect(trace.selectedNodeIds[0]).toBe('route:project-alignment');
+
+    const result = buildRouteAnswer(
+      question,
+      'compact',
+      'route:project-alignment',
+      trace,
+      snapshot,
+      false,
+    );
+
+    expect(result.ids).toEqual(
+      expect.arrayContaining([
+        'route:project-alignment',
+        'E.12',
+        'A.1.1',
+        'A.15',
+        'A.2.2',
+        'A.2.3',
+      ]),
+    );
+    expect(result.answer).toContain('Product-role feedback packet IDs');
+    expect(result.answer).toContain('Acceptance check:');
+    expect(result.answer).toContain('Next move:');
+  });
+
   it('uses a compact route trace shortcut for adoption kickoff queries', async () => {
     const snapshot = await getSnapshotWithRouteFixtures();
     const engine = new QueryEngine(snapshot, false);


### PR DESCRIPTION
## Source evidence
- Discussion #86: https://github.com/venikman/fpf-memory/discussions/86
- Tuesday product-check memory showed the product-maintainer prompt still missed the documented product-role feedback packet, while adjacent agent-integrator/spec-writer prompts had already improved.

## Problem
The compact maintainer prompt drifted into spec-authoring IDs like `E.17.AUD` and `E.8` instead of the documented packet centered on `E.12`, `A.1.1`, `A.15`, `A.2.2`, and `A.2.3`.

## Change made
- Add a `product-role-feedback` heuristic seed that routes maintainer/product-feedback prompts to `route:project-alignment`.
- Project the documented product-role feedback packet IDs and maintainer-specific acceptance/next-move guidance when that intent is matched.
- Refresh `published/current/**` against the committed `published/current/FPF-Spec.md` surface so the committed snapshot/compiler fingerprint matches the runtime change.
- Add regression coverage in query-contracts, runtime, and MCP server tests.

## Validation
- `TMPDIR="$PWD/.tmp/bun" bunx rstest run tests/query-contracts.test.ts tests/fpf-spec-runtime.test.ts tests/mcp-server.test.ts`
  - Passed: 81 tests, 0 failures.
- `TMPDIR="$PWD/.tmp/bun" bun run check`
  - Passed (`tsc --noEmit`).
- `TMPDIR="$PWD/.tmp/bun" bun run cli -- query --question "As a product maintainer, turn live product smoke evidence plus recurring role-feedback discussions into one adoption improvement, severity, and validation path without reading or pasting the full FPF." --mode compact`
  - Returned `status: "ok"` with `route:project-alignment`, `E.12`, `A.1.1`, `A.15`, `A.2.2`, and `A.2.3`.

## Residual risk
- The packet is still implemented as a routed projection over `route:project-alignment`, not as a first-class dedicated route/doc selector. If later product-role prompts diverge from this maintainer wording, they may need additional intent tuning.
- I left the local untracked `.tmp/` validation directory unstaged because shell policy blocked deleting it directly in this session.

## Friday handoff
Friday review/merge captain should replay the maintainer CLI/MCP prompt on the PR head, verify the refreshed published snapshot is intentional, and merge only after confirming the compact packet stays bounded to product-feedback work rather than spec-authoring guidance.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts query intent detection and route answer projection for `route:project-alignment`, which can change which IDs/guidance are returned for some prompts; mitigated by added regression tests.
> 
> **Overview**
> Routes product-maintainer/product-feedback prompts to the documented *product-role feedback packet* by adding new `PRODUCT_ROLE_FEEDBACK_*` intent signals and a `product-role-feedback` heuristic seed rule that boosts `route:project-alignment`.
> 
> When that intent matches, `buildRouteAnswer` now injects supplemental packet IDs (`E.12`, `A.1.1`, `A.15`, `A.2.2`, `A.2.3`) and swaps in maintainer-specific acceptance/next-move guidance plus constraints to avoid escalating to spec-writing IDs.
> 
> Refreshes the published artifacts (`published/current/manifest.json` + snapshot metadata/rules) and adds regression coverage across query-contracts, runtime, and MCP server tests to assert the new routing/projection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0d13848007ff39a6e28b56f3d989cae2959f19e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->