### PR TITLE
fix: align docs provenance and route selectors

### DIFF
--- a/docs/mcp-recipes.md
+++ b/docs/mcp-recipes.md
@@ -95,7 +95,7 @@ Good retrieval shape:
 
 - For ordinary code review, start from the local diff, CI evidence, and the PR/code review packet rather than forcing a route.
 - Use `route:writing-or-reviewing-patterns` only when the PR changes FPF pattern or specification text.
-- Add `route:boundary-unpacking-claim-routing` only when the change touches an API, contract, workflow, protocol, CI gate, or deploy promise.
+- Add `route:boundary-unpacking-and-claim-decomposition` only when the change touches an API, contract, workflow, protocol, CI gate, or deploy promise.
 - Read exact pattern pages only when a finding depends on the wording.
 - Keep the verdict tied to evidence: merge, fix first, or split scope.
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -26,8 +26,8 @@ Name the work shape first, pick the smallest matching doorway, and keep exact FP
 | Review a PR or design change | `route:writing-or-reviewing-patterns` via [Routes](/generated/routes/index) | Findings tied to IDs, constraints, risks, and tests |
 | Dogfood a product as a user role | [Product-role feedback packet](/work-packets#product-role-feedback-packet) | Replayable job, friction evidence, proposed improvement, discussion-ready feedback |
 | Write a specification | [E.8](/generated/patterns/E.8) + [E.19](/generated/patterns/E.19) | Clear pattern order, semantic change record, acceptance harness |
-| Unpack an API, contract, or promise | `route:boundary-unpacking-claim-routing` via [Routes](/generated/routes/index) | Atomic claims, boundary duties, evidence needs |
-| Compare options | `route:lawful-comparison-pool-selection-selected-set-publication` via [Routes](/generated/routes/index) | Governed shortlist or set result |
+| Unpack an API, contract, or promise | `route:boundary-unpacking` via [Routes](/generated/routes/index) | Atomic claims, boundary duties, evidence needs |
+| Compare options | `route:admissible-comparison-pool-selection-or-selected-set-publication` via [Routes](/generated/routes/index) | Governed shortlist or set result |
 | Use FPF inside an agent conversation | [MCP recipes](/mcp-recipes) | Compact cited context instead of a full-spec paste |
 
 ## Operating rule

--- a/docs/work-packets.md
+++ b/docs/work-packets.md
@@ -47,7 +47,7 @@ Use:
 - [E.8 Authoring conventions](/generated/patterns/E.8) for FPF pattern or specification wording changes
 - [E.19 — Pattern Quality Gates: Review & Refresh Profiles](/generated/patterns/E.19) as the pattern change-record gate
 - `route:writing-or-reviewing-patterns` via [Routes](/generated/routes/index) only when the PR changes FPF pattern or specification text
-- `route:boundary-unpacking-claim-routing` via [Routes](/generated/routes/index) for APIs, contracts, protocols, or CI/deploy gates
+- `route:boundary-unpacking-and-claim-decomposition` via [Routes](/generated/routes/index) for APIs, contracts, protocols, or CI/deploy gates
 - Otherwise use this packet as the review checklist and retrieve exact IDs only when a finding depends on FPF wording
 
 Packet:

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -64,13 +64,20 @@ if (currentRegistrySource !== nextRegistrySource) {
 let manifestSourceHash = '';
 let manifestUpstreamRef = '';
 let manifestPublishedAt = '';
+let manifestUpstreamCommittedAt = '';
 try {
   const manifest = JSON.parse(
     readFileSync(resolve(process.cwd(), 'published/current/manifest.json'), 'utf8'),
-  ) as { sourceHash?: string; upstreamRef?: string; publishedAt?: string };
+  ) as {
+    sourceHash?: string;
+    upstreamRef?: string;
+    publishedAt?: string;
+    upstreamCommittedAt?: string;
+  };
   manifestSourceHash = manifest.sourceHash ?? '';
   manifestUpstreamRef = manifest.upstreamRef ?? '';
   manifestPublishedAt = manifest.publishedAt ?? '';
+  manifestUpstreamCommittedAt = manifest.upstreamCommittedAt ?? '';
 } catch {
   // No manifest available — byline injection will be skipped.
 }
@@ -113,6 +120,7 @@ export default defineConfig({
     ['meta', { name: 'fpf-source-hash', content: manifestSourceHash }],
     ['meta', { name: 'fpf-upstream-ref', content: manifestUpstreamRef }],
     ['meta', { name: 'fpf-published-at', content: manifestPublishedAt }],
+    ['meta', { name: 'fpf-upstream-committed-at', content: manifestUpstreamCommittedAt }],
     ['meta', { property: 'og:site_name', content: 'FPF Reference' }],
     ['meta', { property: 'og:locale', content: 'en' }],
     ['meta', { name: 'twitter:card', content: 'summary' }],
@@ -164,7 +172,7 @@ function fixHomeFeatureCards(root){(root||document).querySelectorAll('.rp-home-f
 function fixNavDropdowns(root){(root||document).querySelectorAll('li.rp-nav-menu__item > .rp-nav-menu__item__container').forEach(function(trigger){if(trigger.dataset.fpfA11yPatched==='1')return;if(trigger.tagName==='A'||trigger.tagName==='BUTTON')return;var panel=trigger.nextElementSibling;if(!panel||!panel.classList||!panel.classList.contains('rp-hover-group'))return;trigger.dataset.fpfA11yPatched='1';trigger.setAttribute('role','button');trigger.setAttribute('tabindex','0');trigger.setAttribute('aria-haspopup','true');function isOpen(){return !panel.classList.contains('rp-hover-group--hidden');}function syncExpanded(){trigger.setAttribute('aria-expanded',String(isOpen()));}syncExpanded();function open(){panel.classList.remove('rp-hover-group--hidden');syncExpanded();}function close(){panel.classList.add('rp-hover-group--hidden');syncExpanded();}trigger.addEventListener('keydown',function(e){if(e.key==='Enter'||e.key===' '||e.key==='ArrowDown'){e.preventDefault();if(isOpen()){close();}else{open();var firstLink=panel.querySelector('a');if(firstLink)firstLink.focus();}}else if(e.key==='Escape'){close();}});panel.addEventListener('keydown',function(e){if(e.key==='Escape'){e.preventDefault();close();trigger.focus();}});var observer=new MutationObserver(syncExpanded);observer.observe(panel,{attributes:true,attributeFilter:['class']});});}
 function injectSkipLink(){if(document.getElementById('fpf-skip-link'))return;var link=document.createElement('a');link.id='fpf-skip-link';link.className='fpf-skip-link';link.href='#fpf-main-content';link.textContent='Skip to main content';if(document.body){document.body.insertBefore(link,document.body.firstChild);}var main=document.querySelector('main, .rspress-doc, .rp-doc-content');if(main){if(!main.id)main.id='fpf-main-content';if(!main.hasAttribute('tabindex'))main.setAttribute('tabindex','-1');}else{var doc=document.querySelector('article, .rspress-doc, #__rspress_root');if(doc&&!document.getElementById('fpf-main-content')){doc.id='fpf-main-content';doc.setAttribute('tabindex','-1');}}}
 function fixSidebarTitles(root){(root||document).querySelectorAll('.rp-doc-layout__sidebar a.rp-link').forEach(function(a){if(a.dataset.fpfA11yPatched==='1')return;a.dataset.fpfA11yPatched='1';var label=a.textContent.replace(/\s+/g,' ').trim();if(label&&!a.hasAttribute('title'))a.setAttribute('title',label);});}
-function injectHeaderProvenance(){if(document.getElementById('fpf-header-provenance'))return;var navLeft=document.querySelector('.rp-nav__left');if(!navLeft)return;function metaContent(name){var sel='meta[name='+JSON.stringify(name)+']';var el=document.querySelector(sel);return el?el.getAttribute('content')||'':'';}var ref=metaContent('fpf-upstream-ref');var rawDate=metaContent('fpf-published-at');if(!ref&&!rawDate)return;var date=rawDate;try{var parsed=new Date(rawDate);if(!isNaN(parsed.getTime())){var y=parsed.getUTCFullYear();var m=String(parsed.getUTCMonth()+1).padStart(2,'0');var d=String(parsed.getUTCDate()).padStart(2,'0');date=y+'-'+m+'-'+d;}}catch(e){}var shortRef=ref?ref.slice(0,8):'';var label=document.createElement('span');label.className='fpf-header-provenance__label';label.textContent='as of';var hashCode=document.createElement('code');hashCode.textContent=shortRef;var dateNode=document.createTextNode(' · '+date);var span=document.createElement('span');span.id='fpf-header-provenance';span.className='fpf-header-provenance';span.title='Spec source — upstream '+ref+' · published '+rawDate;span.appendChild(label);span.appendChild(document.createTextNode(' '));span.appendChild(hashCode);span.appendChild(dateNode);navLeft.appendChild(span);}
+function injectHeaderProvenance(){if(document.getElementById('fpf-header-provenance'))return;var navLeft=document.querySelector('.rp-nav__left');if(!navLeft)return;function metaContent(name){var sel='meta[name='+JSON.stringify(name)+']';var el=document.querySelector(sel);return el?el.getAttribute('content')||'':'';}var ref=metaContent('fpf-upstream-ref');var rawPublishedAt=metaContent('fpf-published-at');var rawCommittedAt=metaContent('fpf-upstream-committed-at');var rawDate=rawCommittedAt||rawPublishedAt;if(!ref&&!rawDate)return;var date=rawDate;try{var parsed=new Date(rawDate);if(!isNaN(parsed.getTime())){var y=parsed.getUTCFullYear();var m=String(parsed.getUTCMonth()+1).padStart(2,'0');var d=String(parsed.getUTCDate()).padStart(2,'0');date=y+'-'+m+'-'+d;}}catch(e){}var shortRef=ref?ref.slice(0,8):'';var label=document.createElement('span');label.className='fpf-header-provenance__label';label.textContent='as of';var hashCode=document.createElement('code');hashCode.textContent=shortRef;var dateNode=document.createTextNode(' · '+date);var span=document.createElement('span');span.id='fpf-header-provenance';span.className='fpf-header-provenance';span.title='Spec source — upstream '+ref+(rawCommittedAt?' · committed '+rawCommittedAt:'')+(rawPublishedAt?' · published '+rawPublishedAt:'');span.appendChild(label);span.appendChild(document.createTextNode(' '));span.appendChild(hashCode);span.appendChild(dateNode);navLeft.appendChild(span);}
 function applyAll(){fixTables();fixMobileSearch();fixSidebarGroups();fixSidebarInert();fixSidebarTitles();fixHomeFeatureCards();fixNavDropdowns();injectSkipLink();injectHeaderProvenance();}
 if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',applyAll);else applyAll();
 var observer=new MutationObserver(function(mutations){var needs=false;for(var i=0;i<mutations.length;i++){if(mutations[i].addedNodes.length){needs=true;break;}}if(needs)applyAll();});

--- a/tests/a11y-shim.test.ts
+++ b/tests/a11y-shim.test.ts
@@ -87,6 +87,16 @@ describe('a11y shim regression checks', () => {
     expect(configSource).toContain('Skip to main content');
   });
 
+  it('uses the upstream commit date for the header provenance stamp', () => {
+    // The header reads "as of <sha> · <date>". That date must describe
+    // the same upstream commit as the SHA; the later local publish date
+    // remains available only as tooltip context.
+    expect(configSource).toContain('fpf-upstream-committed-at');
+    expect(configSource).toContain('rawCommittedAt||rawPublishedAt');
+    expect(configSource).toContain("' · committed '+rawCommittedAt");
+    expect(configSource).toContain("' · published '+rawPublishedAt");
+  });
+
   it('marks collapsed sidebar panels as `inert` so their descendants leave the tab order', () => {
     // R5-P1-003: rspress collapses sidebar groups by setting
     // `gridTemplateRows: 0fr` on the panel; descendants stay tabbable


### PR DESCRIPTION
## Summary
- add upstreamCommittedAt to the docs head metadata
- make the header `as of <sha> · <date>` stamp use the upstream commit date instead of the later local publish date
- refresh stale curated route selectors in Start Here, Work Packets, and MCP Recipes so they resolve against the current FPF route graph

## Audit
- live /api/fpf/status, GitHub raw spec, and local published/current all match upstream `2e112078` at `sha256:73c08fb554cc5920f4bf5497e0d356ab6d3bcd5bdb605f8dcc2f82587565005e`
- live /generated/routes exposes all 22 expected route pages and all route-page pattern IDs resolve in the upstream spec
- live /work-packets rendered all expected packet headings/IDs, but one stale route selector was found and fixed locally
- local curated docs route-selector audit now reports all selectors resolving against the current route graph

## Validation
- bun run test -- tests/a11y-shim.test.ts
- bun run docs:build
- bun run lint
- bun run check
- browser render check: local static server showed `as of 2e112078 · 2026-05-29` and tooltip with committed 2026-05-29 plus published 2026-05-30

## Autoreview
- attempted `/Users/stas-studio/.codex/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; blocked because default `gpt-5.5` requires a newer Codex CLI
- attempted same engine with `--model codex=gpt-5.1`; blocked because this ChatGPT-backed Codex account does not support `gpt-5.1`