### PR TITLE
Give runtime snapshot reuse test CI headroom

### DIFF
--- a/tests/fpf-spec-runtime.test.ts
+++ b/tests/fpf-spec-runtime.test.ts
@@ -18,6 +18,8 @@ import { DEFAULT_SOURCE_PATH } from '../src/core/constants.js';
 import { ARTIFACT_FILENAMES } from '../src/runtime/constants.js';
 import { FpfRuntime } from '../src/runtime/runtime.js';
 
+const SNAPSHOT_REUSE_TEST_TIMEOUT_MS = 70_000;
+
 describe('FpfRuntime', () => {
   const canonicalSourcePath = resolve(process.cwd(), DEFAULT_SOURCE_PATH);
   let tempRoot: string;
@@ -44,70 +46,78 @@ describe('FpfRuntime', () => {
     return JSON.parse(await readFile(resolve(artifactDir, filename), 'utf8')) as T;
   }
 
-  it('builds a local artifact set and reuses the snapshot when the source hash is unchanged', async () => {
-    const first = await runtime.refresh();
-    expect(first.rebuilt).toBe(true);
-    expect(first.reason).toBe('missing_snapshot');
-    expect(first.compiler.mode).toBe('local_vectorless');
-    expect(first.validation.parsedPatterns).toBeGreaterThan(50);
-    expect(first.validation.parsedRoutes).toBe(first.compiler.routeNodes);
-    expect(first.validation.parsedLexiconEntries).toBeGreaterThan(0);
+  // This exercises initial build, current-snapshot reuse, artifact backfill,
+  // source-hash rebuild, and forced rebuild. Large upstream specs can push the
+  // chain past Rstest's default 20s timeout on GitHub runners.
+  it(
+    'builds a local artifact set and reuses the snapshot when the source hash is unchanged',
+    async () => {
+      const first = await runtime.refresh();
+      expect(first.rebuilt).toBe(true);
+      expect(first.reason).toBe('missing_snapshot');
+      expect(first.compiler.mode).toBe('local_vectorless');
+      expect(first.validation.parsedPatterns).toBeGreaterThan(50);
+      expect(first.validation.parsedRoutes).toBe(first.compiler.routeNodes);
+      expect(first.validation.parsedLexiconEntries).toBeGreaterThan(0);
 
-    for (const filename of Object.values(ARTIFACT_FILENAMES)) {
-      const content = await readFile(resolve(artifactDir, filename), 'utf8');
-      expect(content.length).toBeGreaterThan(0);
-    }
+      for (const filename of Object.values(ARTIFACT_FILENAMES)) {
+        const content = await readFile(resolve(artifactDir, filename), 'utf8');
+        expect(content.length).toBeGreaterThan(0);
+      }
 
-    const indexMap = await readArtifact<{
-      roots: string[];
-      nodes: Record<
-        string,
-        {
-          description: string;
-          metadata: {
-            patternId?: string;
-            role: string;
-            routeBearing: boolean;
-          };
-        }
-      >;
-    }>(ARTIFACT_FILENAMES.indexMap);
-    expect(indexMap.nodes['A.1.1']?.description.length).toBeGreaterThan(0);
-    expect(indexMap.nodes['A.1.1']?.metadata.patternId).toBe('A.1.1');
-    expect(indexMap.nodes['J.4']?.metadata.routeBearing).toBe(true);
+      const indexMap = await readArtifact<{
+        roots: string[];
+        nodes: Record<
+          string,
+          {
+            description: string;
+            metadata: {
+              patternId?: string;
+              role: string;
+              routeBearing: boolean;
+            };
+          }
+        >;
+      }>(ARTIFACT_FILENAMES.indexMap);
+      expect(indexMap.nodes['A.1.1']?.description.length).toBeGreaterThan(0);
+      expect(indexMap.nodes['A.1.1']?.metadata.patternId).toBe('A.1.1');
+      expect(indexMap.nodes['J.4']?.metadata.routeBearing).toBe(true);
 
-    const snapshot = await readArtifact<{
-      relationGraph: Array<{ from: string; relation: string; to: string }>;
-    }>(ARTIFACT_FILENAMES.snapshot);
-    expect(
-      snapshot.relationGraph.some(
-        (edge) => edge.from === 'A.15' && edge.relation === 'outline_child' && edge.to === 'A.15.2',
-      ),
-    ).toBe(true);
-    expect(
-      snapshot.relationGraph.some((edge) => edge.relation === 'explicit_reference'),
-    ).toBe(true);
+      const snapshot = await readArtifact<{
+        relationGraph: Array<{ from: string; relation: string; to: string }>;
+      }>(ARTIFACT_FILENAMES.snapshot);
+      expect(
+        snapshot.relationGraph.some(
+          (edge) =>
+            edge.from === 'A.15' && edge.relation === 'outline_child' && edge.to === 'A.15.2',
+        ),
+      ).toBe(true);
+      expect(
+        snapshot.relationGraph.some((edge) => edge.relation === 'explicit_reference'),
+      ).toBe(true);
 
-    const second = await runtime.refresh();
-    expect(second.rebuilt).toBe(false);
-    expect(second.reason).toBe('snapshot_current');
+      const second = await runtime.refresh();
+      expect(second.rebuilt).toBe(false);
+      expect(second.reason).toBe('snapshot_current');
 
-    await rm(resolve(artifactDir, ARTIFACT_FILENAMES.routeGraph), { force: true });
-    const backfilled = await runtime.refresh();
-    expect(backfilled.rebuilt).toBe(false);
-    expect(await readFile(resolve(artifactDir, ARTIFACT_FILENAMES.routeGraph), 'utf8')).toContain(
-      '"relations"',
-    );
+      await rm(resolve(artifactDir, ARTIFACT_FILENAMES.routeGraph), { force: true });
+      const backfilled = await runtime.refresh();
+      expect(backfilled.rebuilt).toBe(false);
+      expect(await readFile(resolve(artifactDir, ARTIFACT_FILENAMES.routeGraph), 'utf8')).toContain(
+        '"relations"',
+      );
 
-    await writeFile(sourcePath, `${await readFile(sourcePath, 'utf8')}\n<!-- hash-shift -->\n`);
-    const third = await runtime.refresh();
-    expect(third.rebuilt).toBe(true);
-    expect(third.reason).toBe('source_hash_changed');
+      await writeFile(sourcePath, `${await readFile(sourcePath, 'utf8')}\n<!-- hash-shift -->\n`);
+      const third = await runtime.refresh();
+      expect(third.rebuilt).toBe(true);
+      expect(third.reason).toBe('source_hash_changed');
 
-    const forced = await runtime.refresh(true);
-    expect(forced.rebuilt).toBe(true);
-    expect(forced.reason).toBe('forced');
-  });
+      const forced = await runtime.refresh(true);
+      expect(forced.rebuilt).toBe(true);
+      expect(forced.reason).toBe('forced');
+    },
+    SNAPSHOT_REUSE_TEST_TIMEOUT_MS,
+  );
 
   it('does not depend on any remote indexing path', async () => {
     const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Summary
- Gives the runtime snapshot reuse test explicit 70s timeout headroom.
- The test chains initial build, snapshot reuse, backfill, source-hash rebuild, and forced rebuild; the larger published spec now exceeds Rstest's default 20s timeout on GitHub runners.

## Evidence
- `bun run test -- tests/fpf-spec-runtime.test.ts` passed locally: 18 tests, ~57s.
- `bun run lint`
- `bun run check`
- `git diff --check`

## Context
This unblocks the fresh CI run for PR #141 after the FPF sync branch was updated from main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout and comment; no application code or runtime logic is modified.
> 
> **Overview**
> Extends the **snapshot reuse** integration test in `tests/fpf-spec-runtime.test.ts` with a **70s** per-test timeout (`SNAPSHOT_REUSE_TEST_TIMEOUT_MS`) instead of Rstest’s default **20s**.
> 
> That test runs a long chain—initial build, snapshot reuse, artifact backfill, source-hash rebuild, and forced rebuild—against the full FPF spec, which now routinely exceeds 20s on GitHub runners. A short comment documents why the extra headroom is needed. **No production or runtime behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f48bf91330f2710384947a3802813539db9e463f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->