### PR TITLE
Add FPF content quality monitor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
         # here so the broken push doesn't reach the deploy jobs.
         run: bun run validate:published
 
+      - name: Monitor generated and curated content quality
+        # Validate the committed publication projection before build jobs.
+        # This catches stale route selectors in curated pages and route catalog
+        # holes against the same published snapshot the deploy will serve.
+        run: bun run monitor:content -- --mode local --format markdown --fail-on-breach
+
   lint:
     name: Lint + boundaries
     runs-on: ubuntu-latest

--- a/.github/workflows/fpf-content-quality.yml
+++ b/.github/workflows/fpf-content-quality.yml
@@ -1,0 +1,36 @@
+name: FPF Content Quality Monitor
+
+on:
+  schedule:
+    # Separate from the sync freshness sentinel: this checks that production
+    # pages still project the published FPF snapshot without stale selectors.
+    - cron: '37 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fpf-content-quality
+  cancel-in-progress: false
+
+env:
+  BUN_VERSION: '1.3.5'
+  FPF_CONTENT_QUALITY_BASE_URL: https://fpf.sh
+
+jobs:
+  monitor:
+    name: Check fpf.sh content quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - run: bun install --frozen-lockfile
+
+      - name: Evaluate hosted generated and curated pages
+        run: bun run monitor:content -- --mode live --format markdown --fail-on-breach

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "publish:current": "bun scripts/publish-current.ts",
     "validate:published": "bun scripts/validate-published-current.ts",
     "monitor:sync": "bun scripts/monitor-fpf-sync.ts",
+    "monitor:content": "bun scripts/monitor-content-quality.ts",
     "evaluate:work": "bun src/cli.ts evaluate-work --target current-pr --base origin/main --format markdown",
     "stage:from-published": "bun scripts/stage-from-published.ts",
     "smoke:mcp:http": "bun scripts/smoke-hosted-mcp.ts",

--- a/scripts/monitor-content-quality.ts
+++ b/scripts/monitor-content-quality.ts
@@ -1,0 +1,90 @@
+import { appendFile } from 'node:fs/promises';
+
+import {
+  DEFAULT_CONTENT_QUALITY_BASE_URL,
+  formatContentQualityMarkdown,
+  runContentQualityMonitor,
+  type ContentQualityMode,
+  type ContentQualityReport,
+} from '../src/build/content-quality-monitor.js';
+import { parseFlagMap, readString } from './_args.js';
+
+const flags = parseFlagMap(process.argv.slice(2));
+const format = readString(
+  flags,
+  'format',
+  process.env.FPF_CONTENT_QUALITY_MONITOR_FORMAT ?? 'json',
+);
+const mode = readMode(
+  readString(flags, 'mode', process.env.FPF_CONTENT_QUALITY_MONITOR_MODE ?? 'local'),
+);
+const failOnBreach = flags.has('fail-on-breach');
+
+const report = await runContentQualityMonitor({
+  mode,
+  baseUrl: readString(
+    flags,
+    'base-url',
+    process.env.FPF_CONTENT_QUALITY_BASE_URL ?? DEFAULT_CONTENT_QUALITY_BASE_URL,
+  ),
+});
+const markdown = formatContentQualityMarkdown(report);
+
+if (process.env.GITHUB_OUTPUT) {
+  await appendFile(process.env.GITHUB_OUTPUT, renderGithubOutput(report), 'utf8');
+}
+if (process.env.GITHUB_STEP_SUMMARY) {
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, markdown, 'utf8');
+}
+
+if (format === 'markdown') {
+  process.stdout.write(markdown);
+} else if (format === 'json') {
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+} else {
+  throw new Error('--format must be json or markdown.');
+}
+
+if (failOnBreach && report.breached) {
+  process.exitCode = 1;
+}
+
+function readMode(value: string): ContentQualityMode {
+  if (value === 'local' || value === 'live') {
+    return value;
+  }
+  throw new Error('--mode must be local or live.');
+}
+
+function renderGithubOutput(report: ContentQualityReport): string {
+  return [
+    ['state', report.state],
+    ['ok', String(report.ok)],
+    ['breached', String(report.breached)],
+    ['mode', report.mode],
+    ['source_hash', report.sourceHash],
+    ['upstream_ref', report.upstreamRef ?? ''],
+    ['route_index_link_coverage_percent', String(report.routeCatalog.routeIndexLinkCoveragePercent)],
+    ['route_page_coverage_percent', String(report.routeCatalog.routePageCoveragePercent)],
+    ['route_content_coverage_percent', String(report.routeCatalog.routeContentCoveragePercent)],
+    ['route_pattern_link_coverage_percent', String(report.routeCatalog.routePatternLinkCoveragePercent)],
+    ['stale_curated_refs', String(countStaleCuratedRefs(report))],
+    ['summary', report.summary],
+  ].map(([key, value]) => `${key}=${sanitizeOutputValue(value)}\n`).join('');
+}
+
+function countStaleCuratedRefs(report: ContentQualityReport): number {
+  return report.curatedDocs.reduce(
+    (total, doc) =>
+      total
+      + doc.unresolvedRouteSelectors.length
+      + doc.unresolvedPatternLinks.length
+      + doc.missingExpectedRouteSelectors.length
+      + doc.unexpectedRouteSelectors.length,
+    0,
+  );
+}
+
+function sanitizeOutputValue(value: string): string {
+  return value.replace(/\r?\n/gu, ' ').trim();
+}

--- a/src/build/content-quality-monitor.ts
+++ b/src/build/content-quality-monitor.ts
@@ -1,0 +1,828 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import {
+  buildDocsProjection,
+  type PublicationManifestSummary,
+} from '../core/documents.js';
+import type {
+  RouteRecord,
+  Snapshot,
+} from '../core/types.js';
+import {
+  buildUpstreamSpecUrl,
+  DEFAULT_UPSTREAM_OWNER,
+  DEFAULT_UPSTREAM_REPO,
+} from './upstream-source.js';
+import {
+  validatePublishedSurface,
+  type PublishCurrentManifest,
+} from './published-surface.js';
+
+export const DEFAULT_CONTENT_QUALITY_BASE_URL = 'https://fpf.sh';
+
+export const CONTENT_QUALITY_CURATED_DOCS = [
+  { label: 'home', path: '/', sourcePath: 'docs/index.md' },
+  { label: 'start-here', path: '/start-here', sourcePath: 'docs/start-here.md' },
+  { label: 'work-packets', path: '/work-packets', sourcePath: 'docs/work-packets.md' },
+  { label: 'connect-mcp', path: '/connect-mcp', sourcePath: 'docs/connect-mcp.md' },
+  { label: 'mcp-recipes', path: '/mcp-recipes', sourcePath: 'docs/mcp-recipes.md' },
+  {
+    label: 'automation-playbook',
+    path: '/automation-playbook',
+    sourcePath: 'docs/automation-playbook.md',
+  },
+] as const;
+
+export const CONTENT_QUALITY_QA_ANCHORS = [
+  {
+    id: 'A.10',
+    title: 'Evidence Graph Referring',
+    use: 'Compare route IDs, page URLs, hashes, and status payloads as explicit evidence.',
+  },
+  {
+    id: 'B.3',
+    title: 'Trust & Assurance Calculus',
+    use: 'Treat content coherence as a publication assurance gate, not a visual preference.',
+  },
+  {
+    id: 'E.19',
+    title: 'Pattern Quality Gates',
+    use: 'Fail when generated or curated pages point at stale FPF IDs.',
+  },
+  {
+    id: 'E.21',
+    title: 'FPF Pattern Quality Characteristic Space',
+    use: 'Track coverage, selector validity, and source coherence separately.',
+  },
+  {
+    id: 'G.6',
+    title: 'Evidence Graph & Provenance Ledger',
+    use: 'Emit machine-readable percentages and provenance for monitors and CI.',
+  },
+] as const;
+
+export type ContentQualityMode = 'local' | 'live';
+export type ContentQualityState = 'ok' | 'breach';
+
+export interface ContentQualityMonitorConfig {
+  mode?: ContentQualityMode;
+  baseUrl?: string;
+  cwd?: string;
+  now?: Date;
+  fetchImpl?: typeof fetch;
+}
+
+export interface ContentQualityRouteProjection {
+  indexPath: string;
+  indexText: string;
+  routePages: ContentQualityRoutePage[];
+}
+
+export interface ContentQualityRoutePage {
+  routeId: string;
+  staticPath: string;
+  text: string;
+}
+
+export interface ContentQualityCuratedDoc {
+  label: string;
+  path: string;
+  sourcePath?: string;
+  text: string;
+}
+
+export interface HostedContentStatus {
+  status: string;
+  servedAt?: string;
+  publication: {
+    upstreamRef: string;
+    publishedAt: string;
+    sourceHash: string;
+    compilerFingerprint?: string;
+    specBytes?: number;
+  };
+  runtime: {
+    sourceHash: string;
+    snapshotSourceHash: string;
+    currentSourceHash: string;
+    builtAt?: string;
+    snapshotExists: boolean;
+    fresh: boolean;
+  };
+}
+
+export interface ContentQualityEvaluationInput {
+  mode: ContentQualityMode;
+  snapshot: Snapshot;
+  sourceHash: string;
+  manifest?: PublicationManifestSummary;
+  routeProjection: ContentQualityRouteProjection;
+  curatedDocs: ContentQualityCuratedDoc[];
+  expectedCuratedDocs?: ContentQualityCuratedDoc[];
+  live?: ContentQualityLiveEvidence;
+  now?: Date;
+}
+
+export interface ContentQualityLiveEvidence {
+  baseUrl: string;
+  hostedStatus: HostedContentStatus;
+  upstreamSpecUrl: string;
+  upstreamSourceHash: string;
+}
+
+export interface ContentQualityReport {
+  state: ContentQualityState;
+  ok: boolean;
+  breached: boolean;
+  mode: ContentQualityMode;
+  generatedAt: string;
+  sourceHash: string;
+  upstreamRef?: string;
+  routeCatalog: RouteCatalogQualityReport;
+  curatedDocs: CuratedDocQualityReport[];
+  live?: ContentQualityLiveReport;
+  quality: ContentQualityCheck[];
+  fpfAnchors: typeof CONTENT_QUALITY_QA_ANCHORS;
+  summary: string;
+}
+
+export interface RouteCatalogQualityReport {
+  expectedRoutes: number;
+  routeIndexLinksFound: number;
+  routePagesFound: number;
+  routeContentRefsFound: number;
+  routeContentRefsExpected: number;
+  routePatternLinksFound: number;
+  routePatternLinksExpected: number;
+  routeIndexLinkCoveragePercent: number;
+  routePageCoveragePercent: number;
+  routeContentCoveragePercent: number;
+  routePatternLinkCoveragePercent: number;
+  missingIndexLinks: string[];
+  missingRoutePages: string[];
+  missingContentRefs: MissingRouteRef[];
+  missingPatternLinks: MissingRouteRef[];
+}
+
+export interface MissingRouteRef {
+  routeId: string;
+  ref: string;
+  expectedPath?: string;
+}
+
+export interface CuratedDocQualityReport {
+  label: string;
+  path: string;
+  sourcePath?: string;
+  routeSelectors: string[];
+  unresolvedRouteSelectors: string[];
+  patternLinks: string[];
+  unresolvedPatternLinks: string[];
+  expectedRouteSelectors?: string[];
+  missingExpectedRouteSelectors: string[];
+  unexpectedRouteSelectors: string[];
+  routeSelectorCoveragePercent: number;
+  patternLinkCoveragePercent: number;
+}
+
+export interface ContentQualityLiveReport {
+  baseUrl: string;
+  upstreamSpecUrl: string;
+  upstreamSourceHash: string;
+  statusSourceCoherent: boolean;
+  upstreamSourceMatchesPublished: boolean;
+  runtimeFresh: boolean;
+  publishedRefMatchesManifest: boolean;
+  hostedPublishedRef?: string;
+  manifestUpstreamRef?: string;
+}
+
+export interface ContentQualityCheck {
+  characteristic: string;
+  status: 'pass' | 'fail';
+  evidence: string;
+  fpf: string[];
+}
+
+interface RouteExpectation {
+  route: RouteRecord;
+  staticPath: string;
+  contentRefs: string[];
+  patternLinkRefs: string[];
+}
+
+export async function runContentQualityMonitor(
+  config: ContentQualityMonitorConfig = {},
+): Promise<ContentQualityReport> {
+  const cwd = resolve(config.cwd ?? process.cwd());
+  const mode = config.mode ?? 'local';
+  const fetchImpl = config.fetchImpl ?? fetch;
+  const surface = await validatePublishedSurface({ cwd });
+  const snapshot = await readPublishedSnapshot(surface.paths.publishedSnapshotPath);
+  const manifest = surface.manifest;
+  const routeProjection =
+    mode === 'live'
+      ? await fetchLiveRouteProjection(snapshot, config.baseUrl ?? DEFAULT_CONTENT_QUALITY_BASE_URL, fetchImpl)
+      : buildLocalRouteProjection(snapshot, manifest);
+  const localCuratedDocs = await readLocalCuratedDocs(cwd, snapshot, manifest);
+  const curatedDocs =
+    mode === 'live'
+      ? await fetchLiveCuratedDocs(config.baseUrl ?? DEFAULT_CONTENT_QUALITY_BASE_URL, fetchImpl)
+      : localCuratedDocs;
+  const live =
+    mode === 'live'
+      ? await fetchLiveEvidence({
+        baseUrl: config.baseUrl ?? DEFAULT_CONTENT_QUALITY_BASE_URL,
+        fetchImpl,
+        manifest,
+      })
+      : undefined;
+
+  return evaluateContentQuality({
+    mode,
+    snapshot,
+    sourceHash: surface.sourceHash,
+    manifest,
+    routeProjection,
+    curatedDocs,
+    expectedCuratedDocs: mode === 'live' ? localCuratedDocs : undefined,
+    live,
+    now: config.now ?? new Date(),
+  });
+}
+
+export function evaluateContentQuality(
+  input: ContentQualityEvaluationInput,
+): ContentQualityReport {
+  const routeCatalog = evaluateRouteCatalog(input.snapshot, input.routeProjection);
+  const expectedCuratedDocs = new Map(
+    (input.expectedCuratedDocs ?? []).map((doc) => [doc.label, doc]),
+  );
+  const curatedDocs = input.curatedDocs.map((doc) =>
+    evaluateCuratedDoc(input.snapshot, doc, expectedCuratedDocs.get(doc.label)),
+  );
+  const live = input.live
+    ? evaluateLiveEvidence(input.sourceHash, input.manifest, input.live)
+    : undefined;
+
+  const staleCuratedRefs = curatedDocs.flatMap((doc) => [
+    ...doc.unresolvedRouteSelectors.map((selector) => `${doc.label}:${selector}`),
+    ...doc.unresolvedPatternLinks.map((selector) => `${doc.label}:${selector}`),
+  ]);
+  const driftedCuratedRefs = curatedDocs.flatMap((doc) => [
+    ...doc.missingExpectedRouteSelectors.map((selector) => `${doc.label}:missing:${selector}`),
+    ...doc.unexpectedRouteSelectors.map((selector) => `${doc.label}:unexpected:${selector}`),
+  ]);
+  const routeCatalogPass =
+    routeCatalog.routeIndexLinkCoveragePercent === 100
+    && routeCatalog.routePageCoveragePercent === 100
+    && routeCatalog.routeContentCoveragePercent === 100
+    && routeCatalog.routePatternLinkCoveragePercent === 100;
+  const curatedPass = staleCuratedRefs.length === 0 && driftedCuratedRefs.length === 0;
+  const livePass = live
+    ? live.statusSourceCoherent
+      && live.upstreamSourceMatchesPublished
+      && live.runtimeFresh
+      && live.publishedRefMatchesManifest
+    : true;
+  const monitoredMcpDocs = new Set(curatedDocs.map((doc) => doc.label));
+  const mcpPagesPresent = ['connect-mcp', 'mcp-recipes', 'automation-playbook']
+    .every((label) => monitoredMcpDocs.has(label));
+
+  const quality: ContentQualityCheck[] = [
+    {
+      characteristic: 'generated route coverage',
+      status: routeCatalogPass ? 'pass' : 'fail',
+      evidence:
+        `index ${formatPercent(routeCatalog.routeIndexLinkCoveragePercent)}, pages ${formatPercent(routeCatalog.routePageCoveragePercent)}, content refs ${formatPercent(routeCatalog.routeContentCoveragePercent)}, pattern links ${formatPercent(routeCatalog.routePatternLinkCoveragePercent)}`,
+      fpf: ['A.10', 'E.19', 'E.21'],
+    },
+    {
+      characteristic: 'curated selector validity',
+      status: curatedPass ? 'pass' : 'fail',
+      evidence: curatedPass
+        ? `${curatedDocs.length} curated pages have no stale route selectors, pattern links, or live selector drift`
+        : `stale curated refs: ${[...staleCuratedRefs, ...driftedCuratedRefs].slice(0, 10).join(', ')}`,
+      fpf: ['A.10', 'E.19'],
+    },
+    {
+      characteristic: 'published source coherence',
+      status: livePass ? 'pass' : 'fail',
+      evidence: live
+        ? `hosted source coherent=${String(live.statusSourceCoherent)}, raw upstream matches=${String(live.upstreamSourceMatchesPublished)}, runtime fresh=${String(live.runtimeFresh)}`
+        : `local published source hash ${input.sourceHash}`,
+      fpf: ['B.3', 'G.6'],
+    },
+    {
+      characteristic: 'MCP context boundary',
+      status: mcpPagesPresent ? 'pass' : 'fail',
+      evidence: mcpPagesPresent
+        ? 'MCP pages are monitored as curated docs; agents only need failing snippets/provenance, not whole MCP pages as default context'
+        : 'one or more MCP curated docs are absent from the monitor input',
+      fpf: ['B.3', 'E.21'],
+    },
+  ];
+
+  const breached = quality.some((item) => item.status === 'fail');
+  const state: ContentQualityState = breached ? 'breach' : 'ok';
+
+  return {
+    state,
+    ok: !breached,
+    breached,
+    mode: input.mode,
+    generatedAt: (input.now ?? new Date()).toISOString(),
+    sourceHash: input.sourceHash,
+    upstreamRef: input.manifest?.upstreamRef,
+    routeCatalog,
+    curatedDocs,
+    live,
+    quality,
+    fpfAnchors: CONTENT_QUALITY_QA_ANCHORS,
+    summary: summarizeContentQuality(
+      state,
+      routeCatalog,
+      [...staleCuratedRefs, ...driftedCuratedRefs],
+      live,
+    ),
+  };
+}
+
+export function formatContentQualityMarkdown(report: ContentQualityReport): string {
+  const qualityRows = report.quality
+    .map((item) =>
+      `| ${item.characteristic} | ${item.status} | ${escapeTableCell(item.evidence)} | ${item.fpf.join(', ')} |`,
+    )
+    .join('\n');
+  const curatedRows = report.curatedDocs
+    .map((doc) =>
+      `| ${doc.label} | ${doc.path} | ${doc.routeSelectors.length} | ${doc.unresolvedRouteSelectors.length} | ${doc.missingExpectedRouteSelectors.length} | ${doc.unexpectedRouteSelectors.length} | ${doc.patternLinks.length} | ${doc.unresolvedPatternLinks.length} |`,
+    )
+    .join('\n');
+  const anchorRows = report.fpfAnchors
+    .map((anchor) => `- ${anchor.id} ${anchor.title}: ${anchor.use}`)
+    .join('\n');
+  const liveBlock = report.live
+    ? `\n## Live Provenance\n\n- Base URL: ${report.live.baseUrl}\n- Hosted upstream ref: ${report.live.hostedPublishedRef ?? 'unknown'}\n- Manifest upstream ref: ${report.live.manifestUpstreamRef ?? 'unknown'}\n- Raw upstream spec: ${report.live.upstreamSpecUrl}\n- Raw upstream hash: ${report.live.upstreamSourceHash}\n`
+    : '';
+
+  return `# FPF Content Quality Monitor
+
+State: **${report.state}**
+
+${report.summary}
+
+| Characteristic | Status | Evidence | FPF anchors |
+| --- | --- | --- | --- |
+${qualityRows}
+
+## Route Coverage
+
+- Expected routes: ${report.routeCatalog.expectedRoutes}
+- Index links: ${report.routeCatalog.routeIndexLinksFound}/${report.routeCatalog.expectedRoutes} (${formatPercent(report.routeCatalog.routeIndexLinkCoveragePercent)})
+- Route pages: ${report.routeCatalog.routePagesFound}/${report.routeCatalog.expectedRoutes} (${formatPercent(report.routeCatalog.routePageCoveragePercent)})
+- Route content refs: ${report.routeCatalog.routeContentRefsFound}/${report.routeCatalog.routeContentRefsExpected} (${formatPercent(report.routeCatalog.routeContentCoveragePercent)})
+- Route pattern links: ${report.routeCatalog.routePatternLinksFound}/${report.routeCatalog.routePatternLinksExpected} (${formatPercent(report.routeCatalog.routePatternLinkCoveragePercent)})
+
+## Curated Pages
+
+| Page | URL | Route selectors | Unresolved routes | Missing expected routes | Unexpected routes | Pattern links | Unresolved patterns |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+${curatedRows}
+${liveBlock}
+## Strategy Anchors
+
+${anchorRows}
+`;
+}
+
+function evaluateRouteCatalog(
+  snapshot: Snapshot,
+  projection: ContentQualityRouteProjection,
+): RouteCatalogQualityReport {
+  const expectations = buildRouteExpectations(snapshot);
+  const pageByPath = new Map(projection.routePages.map((page) => [page.staticPath, page]));
+  const pageById = new Map(projection.routePages.map((page) => [page.routeId, page]));
+  const missingIndexLinks: string[] = [];
+  const missingRoutePages: string[] = [];
+  const missingContentRefs: MissingRouteRef[] = [];
+  const missingPatternLinks: MissingRouteRef[] = [];
+
+  let routeIndexLinksFound = 0;
+  let routePagesFound = 0;
+  let routeContentRefsFound = 0;
+  let routeContentRefsExpected = 0;
+  let routePatternLinksFound = 0;
+  let routePatternLinksExpected = 0;
+
+  for (const expectation of expectations) {
+    if (containsProjectionToken(projection.indexText, expectation.staticPath)) {
+      routeIndexLinksFound += 1;
+    } else {
+      missingIndexLinks.push(expectation.staticPath);
+    }
+
+    const routePage = pageByPath.get(expectation.staticPath) ?? pageById.get(expectation.route.id);
+    if (!routePage) {
+      missingRoutePages.push(expectation.staticPath);
+      routeContentRefsExpected += expectation.contentRefs.length;
+      routePatternLinksExpected += expectation.patternLinkRefs.length;
+      for (const ref of expectation.contentRefs) {
+        missingContentRefs.push({ routeId: expectation.route.id, ref });
+      }
+      for (const ref of expectation.patternLinkRefs) {
+        missingPatternLinks.push({
+          routeId: expectation.route.id,
+          ref,
+          expectedPath: patternStaticPath(ref),
+        });
+      }
+      continue;
+    }
+
+    routePagesFound += 1;
+    for (const ref of expectation.contentRefs) {
+      routeContentRefsExpected += 1;
+      if (containsProjectionToken(routePage.text, ref)) {
+        routeContentRefsFound += 1;
+      } else {
+        missingContentRefs.push({ routeId: expectation.route.id, ref });
+      }
+    }
+
+    for (const ref of expectation.patternLinkRefs) {
+      const expectedPath = patternStaticPath(ref);
+      routePatternLinksExpected += 1;
+      if (containsProjectionToken(routePage.text, expectedPath)) {
+        routePatternLinksFound += 1;
+      } else {
+        missingPatternLinks.push({ routeId: expectation.route.id, ref, expectedPath });
+      }
+    }
+  }
+
+  return {
+    expectedRoutes: expectations.length,
+    routeIndexLinksFound,
+    routePagesFound,
+    routeContentRefsFound,
+    routeContentRefsExpected,
+    routePatternLinksFound,
+    routePatternLinksExpected,
+    routeIndexLinkCoveragePercent: percent(routeIndexLinksFound, expectations.length),
+    routePageCoveragePercent: percent(routePagesFound, expectations.length),
+    routeContentCoveragePercent: percent(routeContentRefsFound, routeContentRefsExpected),
+    routePatternLinkCoveragePercent: percent(routePatternLinksFound, routePatternLinksExpected),
+    missingIndexLinks,
+    missingRoutePages,
+    missingContentRefs,
+    missingPatternLinks,
+  };
+}
+
+function evaluateCuratedDoc(
+  snapshot: Snapshot,
+  doc: ContentQualityCuratedDoc,
+  expectedDoc?: ContentQualityCuratedDoc,
+): CuratedDocQualityReport {
+  const routeSelectors = extractRouteSelectors(doc.text);
+  const expectedRouteSelectors = expectedDoc ? extractRouteSelectors(expectedDoc.text) : undefined;
+  const patternLinks = extractPatternLinks(doc.text);
+  const unresolvedRouteSelectors = routeSelectors.filter(
+    (selector) => !snapshot.routeGraph.nodes[selector],
+  );
+  const unresolvedPatternLinks = patternLinks.filter(
+    (link) => !snapshot.patternGraph.nodes[link],
+  );
+
+  return {
+    label: doc.label,
+    path: doc.path,
+    sourcePath: doc.sourcePath,
+    routeSelectors,
+    unresolvedRouteSelectors,
+    patternLinks,
+    unresolvedPatternLinks,
+    expectedRouteSelectors,
+    missingExpectedRouteSelectors: expectedRouteSelectors
+      ? expectedRouteSelectors.filter((selector) => !routeSelectors.includes(selector))
+      : [],
+    unexpectedRouteSelectors: expectedRouteSelectors
+      ? routeSelectors.filter((selector) => !expectedRouteSelectors.includes(selector))
+      : [],
+    routeSelectorCoveragePercent: percent(
+      routeSelectors.length - unresolvedRouteSelectors.length,
+      routeSelectors.length,
+    ),
+    patternLinkCoveragePercent: percent(
+      patternLinks.length - unresolvedPatternLinks.length,
+      patternLinks.length,
+    ),
+  };
+}
+
+function evaluateLiveEvidence(
+  sourceHash: string,
+  manifest: PublicationManifestSummary | undefined,
+  live: ContentQualityLiveEvidence,
+): ContentQualityLiveReport {
+  const hosted = live.hostedStatus;
+  const statusSourceCoherent =
+    hosted.status === 'ok'
+    && hosted.publication.sourceHash === sourceHash
+    && hosted.runtime.sourceHash === sourceHash
+    && hosted.runtime.snapshotSourceHash === sourceHash
+    && hosted.runtime.currentSourceHash === sourceHash;
+
+  return {
+    baseUrl: live.baseUrl,
+    upstreamSpecUrl: live.upstreamSpecUrl,
+    upstreamSourceHash: live.upstreamSourceHash,
+    statusSourceCoherent,
+    upstreamSourceMatchesPublished: live.upstreamSourceHash === sourceHash,
+    runtimeFresh: hosted.runtime.snapshotExists && hosted.runtime.fresh,
+    publishedRefMatchesManifest: manifest?.upstreamRef
+      ? hosted.publication.upstreamRef === manifest.upstreamRef
+      : true,
+    hostedPublishedRef: hosted.publication.upstreamRef,
+    manifestUpstreamRef: manifest?.upstreamRef,
+  };
+}
+
+function buildRouteExpectations(snapshot: Snapshot): RouteExpectation[] {
+  return Object.values(snapshot.routeGraph.nodes)
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((route) => {
+      const contentRefs = uniqueStrings([
+        route.id,
+        ...route.orderedIds,
+        ...route.optionalIds,
+        ...route.landingIds,
+        ...route.routeSurfaces,
+        ...route.nextOwners,
+        ...route.reroutes,
+        ...route.citations,
+      ]);
+      const linkedRefs = uniqueStrings([
+        ...route.orderedIds,
+        ...route.optionalIds,
+        ...route.landingIds,
+        ...route.routeSurfaces,
+        ...route.nextOwners,
+        ...route.reroutes,
+      ]);
+      const patternLinkRefs = linkedRefs.filter((ref) => Boolean(snapshot.patternGraph.nodes[ref]));
+      return {
+        route,
+        staticPath: routeStaticPath(route.id),
+        contentRefs,
+        patternLinkRefs,
+      };
+    });
+}
+
+function buildLocalRouteProjection(
+  snapshot: Snapshot,
+  manifest: PublishCurrentManifest,
+): ContentQualityRouteProjection {
+  const projection = buildDocsProjection(snapshot, manifest);
+  const indexPage = projection.pages.find((page) => page.staticPath === '/generated/routes/index');
+  if (!indexPage) {
+    throw new Error('Generated route index page is missing from docs projection.');
+  }
+
+  return {
+    indexPath: indexPage.staticPath,
+    indexText: indexPage.markdown,
+    routePages: projection.pages
+      .filter((page) => page.kind === 'route' && page.nodeId)
+      .map((page) => ({
+        routeId: page.nodeId ?? '',
+        staticPath: page.staticPath,
+        text: page.markdown,
+      })),
+  };
+}
+
+async function fetchLiveRouteProjection(
+  snapshot: Snapshot,
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<ContentQualityRouteProjection> {
+  const routes = Object.values(snapshot.routeGraph.nodes)
+    .sort((left, right) => left.id.localeCompare(right.id));
+  const routePages = await Promise.all(
+    routes.map(async (route) => {
+      const staticPath = routeStaticPath(route.id);
+      return {
+        routeId: route.id,
+        staticPath,
+        text: await fetchText(fetchImpl, baseUrl, staticPath),
+      };
+    }),
+  );
+
+  return {
+    indexPath: '/generated/routes',
+    indexText: await fetchText(fetchImpl, baseUrl, '/generated/routes'),
+    routePages,
+  };
+}
+
+async function fetchLiveCuratedDocs(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<ContentQualityCuratedDoc[]> {
+  return Promise.all(
+    CONTENT_QUALITY_CURATED_DOCS.map(async (doc) => ({
+      label: doc.label,
+      path: doc.path,
+      sourcePath: doc.sourcePath,
+      text: await fetchText(fetchImpl, baseUrl, doc.path),
+    })),
+  );
+}
+
+async function fetchLiveEvidence(input: {
+  baseUrl: string;
+  fetchImpl: typeof fetch;
+  manifest: PublishCurrentManifest;
+}): Promise<ContentQualityLiveEvidence> {
+  const upstreamSpecUrl = buildUpstreamSpecUrl({
+    owner: DEFAULT_UPSTREAM_OWNER,
+    repo: DEFAULT_UPSTREAM_REPO,
+    ref: input.manifest.upstreamRef,
+  });
+  const [hostedStatus, upstreamSpecText] = await Promise.all([
+    fetchJson<HostedContentStatus>(input.fetchImpl, input.baseUrl, '/api/fpf/status'),
+    fetchTextUrl(input.fetchImpl, upstreamSpecUrl),
+  ]);
+
+  return {
+    baseUrl: input.baseUrl,
+    hostedStatus,
+    upstreamSpecUrl,
+    upstreamSourceHash: hashText(upstreamSpecText),
+  };
+}
+
+async function readPublishedSnapshot(snapshotPath: string): Promise<Snapshot> {
+  const snapshotText = await readFile(snapshotPath, 'utf8');
+  return JSON.parse(snapshotText) as Snapshot;
+}
+
+async function readLocalCuratedDocs(
+  cwd: string,
+  snapshot: Snapshot,
+  manifest: PublishCurrentManifest,
+): Promise<ContentQualityCuratedDoc[]> {
+  const homePage = buildDocsProjection(snapshot, manifest).pages
+    .find((page) => page.staticPath === '/');
+
+  return Promise.all(
+    CONTENT_QUALITY_CURATED_DOCS.map(async (doc) => {
+      if (doc.label === 'home') {
+        return {
+          label: doc.label,
+          path: doc.path,
+          sourcePath: doc.sourcePath,
+          text: homePage?.markdown ?? '',
+        };
+      }
+
+      return {
+        label: doc.label,
+        path: doc.path,
+        sourcePath: doc.sourcePath,
+        text: await readFile(resolve(cwd, doc.sourcePath), 'utf8'),
+      };
+    }),
+  );
+}
+
+function routeStaticPath(routeId: string): string {
+  return `/generated/routes/route_${routeId.replace(/^route:/u, '')}`;
+}
+
+function patternStaticPath(patternId: string): string {
+  return `/generated/patterns/${patternId}`;
+}
+
+function extractRouteSelectors(text: string): string[] {
+  return uniqueStrings(
+    [...text.matchAll(/\broute:[a-z0-9][a-z0-9-]*/gu)].map((match) => match[0]),
+  );
+}
+
+function extractPatternLinks(text: string): string[] {
+  return uniqueStrings(
+    [...text.matchAll(/\/generated\/patterns\/([A-Z]\.\d+(?:\.[A-Za-z0-9]+)*(?::[A-Za-z0-9.]+)?)/gu)]
+      .map((match) => match[1])
+      .filter((value): value is string => Boolean(value)),
+  );
+}
+
+function containsProjectionToken(text: string, needle: string): boolean {
+  return text.includes(needle) || htmlToSearchText(text).includes(needle);
+}
+
+function htmlToSearchText(text: string): string {
+  return text
+    .replace(/<script\b[\s\S]*?<\/script>/giu, ' ')
+    .replace(/<style\b[\s\S]*?<\/style>/giu, ' ')
+    .replace(/<[^>]+>/gu, ' ')
+    .replace(/&quot;/gu, '"')
+    .replace(/&#39;/gu, "'")
+    .replace(/&amp;/gu, '&')
+    .replace(/&lt;/gu, '<')
+    .replace(/&gt;/gu, '>')
+    .replace(/\s+/gu, ' ');
+}
+
+async function fetchJson<T>(
+  fetchImpl: typeof fetch,
+  baseUrl: string,
+  path: string,
+): Promise<T> {
+  const text = await fetchText(fetchImpl, baseUrl, path);
+  return JSON.parse(text) as T;
+}
+
+async function fetchText(
+  fetchImpl: typeof fetch,
+  baseUrl: string,
+  path: string,
+): Promise<string> {
+  return fetchTextUrl(fetchImpl, new URL(path, baseUrl).toString());
+}
+
+async function fetchTextUrl(fetchImpl: typeof fetch, url: string): Promise<string> {
+  const response = await fetchImpl(url, {
+    headers: {
+      Accept: 'text/html,application/json,text/plain;q=0.9,*/*;q=0.8',
+      'User-Agent': 'fpf-memory-content-quality-monitor',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  }
+  return response.text();
+}
+
+function hashText(text: string): string {
+  return `sha256:${createHash('sha256').update(text).digest('hex')}`;
+}
+
+function percent(found: number, expected: number): number {
+  if (expected === 0) return 100;
+  return Math.round((found / expected) * 10_000) / 100;
+}
+
+function formatPercent(value: number): string {
+  return `${value.toFixed(value % 1 === 0 ? 0 : 2)}%`;
+}
+
+function escapeTableCell(value: string): string {
+  return value.replace(/\|/gu, '\\|');
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))];
+}
+
+function summarizeContentQuality(
+  state: ContentQualityState,
+  routeCatalog: RouteCatalogQualityReport,
+  staleCuratedRefs: string[],
+  live: ContentQualityLiveReport | undefined,
+): string {
+  if (state === 'ok') {
+    const liveSuffix = live
+      ? ` Live fpf.sh status and raw upstream spec hash match ${live.upstreamSourceHash}.`
+      : '';
+    return `Content projection matches the published FPF source: route index, route pages, route refs, and curated selectors are all 100%.${liveSuffix}`;
+  }
+
+  const failed = [
+    routeCatalog.missingIndexLinks.length > 0
+      ? `${routeCatalog.missingIndexLinks.length} missing route index links`
+      : '',
+    routeCatalog.missingRoutePages.length > 0
+      ? `${routeCatalog.missingRoutePages.length} missing route pages`
+      : '',
+    routeCatalog.missingContentRefs.length > 0
+      ? `${routeCatalog.missingContentRefs.length} missing route content refs`
+      : '',
+    routeCatalog.missingPatternLinks.length > 0
+      ? `${routeCatalog.missingPatternLinks.length} missing route pattern links`
+      : '',
+    staleCuratedRefs.length > 0 ? `${staleCuratedRefs.length} stale curated refs` : '',
+    live && (!live.statusSourceCoherent || !live.upstreamSourceMatchesPublished || !live.runtimeFresh)
+      ? 'live source coherence failed'
+      : '',
+  ].filter(Boolean);
+
+  return `Content quality breach: ${failed.join(', ')}.`;
+}

--- a/tests/content-quality-monitor.test.ts
+++ b/tests/content-quality-monitor.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from '@rstest/core';
+
+import {
+  evaluateContentQuality,
+  formatContentQualityMarkdown,
+  type ContentQualityCuratedDoc,
+  type ContentQualityRouteProjection,
+  type HostedContentStatus,
+} from '../src/build/content-quality-monitor.js';
+import type {
+  PatternRecord,
+  RouteRecord,
+  Snapshot,
+} from '../src/core/types.js';
+
+describe('FPF content quality monitor', () => {
+  it('passes when generated routes and curated docs resolve against the snapshot', () => {
+    const report = evaluateContentQuality({
+      mode: 'local',
+      snapshot: makeSnapshot(),
+      sourceHash: SOURCE_HASH,
+      manifest: makeManifest(),
+      routeProjection: makeRouteProjection(),
+      curatedDocs: makeCuratedDocs(),
+      now: new Date('2026-05-30T16:00:00Z'),
+    });
+
+    expect(report.state).toBe('ok');
+    expect(report.routeCatalog.routeIndexLinkCoveragePercent).toBe(100);
+    expect(report.routeCatalog.routeContentCoveragePercent).toBe(100);
+    expect(report.routeCatalog.routePatternLinkCoveragePercent).toBe(100);
+    expect(report.curatedDocs.every((doc) => doc.unresolvedRouteSelectors.length === 0)).toBe(
+      true,
+    );
+  });
+
+  it('breaches when a curated work packet points at a stale route selector', () => {
+    const report = evaluateContentQuality({
+      mode: 'local',
+      snapshot: makeSnapshot(),
+      sourceHash: SOURCE_HASH,
+      manifest: makeManifest(),
+      routeProjection: makeRouteProjection(),
+      curatedDocs: makeCuratedDocs({
+        'work-packets': 'Use route:boundary-unpacking-claim-routing.',
+      }),
+      now: new Date('2026-05-30T16:00:00Z'),
+    });
+
+    expect(report.state).toBe('breach');
+    expect(report.curatedDocs.find((doc) => doc.label === 'work-packets')?.unresolvedRouteSelectors)
+      .toEqual(['route:boundary-unpacking-claim-routing']);
+    expect(report.quality.find((item) => item.characteristic === 'curated selector validity')?.status)
+      .toBe('fail');
+  });
+
+  it('breaches when route catalog links or route page contents are missing', () => {
+    const projection = makeRouteProjection({
+      indexText: '[project](/generated/routes/route_project-alignment)',
+      reviewText: 'Route route:writing-or-reviewing-patterns A.3',
+    });
+    const report = evaluateContentQuality({
+      mode: 'local',
+      snapshot: makeSnapshot(),
+      sourceHash: SOURCE_HASH,
+      manifest: makeManifest(),
+      routeProjection: projection,
+      curatedDocs: makeCuratedDocs(),
+      now: new Date('2026-05-30T16:00:00Z'),
+    });
+
+    expect(report.state).toBe('breach');
+    expect(report.routeCatalog.missingIndexLinks).toEqual([
+      '/generated/routes/route_writing-or-reviewing-patterns',
+    ]);
+    expect(report.routeCatalog.missingPatternLinks).toContainEqual({
+      routeId: 'route:writing-or-reviewing-patterns',
+      ref: 'A.3',
+      expectedPath: '/generated/patterns/A.3',
+    });
+    expect(report.routeCatalog.routeIndexLinkCoveragePercent).toBe(50);
+  });
+
+  it('breaches live mode when hosted status or raw upstream hash diverges', () => {
+    const report = evaluateContentQuality({
+      mode: 'live',
+      snapshot: makeSnapshot(),
+      sourceHash: SOURCE_HASH,
+      manifest: makeManifest(),
+      routeProjection: makeRouteProjection(),
+      curatedDocs: makeCuratedDocs(),
+      live: {
+        baseUrl: 'https://fpf.sh',
+        hostedStatus: makeHostedStatus({ sourceHash: 'sha256:wrong' }),
+        upstreamSpecUrl: 'https://raw.githubusercontent.com/ailev/FPF/main/FPF-Spec.md',
+        upstreamSourceHash: 'sha256:wrong',
+      },
+      now: new Date('2026-05-30T16:00:00Z'),
+    });
+
+    expect(report.state).toBe('breach');
+    expect(report.live?.statusSourceCoherent).toBe(false);
+    expect(report.live?.upstreamSourceMatchesPublished).toBe(false);
+    expect(report.quality.find((item) => item.characteristic === 'published source coherence')?.status)
+      .toBe('fail');
+  });
+
+  it('breaches live mode when curated route selectors differ from repo docs', () => {
+    const report = evaluateContentQuality({
+      mode: 'live',
+      snapshot: makeSnapshot(),
+      sourceHash: SOURCE_HASH,
+      manifest: makeManifest(),
+      routeProjection: makeRouteProjection(),
+      curatedDocs: makeCuratedDocs({
+        'work-packets': 'Use route:project-alignment.',
+      }),
+      expectedCuratedDocs: makeCuratedDocs({
+        'work-packets': 'Use route:writing-or-reviewing-patterns.',
+      }),
+      live: {
+        baseUrl: 'https://fpf.sh',
+        hostedStatus: makeHostedStatus(),
+        upstreamSpecUrl: 'https://raw.githubusercontent.com/ailev/FPF/main/FPF-Spec.md',
+        upstreamSourceHash: SOURCE_HASH,
+      },
+      now: new Date('2026-05-30T16:00:00Z'),
+    });
+
+    const workPackets = report.curatedDocs.find((doc) => doc.label === 'work-packets');
+    expect(report.state).toBe('breach');
+    expect(workPackets?.missingExpectedRouteSelectors).toEqual([
+      'route:writing-or-reviewing-patterns',
+    ]);
+    expect(workPackets?.unexpectedRouteSelectors).toEqual(['route:project-alignment']);
+  });
+
+  it('renders percentages and FPF QA anchors in markdown', () => {
+    const report = evaluateContentQuality({
+      mode: 'local',
+      snapshot: makeSnapshot(),
+      sourceHash: SOURCE_HASH,
+      manifest: makeManifest(),
+      routeProjection: makeRouteProjection(),
+      curatedDocs: makeCuratedDocs(),
+      now: new Date('2026-05-30T16:00:00Z'),
+    });
+
+    const markdown = formatContentQualityMarkdown(report);
+
+    expect(markdown).toContain('100%');
+    expect(markdown).toContain('A.10');
+    expect(markdown).toContain('E.19');
+    expect(markdown).toContain('MCP pages are monitored as curated docs');
+  });
+});
+
+const SOURCE_HASH = 'sha256:published';
+const UPSTREAM_REF = '2e112078bb209e5e3a511c3bd1aa6b1b2e299efe';
+
+function makeSnapshot(): Snapshot {
+  const patterns = {
+    'A.1': makePattern('A.1', 'Role and work boundary'),
+    'A.2': makePattern('A.2', 'Evidence surface'),
+    'A.3': makePattern('A.3', 'Review path'),
+  };
+  const routes = {
+    'route:project-alignment': makeRoute({
+      id: 'route:project-alignment',
+      name: 'project alignment',
+      orderedIds: ['A.1', 'A.2'],
+    }),
+    'route:writing-or-reviewing-patterns': makeRoute({
+      id: 'route:writing-or-reviewing-patterns',
+      name: 'writing or reviewing patterns',
+      orderedIds: ['A.3'],
+    }),
+  };
+
+  return {
+    sourcePath: 'published/current/FPF-Spec.md',
+    sourceHash: SOURCE_HASH,
+    builtAt: '2026-05-30T16:00:00Z',
+    compilerFingerprint: 'sha256:compiler',
+    compilerMode: 'local_vectorless',
+    indexRoots: [],
+    indexMap: {},
+    anchorMap: {},
+    patternGraph: { nodes: patterns, relations: [] },
+    routeGraph: { nodes: routes, relations: [] },
+    lexicon: {},
+    compiledNodes: {},
+    relationGraph: [],
+    indexes: {
+      idIndex: {},
+      titleIndex: {},
+      aliasIndex: {},
+      lexiconIndex: {},
+      routeNameIndex: {},
+      statusIndex: {},
+      familyIndex: {},
+    },
+    validation: {
+      parsedSections: 0,
+      parsedPatterns: 3,
+      parsedRoutes: 2,
+      parsedLexiconEntries: 0,
+      indexMapNodes: 0,
+      missingRequiredFields: 0,
+      unresolvedReferences: [],
+      duplicateIds: [],
+      duplicateHeadings: [],
+      brokenRoutes: [],
+    },
+  };
+}
+
+function makePattern(id: string, title: string): PatternRecord {
+  return {
+    id,
+    title,
+    status: 'Active',
+    keywords: [],
+    queries: [],
+    aliases: [],
+    dependenciesRaw: '',
+    sectionIds: [],
+    relations: [],
+    searchableText: `${id} ${title}`,
+  };
+}
+
+function makeRoute(overrides: Partial<RouteRecord> & Pick<RouteRecord, 'id' | 'name'>): RouteRecord {
+  return {
+    id: overrides.id,
+    name: overrides.name,
+    description: `${overrides.name} route`,
+    orderedIds: overrides.orderedIds ?? [],
+    optionalIds: overrides.optionalIds ?? [],
+    landingIds: overrides.landingIds ?? [],
+    routeSurfaces: overrides.routeSurfaces ?? [],
+    nextOwners: overrides.nextOwners ?? [],
+    reroutes: overrides.reroutes ?? [],
+    citations: overrides.citations ?? [],
+    anchorIds: overrides.anchorIds ?? [],
+    searchableText: overrides.searchableText ?? overrides.name,
+    constraints: overrides.constraints ?? [],
+    firstHonestBurden: overrides.firstHonestBurden,
+  };
+}
+
+function makeRouteProjection(overrides: {
+  indexText?: string;
+  projectText?: string;
+  reviewText?: string;
+} = {}): ContentQualityRouteProjection {
+  return {
+    indexPath: '/generated/routes',
+    indexText: overrides.indexText ?? [
+      '[project](/generated/routes/route_project-alignment)',
+      '[review](/generated/routes/route_writing-or-reviewing-patterns)',
+    ].join('\n'),
+    routePages: [
+      {
+        routeId: 'route:project-alignment',
+        staticPath: '/generated/routes/route_project-alignment',
+        text: overrides.projectText ?? [
+          'Route route:project-alignment',
+          'A.1 /generated/patterns/A.1',
+          'A.2 /generated/patterns/A.2',
+        ].join('\n'),
+      },
+      {
+        routeId: 'route:writing-or-reviewing-patterns',
+        staticPath: '/generated/routes/route_writing-or-reviewing-patterns',
+        text: overrides.reviewText ?? [
+          'Route route:writing-or-reviewing-patterns',
+          'A.3 /generated/patterns/A.3',
+        ].join('\n'),
+      },
+    ],
+  };
+}
+
+function makeCuratedDocs(overrides: Record<string, string> = {}): ContentQualityCuratedDoc[] {
+  const docs = [
+    { label: 'home', path: '/', sourcePath: 'docs/index.md', text: '' },
+    {
+      label: 'start-here',
+      path: '/start-here',
+      sourcePath: 'docs/start-here.md',
+      text: 'Start with route:project-alignment.',
+    },
+    {
+      label: 'work-packets',
+      path: '/work-packets',
+      sourcePath: 'docs/work-packets.md',
+      text: 'Use route:writing-or-reviewing-patterns and /generated/patterns/A.3.',
+    },
+    {
+      label: 'connect-mcp',
+      path: '/connect-mcp',
+      sourcePath: 'docs/connect-mcp.md',
+      text: 'Ask for route:project-alignment.',
+    },
+    {
+      label: 'mcp-recipes',
+      path: '/mcp-recipes',
+      sourcePath: 'docs/mcp-recipes.md',
+      text: 'Review with route:writing-or-reviewing-patterns.',
+    },
+    {
+      label: 'automation-playbook',
+      path: '/automation-playbook',
+      sourcePath: 'docs/automation-playbook.md',
+      text: 'Keep publication evidence bounded.',
+    },
+  ];
+
+  return docs.map((doc) => ({
+    ...doc,
+    text: overrides[doc.label] ?? doc.text,
+  }));
+}
+
+function makeManifest(): {
+  channel: string;
+  sourceHash: string;
+  upstreamRef: string;
+  publishedAt: string;
+  upstreamRepoUrl: string;
+  upstreamCommittedAt: string;
+} {
+  return {
+    channel: 'current',
+    sourceHash: SOURCE_HASH,
+    upstreamRef: UPSTREAM_REF,
+    publishedAt: '2026-05-30T16:00:00Z',
+    upstreamRepoUrl: 'https://github.com/ailev/FPF',
+    upstreamCommittedAt: '2026-05-29T22:34:53Z',
+  };
+}
+
+function makeHostedStatus(overrides: { sourceHash?: string } = {}): HostedContentStatus {
+  const sourceHash = overrides.sourceHash ?? SOURCE_HASH;
+  return {
+    status: 'ok',
+    servedAt: '2026-05-30T16:00:00Z',
+    publication: {
+      upstreamRef: UPSTREAM_REF,
+      publishedAt: '2026-05-30T16:00:00Z',
+      sourceHash,
+    },
+    runtime: {
+      sourceHash,
+      snapshotSourceHash: sourceHash,
+      currentSourceHash: sourceHash,
+      snapshotExists: true,
+      fresh: true,
+    },
+  };
+}

--- a/tests/content-quality-workflow.test.ts
+++ b/tests/content-quality-workflow.test.ts
@@ -1,0 +1,28 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from '@rstest/core';
+
+describe('FPF content quality workflow', () => {
+  it('gates pull requests with the local content monitor', async () => {
+    const workflow = await readFile(resolve(process.cwd(), '.github/workflows/ci.yml'), 'utf8');
+
+    expect(workflow).toContain('Monitor generated and curated content quality');
+    expect(workflow).toContain(
+      'bun run monitor:content -- --mode local --format markdown --fail-on-breach',
+    );
+  });
+
+  it('monitors production route and curated page drift on a schedule', async () => {
+    const workflow = await readFile(
+      resolve(process.cwd(), '.github/workflows/fpf-content-quality.yml'),
+      'utf8',
+    );
+
+    expect(workflow).toContain("- cron: '37 * * * *'");
+    expect(workflow).toContain(
+      'bun run monitor:content -- --mode live --format markdown --fail-on-breach',
+    );
+    expect(workflow).toContain('FPF_CONTENT_QUALITY_BASE_URL: https://fpf.sh');
+  });
+});


### PR DESCRIPTION
## Summary
- add `monitor:content` with local and live modes for generated route coverage, curated docs selector validity, repo-vs-live selector drift, and source/hash coherence
- gate PR CI with the local content monitor
- add an hourly production content-quality sentinel for `fpf.sh`

## Validation
- `bun run validate:published` passed; source hash `sha256:73c08fb554cc5920f4bf5497e0d356ab6d3bcd5bdb605f8dcc2f82587565005e`, upstream `2e112078bb209e5e3a511c3bd1aa6b1b2e299efe`
- `bun run monitor:content -- --mode local --format markdown --fail-on-breach` passed: 22/22 route links, 22/22 route pages, 167/167 route refs, 116/116 route pattern links, 6 curated pages clean
- `bun run monitor:content -- --mode live --format markdown --fail-on-breach` passed with the same 100% route/curated coverage and live/raw upstream hash match
- `bun run lint` passed
- `bun run check` passed
- `bun run test -- tests/content-quality-monitor.test.ts tests/content-quality-workflow.test.ts tests/sync-fpf-workflow.test.ts` passed: 12 tests
- `bun run docs:build` passed; generated 982 docs pages
- `bun run vercel:origin:build` passed; function bundle 99.96 MB, 140.04 MB headroom
- `$autoreview` attempted via `/Users/stas-studio/.codex/skills/autoreview/scripts/autoreview --mode branch --base origin/main`, but the helper failed before review because `gpt-5.5` requires a newer Codex CLI/app version

## Notes
- MCP docs are monitored as curated pages (`connect-mcp`, `mcp-recipes`, `automation-playbook`), but agents do not need whole MCP subpages as default prompt context; the monitor emits failing snippets/provenance instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a blocking CI step and production sentinel that can fail on content drift or live/hash mismatch; behavior is read-only validation with no auth or data writes.
> 
> **Overview**
> Adds a **FPF content quality monitor** (`monitor:content`) that scores generated route coverage, curated `route:` / pattern link validity, and (in **live** mode) hosted vs manifest source hashes and repo-vs-production selector drift.
> 
> **Local** mode runs in CI right after `validate:published`, failing the setup job on breach so broken projections do not reach build/deploy. A new **hourly** workflow hits `https://fpf.sh` in **live** mode for the same checks against production HTML and `/api/fpf/status`. Reports are JSON or markdown, with optional GitHub step summary/output and `--fail-on-breach`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4827f408c66b6f63e562e2a912f430908cccf50f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->