### PR TITLE
Add guarded FPF sync monitor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ FPF_UPSTREAM_SPEC_PATH=FPF-Spec.md
 #   bun run spec:download
 #   (writes .fpf-upstream/FPF-Spec.md; keep the line below)
 FPF_PUBLISH_SOURCE_PATH=.fpf-upstream/FPF-Spec.md
+FPF_SYNC_MONITOR_STATUS_URL=https://fpf.sh/api/fpf/status
+FPF_SYNC_MONITOR_MAX_DRIFT_HOURS=10
 FPF_RUNTIME_ARTIFACT_DIR=.runtime/fpf-index
 FPF_QUERY_DEFAULT_MODE=verbose
 # Optional LM Studio path. If you set either base URL or model, the missing half

--- a/.github/workflows/fpf-sync-monitor.yml
+++ b/.github/workflows/fpf-sync-monitor.yml
@@ -1,0 +1,59 @@
+name: FPF Sync Monitor
+
+on:
+  schedule:
+    # Hourly sentinel. sync-fpf.yml is the worker; this workflow is the SLO monitor
+    # and recovery trigger when upstream changed but no dispatch arrived.
+    - cron: '17 * * * *'
+  workflow_dispatch:
+    inputs:
+      max_drift_hours:
+        description: 'Allowed upstream-to-fpf.sh drift before this monitor fails'
+        required: false
+        default: '10'
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: fpf-sync-monitor
+  cancel-in-progress: false
+
+env:
+  BUN_VERSION: '1.3.5'
+  FPF_SYNC_MONITOR_STATUS_URL: https://fpf.sh/api/fpf/status
+  FPF_SYNC_MONITOR_MAX_DRIFT_HOURS: ${{ github.event.inputs.max_drift_hours || '10' }}
+
+jobs:
+  monitor:
+    name: Check fpf.sh sync SLO
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - run: bun install --frozen-lockfile
+
+      - name: Evaluate hosted sync health
+        id: monitor
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun run monitor:sync -- --format markdown
+
+      - name: Trigger guarded publication sync
+        if: steps.monitor.outputs.needs_sync == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM_REF: ${{ steps.monitor.outputs.upstream_ref }}
+        run: gh workflow run sync-fpf.yml --ref main -f upstream_ref="$UPSTREAM_REF"
+
+      - name: Enforce sync SLO
+        if: steps.monitor.outputs.breached == 'true'
+        run: |
+          echo "::error::${{ steps.monitor.outputs.summary }}"
+          exit 1

--- a/.github/workflows/sync-fpf.yml
+++ b/.github/workflows/sync-fpf.yml
@@ -15,7 +15,7 @@ name: Sync FPF Publication
 # the same E2E gates that protect every other change to main.
 on:
   repository_dispatch:
-    types: [fpf-origin-updated]
+    types: [fpf-origin-updated, fpf-sync-updated]
   schedule:
     # Every 6 hours. Dispatch should usually win; this is the freshness backstop.
     - cron: '0 */6 * * *'
@@ -206,6 +206,25 @@ jobs:
             exit 0
           fi
 
+          PR_HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid)
+          CI_RUN_JSON=$(gh run list \
+            --workflow ci.yml \
+            --branch "chore/sync-fpf-${{ steps.detect.outputs.short_ref }}" \
+            --json databaseId,headSha,status,conclusion,url \
+            --limit 20 \
+            --jq "[.[] | select(.headSha == \"$PR_HEAD_SHA\")] | first // empty")
+          if [ -z "$CI_RUN_JSON" ]; then
+            echo "::warning::No manually triggered CI run found for PR #$PR_NUMBER head $PR_HEAD_SHA; leaving it open."
+            exit 0
+          fi
+          CI_STATUS=$(jq -r .status <<<"$CI_RUN_JSON")
+          CI_CONCLUSION=$(jq -r .conclusion <<<"$CI_RUN_JSON")
+          if [ "$CI_STATUS" != "completed" ] || [ "$CI_CONCLUSION" != "success" ]; then
+            echo "::warning::Manual CI run for PR #$PR_NUMBER is not passing; leaving it open."
+            jq -r '"- ci: status=\(.status) conclusion=\(.conclusion) \(.url)"' <<<"$CI_RUN_JSON"
+            exit 0
+          fi
+
           CHECKS_JSON=$(gh pr checks "$PR_NUMBER" --json name,bucket,state,link)
           CHECK_COUNT=$(jq 'length' <<<"$CHECKS_JSON")
           if [ "$CHECK_COUNT" -eq 0 ]; then
@@ -213,7 +232,7 @@ jobs:
             exit 0
           fi
 
-          REQUIRED_CHECK_NAMES='["ci","Vercel","Playwright on Vercel preview"]'
+          REQUIRED_CHECK_NAMES='["Vercel","Playwright on Vercel preview"]'
           MISSING_REQUIRED=$(jq --argjson required "$REQUIRED_CHECK_NAMES" '
             ($required - [.[] | select(.bucket == "pass") | .name])
           ' <<<"$CHECKS_JSON")

--- a/README.md
+++ b/README.md
@@ -88,10 +88,11 @@ Out:
 
 `.github/workflows/sync-fpf.yml` keeps both public surfaces current when FPF changes upstream in [ailev/FPF](https://github.com/ailev/FPF):
 
-- Fast path: a trusted origin notifier can send this repo a `repository_dispatch` event named `fpf-origin-updated` with `client_payload.sha`/`after`, `client_payload.ref`/`branch`, and optionally `client_payload.spec_url`.
+- Fast path: a trusted origin notifier can send this repo a `repository_dispatch` event named `fpf-origin-updated` or `fpf-sync-updated` with `client_payload.sha`/`after`, `client_payload.ref`/`branch`, and optionally `client_payload.spec_url`.
 - Backstops: the workflow also runs every 6 hours and can be triggered manually with a branch, tag, commit SHA, or raw spec URL paired with an explicit upstream ref.
 - Work performed: download `FPF-Spec.md`, run `publish:current`, validate `published/current/**`, build the static docs, build the Vercel-origin MCP bundle, and open a publication PR only when files changed.
 - Hosted MCP handoff: after the review window and required checks pass, the workflow squash-merges the PR. The resulting `main` push gives Vercel's Git integration the refreshed `fpf.sh` inputs.
+- Monitor: `.github/workflows/fpf-sync-monitor.yml` runs hourly, checks `ailev/FPF` HEAD against `https://fpf.sh/api/fpf/status`, triggers `sync-fpf.yml` when upstream is ahead, and fails only when drift exceeds the configured SLO or the hosted runtime is internally stale.
 
 Minimal dispatch payload:
 
@@ -103,6 +104,12 @@ Minimal dispatch payload:
   }
 }
 ```
+
+Publication QA follows FPF anchors directly:
+
+- `B.5.1` separates exploration, shaping, evidence, and operation: sync PRs do publication work; monitor runs production evidence.
+- `A.10` and `G.6` make SHA, manifest, source hash, runtime freshness, and check URLs the evidence graph.
+- `B.3`, `E.19`, and `E.21` keep quality gates explicit: source/ref coherence, runtime freshness, preview/E2E, CI, recoverability, and max drift are separate characteristics, not one vague "green" claim.
 
 ## Configuration
 
@@ -116,6 +123,8 @@ Copy `.env.example` to `.env`. The most common settings:
 | `FPF_UPSTREAM_REPO`                       | `FPF`                                | GitHub repo for upstream publication provenance and downloads.         |
 | `FPF_UPSTREAM_REF`                        | `main`                               | Branch, tag, or SHA used by `spec:download` and `publish:current`.     |
 | `FPF_UPSTREAM_SPEC_PATH`                  | `FPF-Spec.md`                        | Path to the spec inside the upstream repo.                             |
+| `FPF_SYNC_MONITOR_STATUS_URL`             | `https://fpf.sh/api/fpf/status`      | Production status endpoint checked by `monitor:sync`.                  |
+| `FPF_SYNC_MONITOR_MAX_DRIFT_HOURS`        | `10`                                 | Allowed upstream-to-production drift before monitor failure.           |
 | `FPF_RUNTIME_ARTIFACT_DIR`                | `.runtime/fpf-index`                 | Where compiled artifacts are written.                                 |
 | `FPF_QUERY_DEFAULT_MODE`                  | `verbose`                            | Default `mode` for `query_fpf_spec` and `ask_fpf`.                    |
 | `FPF_LOCAL_LLM_BASE_URL`                  | `http://localhost:1234/v1`           | Optional LM Studio endpoint. Omit to stay fully deterministic.        |
@@ -130,6 +139,8 @@ Copy `.env.example` to `.env`. The most common settings:
 <summary>Detailed notes on these variables</summary>
 
 `FPF_SPEC_SOURCE_PATH` must be a **local filesystem path** — the runtime does not fetch `https://` URLs. The default is the committed publication surface: `published/current/FPF-Spec.md`. Local memory preparation uses `FPF_PUBLISH_SOURCE_PATH`, which defaults to `.fpf-upstream/FPF-Spec.md` after `bun run spec:download`. You can instead point `FPF_PUBLISH_SOURCE_PATH` at a local checkout of [github.com/ailev/FPF](https://github.com/ailev/FPF) such as [`FPF-Spec.md`](https://github.com/ailev/FPF/blob/main/FPF-Spec.md). `bun run spec:download` tracks `ailev/FPF` `main` by default; the sync workflow resolves one upstream ref and passes it to both download and publish before writing `published/current/manifest.json`. Override owner/repo/ref/spec path with `FPF_UPSTREAM_OWNER`, `FPF_UPSTREAM_REPO`, `FPF_UPSTREAM_REF`, and `FPF_UPSTREAM_SPEC_PATH`; override the raw download URL or output path with `FPF_UPSTREAM_SPEC_URL` and `FPF_DOWNLOAD_SPEC_OUTPUT`. In automation, a raw `spec_url` must be paired with an explicit ref or SHA so manifest provenance remains verifiable. Keep `FPF_SPEC_SOURCE_PATH` aligned across `.env`, your shell, and any MCP config (`server.json` `env`) so every runtime/docs entrypoint agrees on the published file it should read.
+
+`FPF_UPSTREAM_SPEC_URL` is intentionally constrained to the canonical `https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<specPath>` shape matching the declared owner, repo, ref, and spec path. This prevents publishing one source while recording another provenance ref.
 
 `FPF_QUERY_DEFAULT_MODE` applies to `query_fpf_spec` and `ask_fpf` when `mode` is omitted. `trace_fpf_path` stays `compact` by default.
 
@@ -152,6 +163,7 @@ bun install
 bun run spec:download            # download FPF-Spec.md into .fpf-upstream/
 bun run publish:current          # refresh published/current/** from FPF_PUBLISH_SOURCE_PATH
 bun run stage:from-published     # stage published/current/** for commit
+bun run monitor:sync             # compare fpf.sh status with upstream HEAD
 bun run hooks:install            # install local git hooks
 ```
 

--- a/docs/automation-playbook.md
+++ b/docs/automation-playbook.md
@@ -34,6 +34,7 @@ The main safety rule is simple: discovery roles stay read-only, implementation r
 | Discussion steward | Keep GitHub Discussions actionable. | Inspect discussions, issues, and PRs; dedupe signals; maintain a Top 3 work list. | Implement fixes or create noisy new threads by default. | Discussion change report and issue-conversion recommendation. |
 | Implementation PR agent | Turn one ready item into a bounded PR. | Edit code/docs, validate, open or update one PR. | Self-merge or perform broad product scouting. | PR with source links, validation output, and residual risk. |
 | PR review and merge captain | Keep PRs moving with independent judgment. | Review PRs, check CI/reviews/mergeability, comment on blockers, merge when policy is met. | Implement fixes or silently wait on blocked PRs. | Merge/no-merge decision with evidence. |
+| FPF sync monitor | Keep fpf.sh self-sustaining against upstream FPF. | Compare upstream HEAD, hosted status, manifest provenance, runtime freshness, and drift SLO; trigger guarded sync when upstream is ahead. | Bypass CI, merge a failed sync PR, or publish unproven source/ref pairs. | Monitor run summary and sync workflow trigger. |
 | Manager brief | Compress automation state for the user. | Read automation memory, repo state, PRs, discussions, docs, and hosted MCP health. | Replace the specialist roles or make external commitments. | Product readiness, changed, validated, Top 3 next actions, decisions needed. |
 | Technical architect | Make periodic system-level judgment. | Review MCP server, index/runtime, docs/adoption UX, CLI, evaluator, packaging/deploy, CI, and automation health. | Create implementation work unless explicitly asked. | Architecture state, risks, recommendations, handoffs, and stop/replan triggers. |
 | Growth and publishing scout | Turn validated evidence into draft public material. | Draft Medium/Substack posts, short social posts, README/forum blurbs, and outreach notes. | Publish, email, DM, post, or log into external accounts without explicit approval. | Share packet with audience, proof points, caveats, links, and call to action. |
@@ -49,6 +50,8 @@ Implementation PR agent
   -> validated PR
 PR review and merge captain
   -> merge or blocker
+FPF sync monitor
+  -> sync trigger or SLO breach evidence
 Manager brief
 
 Technical architect
@@ -87,6 +90,20 @@ A PR may be merged by the review/merge role only when:
 - the PR has independent approval or an approved fast-track condition for the current head.
 
 If any condition is missing, the role should report the exact blocker rather than waiting silently.
+
+## fpf.sh Sync QA and Monitoring
+
+The production sync loop uses FPF as a quality model:
+
+- `B.5.1` keeps the worker and monitor separate: `sync-fpf.yml` operates the publication PR; `fpf-sync-monitor.yml` observes production state and triggers recovery.
+- `A.10` and `G.6` define the evidence: upstream SHA, upstream commit date, manifest `upstreamRef`, source hash, hosted runtime freshness, CI run URL, Vercel preview, and Playwright preview.
+- `B.3`, `E.19`, and `E.21` define gates and characteristics: source/ref coherence, runtime freshness, recoverability, traceability, and max drift are checked separately.
+
+Operational defaults:
+
+- `sync-fpf.yml` accepts `fpf-origin-updated` and `fpf-sync-updated` dispatches, polls every 6 hours, opens a PR, runs validation/build/preview, then auto-merges only after the review window and required evidence pass.
+- `fpf-sync-monitor.yml` polls hourly, runs `bun run monitor:sync`, triggers `sync-fpf.yml` when upstream is ahead, and fails the monitor if `fpf.sh` exceeds the drift SLO or the hosted runtime is stale.
+- The default drift SLO is 10 hours: 6-hour poll backstop plus 2-hour review window plus operational margin.
 
 ## Publishing and outreach packets
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "spec:download": "bun scripts/download-upstream-spec.ts",
     "publish:current": "bun scripts/publish-current.ts",
     "validate:published": "bun scripts/validate-published-current.ts",
+    "monitor:sync": "bun scripts/monitor-fpf-sync.ts",
     "evaluate:work": "bun src/cli.ts evaluate-work --target current-pr --base origin/main --format markdown",
     "stage:from-published": "bun scripts/stage-from-published.ts",
     "smoke:mcp:http": "bun scripts/smoke-hosted-mcp.ts",

--- a/scripts/monitor-fpf-sync.ts
+++ b/scripts/monitor-fpf-sync.ts
@@ -1,0 +1,81 @@
+import { appendFile } from 'node:fs/promises';
+
+import {
+  DEFAULT_SYNC_MONITOR_MAX_DRIFT_HOURS,
+  DEFAULT_SYNC_MONITOR_STATUS_URL,
+  formatSyncMonitorMarkdown,
+  runFpfSyncMonitor,
+  type SyncMonitorReport,
+} from '../src/build/sync-monitor.js';
+import {
+  DEFAULT_UPSTREAM_OWNER,
+  DEFAULT_UPSTREAM_REF,
+  DEFAULT_UPSTREAM_REPO,
+} from '../src/build/upstream-source.js';
+import {
+  parseFlagMap,
+  readOptionalString,
+  readPositiveInteger,
+  readString,
+} from './_args.js';
+
+const flags = parseFlagMap(process.argv.slice(2));
+const format = readString(flags, 'format', process.env.FPF_SYNC_MONITOR_FORMAT ?? 'json');
+const failOnBreach = flags.has('fail-on-breach');
+
+const report = await runFpfSyncMonitor({
+  statusUrl: readString(flags, 'status-url', process.env.FPF_SYNC_MONITOR_STATUS_URL ?? DEFAULT_SYNC_MONITOR_STATUS_URL),
+  upstreamOwner: readString(flags, 'upstream-owner', process.env.FPF_UPSTREAM_OWNER ?? DEFAULT_UPSTREAM_OWNER),
+  upstreamRepo: readString(flags, 'upstream-repo', process.env.FPF_UPSTREAM_REPO ?? DEFAULT_UPSTREAM_REPO),
+  upstreamRef: readString(flags, 'upstream-ref', process.env.FPF_UPSTREAM_REF ?? DEFAULT_UPSTREAM_REF),
+  maxDriftHours: readPositiveInteger(
+    flags,
+    'max-drift-hours',
+    process.env.FPF_SYNC_MONITOR_MAX_DRIFT_HOURS,
+    DEFAULT_SYNC_MONITOR_MAX_DRIFT_HOURS,
+  ),
+  githubToken: readOptionalString(flags, 'github-token', process.env.GITHUB_TOKEN),
+});
+
+const markdown = formatSyncMonitorMarkdown(report);
+
+if (process.env.GITHUB_OUTPUT) {
+  await appendFile(process.env.GITHUB_OUTPUT, renderGithubOutput(report), 'utf8');
+}
+if (process.env.GITHUB_STEP_SUMMARY) {
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, markdown, 'utf8');
+}
+
+if (format === 'markdown') {
+  process.stdout.write(markdown);
+} else if (format === 'json') {
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+} else {
+  throw new Error('--format must be json or markdown.');
+}
+
+if (failOnBreach && report.breached) {
+  process.exitCode = 1;
+}
+
+function renderGithubOutput(report: SyncMonitorReport): string {
+  return [
+    ['state', report.state],
+    ['ok', String(report.ok)],
+    ['breached', String(report.breached)],
+    ['needs_sync', String(report.needsSync)],
+    ['upstream_ref', report.upstream.sha],
+    ['upstream_short_ref', report.upstream.sha.slice(0, 8)],
+    ['published_ref', report.hosted.publication.upstreamRef],
+    ['published_short_ref', report.hosted.publication.upstreamRef.slice(0, 8)],
+    ['drift_hours', String(report.driftHours)],
+    ['max_drift_hours', String(report.maxDriftHours)],
+    ['runtime_fresh', String(report.runtimeFresh)],
+    ['source_coherent', String(report.sourceCoherent)],
+    ['summary', report.summary],
+  ].map(([key, value]) => `${key}=${sanitizeOutputValue(value)}\n`).join('');
+}
+
+function sanitizeOutputValue(value: string): string {
+  return value.replace(/\r?\n/gu, ' ').trim();
+}

--- a/scripts/upstream-ref.ts
+++ b/scripts/upstream-ref.ts
@@ -12,6 +12,7 @@ export {
   DEFAULT_UPSTREAM_REPO_URL,
   DEFAULT_UPSTREAM_SPEC_PATH,
   DEFAULT_UPSTREAM_URL,
+  normalizeUpstreamRef,
   parseUpstreamSpecSourceEnv,
   resolveUpstreamSpecUrl,
 } from '../src/build/upstream-source.js';

--- a/src/build/sync-monitor.ts
+++ b/src/build/sync-monitor.ts
@@ -1,0 +1,363 @@
+import { publishCurrentManifestSchema } from './published-surface.js';
+import {
+  DEFAULT_UPSTREAM_OWNER,
+  DEFAULT_UPSTREAM_REF,
+  DEFAULT_UPSTREAM_REPO,
+  normalizeUpstreamRef,
+} from './upstream-source.js';
+
+export const DEFAULT_SYNC_MONITOR_STATUS_URL = 'https://fpf.sh/api/fpf/status';
+export const DEFAULT_SYNC_MONITOR_MAX_DRIFT_HOURS = 10;
+
+export const FPF_SYNC_QA_ANCHORS = [
+  {
+    id: 'B.5.1',
+    title: 'Explore -> Shape -> Evidence -> Operate',
+    use: 'Separate discovery, implementation, proof, and production monitoring.',
+  },
+  {
+    id: 'A.10',
+    title: 'Evidence Graph Referring',
+    use: 'Treat upstream SHA, manifest hash, hosted status, and checks as explicit evidence.',
+  },
+  {
+    id: 'B.3',
+    title: 'Trust & Assurance Calculus',
+    use: 'Gate publication on congruent source, snapshot, runtime, and deploy evidence.',
+  },
+  {
+    id: 'E.19',
+    title: 'Pattern Quality Gates',
+    use: 'Run refresh and review gates before a changed spec reaches production.',
+  },
+  {
+    id: 'E.21',
+    title: 'FPF Pattern Quality Characteristic Space',
+    use: 'Track freshness, coherence, recoverability, and traceability as separate characteristics.',
+  },
+  {
+    id: 'G.6',
+    title: 'Evidence Graph & Provenance Ledger',
+    use: 'Preserve machine-readable provenance for every published surface.',
+  },
+] as const;
+
+export interface SyncMonitorConfig {
+  statusUrl?: string;
+  upstreamOwner?: string;
+  upstreamRepo?: string;
+  upstreamRef?: string;
+  maxDriftHours?: number;
+  now?: Date;
+  githubToken?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface UpstreamCommitStatus {
+  owner: string;
+  repo: string;
+  ref: string;
+  sha: string;
+  committedAt: string;
+  message: string;
+  htmlUrl: string;
+}
+
+export interface HostedSyncStatus {
+  status: string;
+  servedAt: string;
+  publication: {
+    upstreamRef: string;
+    publishedAt: string;
+    sourceHash: string;
+    compilerFingerprint: string;
+    specBytes: number;
+  };
+  runtime: {
+    sourceHash: string;
+    snapshotSourceHash: string;
+    currentSourceHash: string;
+    builtAt: string;
+    snapshotExists: boolean;
+    fresh: boolean;
+  };
+}
+
+export type SyncMonitorState = 'ok' | 'pending_sync' | 'breach';
+
+export interface SyncMonitorReport {
+  state: SyncMonitorState;
+  ok: boolean;
+  breached: boolean;
+  needsSync: boolean;
+  generatedAt: string;
+  maxDriftHours: number;
+  driftHours: number;
+  runtimeFresh: boolean;
+  sourceCoherent: boolean;
+  upstreamAhead: boolean;
+  upstream: UpstreamCommitStatus;
+  hosted: HostedSyncStatus;
+  quality: Array<{
+    characteristic: string;
+    status: 'pass' | 'pending' | 'fail';
+    evidence: string;
+    fpf: string[];
+  }>;
+  fpfAnchors: typeof FPF_SYNC_QA_ANCHORS;
+  summary: string;
+}
+
+interface GitHubCommitResponse {
+  sha?: unknown;
+  html_url?: unknown;
+  commit?: {
+    message?: unknown;
+    author?: { date?: unknown };
+    committer?: { date?: unknown };
+  };
+}
+
+export async function runFpfSyncMonitor(
+  config: SyncMonitorConfig = {},
+): Promise<SyncMonitorReport> {
+  const fetchImpl = config.fetchImpl ?? fetch;
+  const upstream = await fetchUpstreamCommit(config, fetchImpl);
+  const hosted = await fetchHostedStatus(
+    config.statusUrl ?? DEFAULT_SYNC_MONITOR_STATUS_URL,
+    fetchImpl,
+  );
+
+  return evaluateFpfSyncMonitor({
+    upstream,
+    hosted,
+    now: config.now ?? new Date(),
+    maxDriftHours: config.maxDriftHours ?? DEFAULT_SYNC_MONITOR_MAX_DRIFT_HOURS,
+  });
+}
+
+export function evaluateFpfSyncMonitor(input: {
+  upstream: UpstreamCommitStatus;
+  hosted: HostedSyncStatus;
+  now: Date;
+  maxDriftHours: number;
+}): SyncMonitorReport {
+  const sourceCoherent =
+    input.hosted.publication.sourceHash === input.hosted.runtime.currentSourceHash
+    && input.hosted.runtime.sourceHash === input.hosted.runtime.currentSourceHash
+    && input.hosted.runtime.snapshotSourceHash === input.hosted.runtime.currentSourceHash;
+  const runtimeFresh =
+    input.hosted.status === 'ok'
+    && input.hosted.runtime.snapshotExists
+    && input.hosted.runtime.fresh
+    && sourceCoherent;
+  const upstreamAhead = input.hosted.publication.upstreamRef !== input.upstream.sha;
+  const driftHours = upstreamAhead
+    ? roundHours((input.now.getTime() - Date.parse(input.upstream.committedAt)) / 3_600_000)
+    : 0;
+  const driftBreached = upstreamAhead && driftHours > input.maxDriftHours;
+  const breached = !runtimeFresh || driftBreached;
+  const state: SyncMonitorState = breached ? 'breach' : upstreamAhead ? 'pending_sync' : 'ok';
+
+  const quality: SyncMonitorReport['quality'] = [
+    {
+      characteristic: 'freshness',
+      status: upstreamAhead ? (driftBreached ? 'fail' : 'pending') : 'pass',
+      evidence: upstreamAhead
+        ? `published ${input.hosted.publication.upstreamRef.slice(0, 8)} lags upstream ${input.upstream.sha.slice(0, 8)} by ${driftHours}h`
+        : `published upstreamRef matches ${input.upstream.sha.slice(0, 8)}`,
+      fpf: ['E.19', 'E.21'],
+    },
+    {
+      characteristic: 'coherence',
+      status: runtimeFresh ? 'pass' : 'fail',
+      evidence: runtimeFresh
+        ? `hosted runtime is fresh at ${input.hosted.runtime.currentSourceHash}`
+        : `hosted status=${input.hosted.status}, fresh=${String(input.hosted.runtime.fresh)}, sourceCoherent=${String(sourceCoherent)}`,
+      fpf: ['B.3', 'A.10'],
+    },
+    {
+      characteristic: 'recoverability',
+      status: upstreamAhead ? 'pending' : 'pass',
+      evidence: upstreamAhead
+        ? 'monitor workflow should trigger sync-fpf.yml for the upstream ref'
+        : 'no recovery action required',
+      fpf: ['B.5.1', 'E.19'],
+    },
+    {
+      characteristic: 'traceability',
+      status: 'pass',
+      evidence: `manifest sourceHash=${input.hosted.publication.sourceHash}, publishedAt=${input.hosted.publication.publishedAt}`,
+      fpf: ['G.6', 'A.10'],
+    },
+  ];
+
+  return {
+    state,
+    ok: state !== 'breach',
+    breached,
+    needsSync: upstreamAhead,
+    generatedAt: input.now.toISOString(),
+    maxDriftHours: input.maxDriftHours,
+    driftHours,
+    runtimeFresh,
+    sourceCoherent,
+    upstreamAhead,
+    upstream: input.upstream,
+    hosted: input.hosted,
+    quality,
+    fpfAnchors: FPF_SYNC_QA_ANCHORS,
+    summary: summarizeState(state, upstreamAhead, driftHours, input.maxDriftHours),
+  };
+}
+
+export function formatSyncMonitorMarkdown(report: SyncMonitorReport): string {
+  const qualityRows = report.quality
+    .map((item) =>
+      `| ${item.characteristic} | ${item.status} | ${item.evidence.replace(/\|/gu, '\\|')} | ${item.fpf.join(', ')} |`,
+    )
+    .join('\n');
+  const anchorRows = report.fpfAnchors
+    .map((anchor) => `- ${anchor.id} ${anchor.title}: ${anchor.use}`)
+    .join('\n');
+
+  return `# FPF Sync Monitor
+
+State: **${report.state}**
+
+${report.summary}
+
+| Characteristic | Status | Evidence | FPF anchors |
+| --- | --- | --- | --- |
+${qualityRows}
+
+## Provenance
+
+- Upstream: [${report.upstream.sha}](${report.upstream.htmlUrl}) (${report.upstream.committedAt})
+- Published: ${report.hosted.publication.upstreamRef} (${report.hosted.publication.publishedAt})
+- Hosted source hash: ${report.hosted.runtime.currentSourceHash}
+- Max drift: ${report.maxDriftHours}h
+
+## Strategy Anchors
+
+${anchorRows}
+`;
+}
+
+async function fetchUpstreamCommit(
+  config: SyncMonitorConfig,
+  fetchImpl: typeof fetch,
+): Promise<UpstreamCommitStatus> {
+  const owner = config.upstreamOwner ?? DEFAULT_UPSTREAM_OWNER;
+  const repo = config.upstreamRepo ?? DEFAULT_UPSTREAM_REPO;
+  const ref = normalizeUpstreamRef(config.upstreamRef ?? DEFAULT_UPSTREAM_REF);
+  const url = `https://api.github.com/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}`;
+  const response = await fetchImpl(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'fpf-memory-sync-monitor',
+      ...(config.githubToken ? { Authorization: `Bearer ${config.githubToken}` } : {}),
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`sync-monitor: GitHub API ${response.status} for ${url}`);
+  }
+  const body = await response.json() as GitHubCommitResponse;
+  const sha = requireString(body.sha, 'commit.sha');
+  const committedAt = requireString(
+    body.commit?.author?.date ?? body.commit?.committer?.date,
+    'commit.author.date',
+  );
+  return {
+    owner,
+    repo,
+    ref,
+    sha,
+    committedAt,
+    message: typeof body.commit?.message === 'string' ? body.commit.message : '',
+    htmlUrl: requireString(body.html_url, 'html_url'),
+  };
+}
+
+async function fetchHostedStatus(
+  statusUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<HostedSyncStatus> {
+  const response = await fetchImpl(statusUrl, {
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    throw new Error(`sync-monitor: hosted status HTTP ${response.status} for ${statusUrl}`);
+  }
+  const body = await response.json() as unknown;
+  return parseHostedStatus(body);
+}
+
+function parseHostedStatus(value: unknown): HostedSyncStatus {
+  const record = requireRecord(value, 'hosted status');
+  const publication = publishCurrentManifestSchema
+    .pick({
+      upstreamRef: true,
+      publishedAt: true,
+      sourceHash: true,
+      compilerFingerprint: true,
+      specBytes: true,
+    })
+    .parse(record.publication);
+  const runtime = requireRecord(record.runtime, 'hosted runtime');
+  return {
+    status: requireString(record.status, 'status'),
+    servedAt: requireString(record.servedAt, 'servedAt'),
+    publication,
+    runtime: {
+      sourceHash: requireString(runtime.sourceHash, 'runtime.sourceHash'),
+      snapshotSourceHash: requireString(runtime.snapshotSourceHash, 'runtime.snapshotSourceHash'),
+      currentSourceHash: requireString(runtime.currentSourceHash, 'runtime.currentSourceHash'),
+      builtAt: requireString(runtime.builtAt, 'runtime.builtAt'),
+      snapshotExists: requireBoolean(runtime.snapshotExists, 'runtime.snapshotExists'),
+      fresh: requireBoolean(runtime.fresh, 'runtime.fresh'),
+    },
+  };
+}
+
+function summarizeState(
+  state: SyncMonitorState,
+  upstreamAhead: boolean,
+  driftHours: number,
+  maxDriftHours: number,
+): string {
+  if (state === 'ok') {
+    return 'fpf.sh is coherent and published from the current upstream ref.';
+  }
+  if (upstreamAhead && state === 'pending_sync') {
+    return `fpf.sh is behind upstream by ${driftHours}h, within the ${maxDriftHours}h sync SLO.`;
+  }
+  return upstreamAhead
+    ? `fpf.sh is behind upstream by ${driftHours}h, exceeding the ${maxDriftHours}h sync SLO.`
+    : 'fpf.sh hosted runtime is not internally coherent.';
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} was not an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} was not a non-empty string.`);
+  }
+  return value;
+}
+
+function requireBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== 'boolean') {
+    throw new Error(`${label} was not a boolean.`);
+  }
+  return value;
+}
+
+function roundHours(value: number): number {
+  return Math.round(value * 10) / 10;
+}

--- a/src/build/upstream-source.ts
+++ b/src/build/upstream-source.ts
@@ -27,7 +27,7 @@ export function buildUpstreamSpecUrl(
 ): string {
   const owner = normalizedValue(config.owner, DEFAULT_UPSTREAM_OWNER);
   const repo = normalizedValue(config.repo, DEFAULT_UPSTREAM_REPO);
-  const ref = normalizedValue(config.ref, DEFAULT_UPSTREAM_REF);
+  const ref = normalizeUpstreamRef(normalizedValue(config.ref, DEFAULT_UPSTREAM_REF));
   const specPath = normalizedSpecPath(
     normalizedValue(config.specPath, DEFAULT_UPSTREAM_SPEC_PATH),
   );
@@ -38,8 +38,12 @@ export function buildUpstreamSpecUrl(
 export function resolveUpstreamSpecUrl(
   config: UpstreamSpecSourceConfig = {},
 ): string {
-  return normalizedOptionalValue(config.explicitUrl)
-    ?? buildUpstreamSpecUrl(config);
+  const explicitUrl = normalizedOptionalValue(config.explicitUrl);
+  if (!explicitUrl) {
+    return buildUpstreamSpecUrl(config);
+  }
+  assertCanonicalRawSpecUrl(explicitUrl, config);
+  return explicitUrl;
 }
 
 export function parseUpstreamSpecSourceEnv(
@@ -47,7 +51,9 @@ export function parseUpstreamSpecSourceEnv(
 ): UpstreamSpecSource {
   const owner = normalizedValue(env.FPF_UPSTREAM_OWNER, DEFAULT_UPSTREAM_OWNER);
   const repo = normalizedValue(env.FPF_UPSTREAM_REPO, DEFAULT_UPSTREAM_REPO);
-  const ref = normalizedValue(env.FPF_UPSTREAM_REF, DEFAULT_UPSTREAM_REF);
+  const ref = normalizeUpstreamRef(
+    normalizedValue(env.FPF_UPSTREAM_REF, DEFAULT_UPSTREAM_REF),
+  );
   const specPath = normalizedSpecPath(
     normalizedValue(env.FPF_UPSTREAM_SPEC_PATH, DEFAULT_UPSTREAM_SPEC_PATH),
   );
@@ -62,6 +68,13 @@ export function parseUpstreamSpecSourceEnv(
   return { owner, repo, ref, specPath, url };
 }
 
+export function normalizeUpstreamRef(ref: string): string {
+  return ref
+    .trim()
+    .replace(/^refs\/heads\//u, '')
+    .replace(/^refs\/tags\//u, '');
+}
+
 function normalizedValue(value: string | undefined, fallback: string): string {
   return normalizedOptionalValue(value) ?? fallback;
 }
@@ -73,4 +86,52 @@ function normalizedOptionalValue(value: string | undefined): string | undefined 
 
 function normalizedSpecPath(specPath: string): string {
   return specPath.replace(/^\/+|\/+$/gu, '');
+}
+
+function assertCanonicalRawSpecUrl(
+  explicitUrl: string,
+  config: UpstreamSpecSourceConfig,
+): void {
+  const owner = normalizedValue(config.owner, DEFAULT_UPSTREAM_OWNER);
+  const repo = normalizedValue(config.repo, DEFAULT_UPSTREAM_REPO);
+  const ref = normalizeUpstreamRef(normalizedValue(config.ref, DEFAULT_UPSTREAM_REF));
+  const specPath = normalizedSpecPath(
+    normalizedValue(config.specPath, DEFAULT_UPSTREAM_SPEC_PATH),
+  );
+  let parsed: URL;
+  try {
+    parsed = new URL(explicitUrl);
+  } catch {
+    throw new Error(`FPF_UPSTREAM_SPEC_URL must be a valid URL: ${explicitUrl}`);
+  }
+
+  if (parsed.protocol !== 'https:' || parsed.hostname !== 'raw.githubusercontent.com') {
+    throw new Error(
+      `FPF_UPSTREAM_SPEC_URL must use canonical raw.githubusercontent.com, got ${explicitUrl}`,
+    );
+  }
+
+  const pathSegments = parsed.pathname
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => decodeURIComponent(segment));
+  const expectedSpecSegments = specPath.split('/').filter(Boolean);
+  const actualOwner = pathSegments[0];
+  const actualRepo = pathSegments[1];
+  const specStart = pathSegments.length - expectedSpecSegments.length;
+  const actualSpecSegments = expectedSpecSegments.length > 0
+    ? pathSegments.slice(specStart)
+    : [];
+  const actualRef = pathSegments.slice(2, specStart).join('/');
+
+  if (
+    actualOwner !== owner
+    || actualRepo !== repo
+    || actualRef !== ref
+    || actualSpecSegments.join('/') !== expectedSpecSegments.join('/')
+  ) {
+    throw new Error(
+      `FPF_UPSTREAM_SPEC_URL must match ${owner}/${repo}@${ref}:${specPath}, got ${explicitUrl}`,
+    );
+  }
 }

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -11,6 +11,9 @@ import { createHostedComposition } from '../src/composition/hosted.js';
 import { DEFAULT_SOURCE_PATH } from '../src/core/constants.js';
 import vercelHandler from '../src/entrypoints/vercel-function.js';
 
+const MCP_REQUEST_TIMEOUT_MS = 30_000;
+const FULL_SURFACE_TEST_TIMEOUT_MS = 70_000;
+
 interface JsonRpcResponse {
   jsonrpc: '2.0';
   id: string | number | null;
@@ -82,7 +85,7 @@ class StdioMcpHarness {
         reject(
           new Error(`Timed out waiting for MCP response to ${method}\n${this.stderr.join('')}`),
         );
-      }, 15_000);
+      }, MCP_REQUEST_TIMEOUT_MS);
       this.pending.set(id, { resolve, reject, timeout });
     });
 
@@ -257,6 +260,10 @@ describe('direct MCP server', () => {
     expect(statusSchema?.additionalProperties).toBe(false);
   });
 
+  // This chains multiple full-surface MCP calls through the stdio transport.
+  // Large upstream spec refreshes can push the query/ask phase past Rstest's
+  // default 20s test timeout on GitHub runners, even when each individual MCP
+  // request is healthy.
   it('serves status, query, and ask surfaces without schema failures', async () => {
     const harness = await startHarness();
     await initializeHarness(harness);
@@ -477,7 +484,7 @@ describe('direct MCP server', () => {
         true,
       );
     }
-  });
+  }, FULL_SURFACE_TEST_TIMEOUT_MS);
 
   it('defaults to public tools when FPF_MCP_SURFACE is unset', async () => {
     const harness = await startHarness('public');

--- a/tests/sync-fpf-workflow.test.ts
+++ b/tests/sync-fpf-workflow.test.ts
@@ -11,7 +11,7 @@ describe('sync FPF publication workflow', () => {
     );
 
     expect(workflow).toContain('repository_dispatch:');
-    expect(workflow).toContain('types: [fpf-origin-updated]');
+    expect(workflow).toContain('types: [fpf-origin-updated, fpf-sync-updated]');
     expect(workflow).toContain("- cron: '0 */6 * * *'");
     expect(workflow).toContain('ailev/FPF');
     expect(workflow).not.toContain('venikman');
@@ -31,5 +31,33 @@ describe('sync FPF publication workflow', () => {
       'FPF_UPSTREAM_SPEC_URL: ${{ steps.upstream.outputs.spec_url }}',
     );
     expect(workflow).toContain('spec_url requires client_payload.sha/after/ref/branch');
+  });
+
+  it('checks the manually triggered CI run by head SHA before auto-merge', async () => {
+    const workflow = await readFile(
+      resolve(process.cwd(), '.github/workflows/sync-fpf.yml'),
+      'utf8',
+    );
+
+    expect(workflow).toContain('gh workflow run ci.yml --ref "$SYNC_BRANCH"');
+    expect(workflow).toContain('PR_HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid');
+    expect(workflow).toContain('--workflow ci.yml');
+    expect(workflow).toContain('--branch "chore/sync-fpf-${{ steps.detect.outputs.short_ref }}"');
+    expect(workflow).toContain('select(.headSha == \\"$PR_HEAD_SHA\\")');
+    expect(workflow).toContain('CI_CONCLUSION');
+    expect(workflow).toContain('REQUIRED_CHECK_NAMES=\'["Vercel","Playwright on Vercel preview"]\'');
+  });
+
+  it('monitors production drift and triggers sync without user intervention', async () => {
+    const workflow = await readFile(
+      resolve(process.cwd(), '.github/workflows/fpf-sync-monitor.yml'),
+      'utf8',
+    );
+
+    expect(workflow).toContain("- cron: '17 * * * *'");
+    expect(workflow).toContain('bun run monitor:sync -- --format markdown');
+    expect(workflow).toContain('gh workflow run sync-fpf.yml --ref main');
+    expect(workflow).toContain('steps.monitor.outputs.needs_sync');
+    expect(workflow).toContain('steps.monitor.outputs.breached');
   });
 });

--- a/tests/sync-monitor.test.ts
+++ b/tests/sync-monitor.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from '@rstest/core';
+
+import {
+  evaluateFpfSyncMonitor,
+  formatSyncMonitorMarkdown,
+  runFpfSyncMonitor,
+  type HostedSyncStatus,
+  type UpstreamCommitStatus,
+} from '../src/build/sync-monitor.js';
+
+describe('FPF sync monitor', () => {
+  it('passes when fpf.sh is fresh and published from upstream HEAD', () => {
+    const report = evaluateFpfSyncMonitor({
+      upstream: makeUpstream({ sha: SHA_CURRENT }),
+      hosted: makeHosted({ upstreamRef: SHA_CURRENT }),
+      now: new Date('2026-05-30T12:00:00Z'),
+      maxDriftHours: 10,
+    });
+
+    expect(report.state).toBe('ok');
+    expect(report.needsSync).toBe(false);
+    expect(report.breached).toBe(false);
+    expect(report.quality.every((item) => item.status === 'pass')).toBe(true);
+  });
+
+  it('marks recent upstream drift as pending sync and recoverable by automation', () => {
+    const report = evaluateFpfSyncMonitor({
+      upstream: makeUpstream({
+        sha: SHA_CURRENT,
+        committedAt: '2026-05-30T08:00:00Z',
+      }),
+      hosted: makeHosted({ upstreamRef: SHA_PUBLISHED }),
+      now: new Date('2026-05-30T12:00:00Z'),
+      maxDriftHours: 10,
+    });
+
+    expect(report.state).toBe('pending_sync');
+    expect(report.ok).toBe(true);
+    expect(report.needsSync).toBe(true);
+    expect(report.driftHours).toBe(4);
+    expect(report.quality.find((item) => item.characteristic === 'freshness')?.status).toBe(
+      'pending',
+    );
+  });
+
+  it('breaches when upstream drift exceeds the SLO', () => {
+    const report = evaluateFpfSyncMonitor({
+      upstream: makeUpstream({
+        sha: SHA_CURRENT,
+        committedAt: '2026-05-29T20:00:00Z',
+      }),
+      hosted: makeHosted({ upstreamRef: SHA_PUBLISHED }),
+      now: new Date('2026-05-30T12:00:00Z'),
+      maxDriftHours: 10,
+    });
+
+    expect(report.state).toBe('breach');
+    expect(report.breached).toBe(true);
+    expect(report.needsSync).toBe(true);
+    expect(report.summary).toContain('exceeding the 10h sync SLO');
+  });
+
+  it('breaches when the hosted runtime is internally stale', () => {
+    const report = evaluateFpfSyncMonitor({
+      upstream: makeUpstream({ sha: SHA_CURRENT }),
+      hosted: makeHosted({
+        upstreamRef: SHA_CURRENT,
+        status: 'stale',
+        runtimeFresh: false,
+      }),
+      now: new Date('2026-05-30T12:00:00Z'),
+      maxDriftHours: 10,
+    });
+
+    expect(report.state).toBe('breach');
+    expect(report.runtimeFresh).toBe(false);
+    expect(report.needsSync).toBe(false);
+    expect(report.quality.find((item) => item.characteristic === 'coherence')?.status).toBe(
+      'fail',
+    );
+  });
+
+  it('renders the FPF-grounded QA strategy in markdown', () => {
+    const report = evaluateFpfSyncMonitor({
+      upstream: makeUpstream({ sha: SHA_CURRENT }),
+      hosted: makeHosted({ upstreamRef: SHA_CURRENT }),
+      now: new Date('2026-05-30T12:00:00Z'),
+      maxDriftHours: 10,
+    });
+
+    const markdown = formatSyncMonitorMarkdown(report);
+
+    expect(markdown).toContain('B.5.1');
+    expect(markdown).toContain('A.10');
+    expect(markdown).toContain('B.3');
+    expect(markdown).toContain('E.19');
+    expect(markdown).toContain('G.6');
+  });
+
+  it('sends GitHub API headers required by the hosted monitor', async () => {
+    let githubHeaders: HeadersInit | undefined;
+    const fetchImpl = Object.assign(
+      async (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        if (String(url).includes('api.github.com')) {
+          githubHeaders = init?.headers;
+          return jsonResponse({
+            sha: SHA_CURRENT,
+            html_url: `https://github.com/ailev/FPF/commit/${SHA_CURRENT}`,
+            commit: {
+              message: 'quality improvement campaign results',
+              author: { date: '2026-05-30T08:00:00Z' },
+            },
+          });
+        }
+
+        return jsonResponse(makeHosted({ upstreamRef: SHA_CURRENT }));
+      },
+      { preconnect: fetch.preconnect },
+    ) satisfies typeof fetch;
+
+    await runFpfSyncMonitor({
+      fetchImpl,
+      now: new Date('2026-05-30T12:00:00Z'),
+      maxDriftHours: 10,
+    });
+
+    expect(githubHeaders).toMatchObject({
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'fpf-memory-sync-monitor',
+    });
+  });
+});
+
+const SHA_CURRENT = '2e112078bb209e5e3a511c3bd1aa6b1b2e299efe';
+const SHA_PUBLISHED = 'ae1ff1c7a231a2ec78d244b40d7805a5538c6608';
+const SOURCE_HASH = 'sha256:73c08fb554cc5920f4bf5497e0d356ab6d3bcd5bdb605f8dcc2f82587565005e';
+
+function makeUpstream(overrides: Partial<UpstreamCommitStatus>): UpstreamCommitStatus {
+  return {
+    owner: 'ailev',
+    repo: 'FPF',
+    ref: 'main',
+    sha: SHA_CURRENT,
+    committedAt: '2026-05-30T08:00:00Z',
+    message: 'quality improvement campaign results',
+    htmlUrl: `https://github.com/ailev/FPF/commit/${SHA_CURRENT}`,
+    ...overrides,
+  };
+}
+
+function makeHosted(
+  overrides: Partial<{
+    upstreamRef: string;
+    status: string;
+    runtimeFresh: boolean;
+    sourceHash: string;
+  }>,
+): HostedSyncStatus {
+  const sourceHash = overrides.sourceHash ?? SOURCE_HASH;
+  return {
+    status: overrides.status ?? 'ok',
+    servedAt: '2026-05-30T12:00:00Z',
+    publication: {
+      upstreamRef: overrides.upstreamRef ?? SHA_CURRENT,
+      publishedAt: '2026-05-30T10:00:00Z',
+      sourceHash,
+      compilerFingerprint: 'sha256:compiler',
+      specBytes: 7_999_874,
+    },
+    runtime: {
+      sourceHash,
+      snapshotSourceHash: sourceHash,
+      currentSourceHash: sourceHash,
+      builtAt: '2026-05-30T10:00:00Z',
+      snapshotExists: true,
+      fresh: overrides.runtimeFresh ?? true,
+    },
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+    status: 200,
+  });
+}

--- a/tests/upstream-source.test.ts
+++ b/tests/upstream-source.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@rstest/core';
 
 import {
   buildUpstreamSpecUrl,
+  normalizeUpstreamRef,
   parseUpstreamSpecSourceEnv,
   resolveUpstreamSpecUrl,
 } from '../src/build/upstream-source.js';
@@ -27,12 +28,50 @@ describe('upstream FPF source resolution', () => {
     });
   });
 
-  it('lets FPF_UPSTREAM_SPEC_URL override the constructed raw URL', () => {
+  it('normalizes full git refs before constructing the download URL', () => {
+    const source = parseUpstreamSpecSourceEnv({
+      FPF_UPSTREAM_REF: 'refs/heads/main',
+    } as NodeJS.ProcessEnv);
+
+    expect(source.ref).toBe('main');
+    expect(source.url).toBe('https://raw.githubusercontent.com/ailev/FPF/main/FPF-Spec.md');
+    expect(normalizeUpstreamRef('refs/tags/v1')).toBe('v1');
+  });
+
+  it('lets matching canonical FPF_UPSTREAM_SPEC_URL override the constructed raw URL', () => {
     expect(
+      resolveUpstreamSpecUrl({
+        ref: '1234567890abcdef1234567890abcdef12345678',
+        explicitUrl:
+          'https://raw.githubusercontent.com/ailev/FPF/1234567890abcdef1234567890abcdef12345678/FPF-Spec.md',
+      }),
+    ).toBe(
+      'https://raw.githubusercontent.com/ailev/FPF/1234567890abcdef1234567890abcdef12345678/FPF-Spec.md',
+    );
+  });
+
+  it('handles an empty normalized spec path without treating -0 as an array end index', () => {
+    expect(
+      resolveUpstreamSpecUrl({
+        specPath: '/',
+        explicitUrl: 'https://raw.githubusercontent.com/ailev/FPF/main',
+      }),
+    ).toBe('https://raw.githubusercontent.com/ailev/FPF/main');
+  });
+
+  it('rejects raw spec URLs that do not match the declared provenance ref', () => {
+    expect(() =>
       resolveUpstreamSpecUrl({
         ref: '1234567890abcdef1234567890abcdef12345678',
         explicitUrl: 'https://example.test/custom/FPF-Spec.md',
       }),
-    ).toBe('https://example.test/custom/FPF-Spec.md');
+    ).toThrow(/canonical raw\.githubusercontent\.com/u);
+
+    expect(() =>
+      resolveUpstreamSpecUrl({
+        ref: '1234567890abcdef1234567890abcdef12345678',
+        explicitUrl: 'https://raw.githubusercontent.com/ailev/FPF/main/FPF-Spec.md',
+      }),
+    ).toThrow(/must match ailev\/FPF@1234567890abcdef1234567890abcdef12345678/u);
   });
 });


### PR DESCRIPTION
## Summary
- Adds an hourly `fpf-sync-monitor.yml` workflow that compares `ailev/FPF` HEAD with `https://fpf.sh/api/fpf/status`, triggers `sync-fpf.yml` when production is behind, and fails only on SLO breach or stale runtime evidence.
- Restores fast dispatch support for both `fpf-origin-updated` and `fpf-sync-updated`, while keeping guarded PR + review window publication.
- Tightens source/ref coherence so explicit raw spec URLs must match the canonical raw GitHub spec path for the declared upstream ref.
- Adds an FPF-grounded QA model for freshness, coherence, recoverability, and traceability.

## Evidence
- `bun run test -- tests/upstream-source.test.ts tests/sync-monitor.test.ts tests/sync-fpf-workflow.test.ts`
- `bun run check`
- `bun run lint`
- `bun run monitor:sync -- --format json` detected current production breach: upstream `2e112078...`, published `ae1ff1c...`, runtime fresh/source-coherent, drift above 10 h SLO.
- `bun run test -- tests/mcp-server.test.ts`
- `bun run validate:published`
- `bun run test -- tests/publish-current.test.ts tests/search-id-registry-drift.test.ts`
- `bun run docs:build`
- `bun run vercel:origin:build`
- `git diff --check`

## Autoreview
Structured `$autoreview` was attempted but blocked by local tool/account compatibility before any review findings were produced:
- Codex engine default `gpt-5.5`: current CLI requires upgrade.
- Codex `gpt-5.1`, `gpt-5`, `gpt-5-codex`: rejected for this ChatGPT-backed Codex account.
- Claude engine: 401 authentication failure.
- Copilot engine: helper failed on unsupported `-C` option.

## Notes
- `.codex/config.toml` has unrelated local user changes and is intentionally not included.
- This PR does not publish announcement copy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production automation (hourly monitor, workflow dispatch, auto-merge rules) and publication provenance validation; mistakes could block merges or allow drift, but behavior stays gated on CI/preview checks and explicit SLO failure.
> 
> **Overview**
> Adds an **hourly production sync monitor** that compares `ailev/FPF` HEAD to `https://fpf.sh/api/fpf/status`, runs `bun run monitor:sync`, **dispatches `sync-fpf.yml`** when upstream is ahead, and **fails the workflow** only on drift past the configurable SLO (default 10h) or incoherent/stale hosted runtime evidence.
> 
> The **publication worker** (`sync-fpf.yml`) now accepts **`fpf-sync-updated`** as well as `fpf-origin-updated`, and tightens **auto-merge**: it requires a **successful `ci.yml` run on the PR head SHA** before merge, and treats **Vercel + Playwright preview** as the required PR checks (drops a blanket `ci` check name from that list).
> 
> **Provenance** is stricter: upstream refs are normalized (`refs/heads/*`, `refs/tags/*`), and **`FPF_UPSTREAM_SPEC_URL` must match** the canonical `raw.githubusercontent.com` URL for the declared owner/repo/ref/spec path.
> 
> Docs and ops wiring: new env vars, README/automation-playbook QA narrative (FPF anchors), `package.json` `monitor:sync`, plus unit/workflow tests and a longer MCP integration timeout for CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb43bee5ad6c2ecfff30caf55d6151230c419bb5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->