### PR TITLE
fix(deploy): align Vercel origin readiness gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,11 @@ Call ask_fpf with:
 For a proof-style grounded answer, add `mode: "proof"`. For the raw structured envelope, call `query_fpf_spec` instead. For a deterministic retrieval/debug trace, call `trace_fpf_path`.
 
 The direct Vercel origin is canonical for clients. There is no separate Vercel forwarding project in this repo.
+The canonical client aliases are `https://fpf.sh/` for the static reference and `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp` for MCP clients.
+`https://mcp.fpf.sh/api/mcp/fpf_memory/mcp` remains a legacy compatibility endpoint during the transition.
+`fpf-memory-mcp-vercel-origin.vercel.app` is a legacy compatibility alias only; do not add it to new docs, scripts, or client setup examples.
+Historical errored preview deployments can remain in Vercel as audit records.
+Treat current production readiness as the latest `fpf.sh` production alias plus status, smoke, QA, and bundle-size gates, not as an absence of old preview errors.
 
 ```bash
 bun run vercel:origin:link

--- a/scripts/_args.ts
+++ b/scripts/_args.ts
@@ -1,4 +1,5 @@
 export type FlagValues = Map<string, string | true>;
+export type OutputFormat = 'json' | 'markdown';
 
 export function parseFlagMap(args: string[]): FlagValues {
   const values: FlagValues = new Map();
@@ -90,6 +91,13 @@ export function asOptionalString(value: unknown): string | undefined {
 
 export function round(value: number): number {
   return Math.round(value * 100) / 100;
+}
+
+export function readOutputFormat(value: string): OutputFormat {
+  if (value === 'json' || value === 'markdown') {
+    return value;
+  }
+  throw new Error(`Unknown format: ${value}`);
 }
 
 export function assert(condition: unknown, message: string): asserts condition {

--- a/scripts/bench-hosted-mcp.ts
+++ b/scripts/bench-hosted-mcp.ts
@@ -11,12 +11,14 @@ import {
   parseFlagMap,
   readNonNegativeInteger,
   readOptionalString,
+  readOutputFormat,
   readPositiveInteger,
   readString,
   round,
+  type OutputFormat,
 } from './_args.js';
 
-const EXPECTED_PUBLIC_TOOLS = [
+export const EXPECTED_PUBLIC_TOOLS = [
   'browse_fpf_catalog',
   'search_fpf',
   'ask_fpf',
@@ -32,7 +34,6 @@ const DEFAULT_WARMUP = 5;
 const DEFAULT_TIMEOUT_MS = 60_000;
 
 type Scenario = 'mixed' | 'query' | 'read' | 'discovery' | 'status';
-type OutputFormat = 'json' | 'markdown';
 type OperationName = 'status' | 'browse' | 'search' | 'read' | 'query';
 
 export interface BenchOptions {
@@ -153,7 +154,7 @@ export class McpHttpClient {
     );
     assert(initialize.serverInfo !== undefined, 'initialize did not return serverInfo.');
     assert(
-      asRecord(initialize.serverInfo, 'serverInfo').name === 'fpf_memory',
+      asRecord(initialize.serverInfo, 'serverInfo').name === 'fpf_reference',
       'initialize returned an unexpected server name.',
     );
     await this.notify('notifications/initialized');
@@ -162,7 +163,11 @@ export class McpHttpClient {
   async listTools(): Promise<string[]> {
     const toolsList = asRecord((await this.rpc('tools/list')).result, 'tools/list result');
     const tools = asArray(toolsList.tools, 'tools/list tools');
-    return tools.map((tool) => asRecord(tool, 'tool').name).filter(isString);
+    return tools.map((tool, index) => {
+      const name = asRecord(tool, `tool ${index}`).name;
+      assert(typeof name === 'string', `tool ${index} name was not a string.`);
+      return name;
+    });
   }
 
   async callTool(
@@ -207,6 +212,10 @@ export class McpHttpClient {
       );
     }
     return { status: response.status, contentType };
+  }
+
+  getSessionId(): string | undefined {
+    return this.sessionId;
   }
 
   private async rpc(method: string, params?: Record<string, unknown>): Promise<RpcResult> {
@@ -653,13 +662,6 @@ function readScenario(value: string): Scenario {
     return value;
   }
   throw new Error(`Unknown scenario: ${value}`);
-}
-
-function readOutputFormat(value: string): OutputFormat {
-  if (value === 'json' || value === 'markdown') {
-    return value;
-  }
-  throw new Error(`Unknown format: ${value}`);
 }
 
 function percentile(sortedValues: number[], rank: number): number {

--- a/scripts/bench-mcp-qa.ts
+++ b/scripts/bench-mcp-qa.ts
@@ -10,14 +10,15 @@ import {
   assert,
   parseFlagMap,
   readOptionalString,
+  readOutputFormat,
   readPositiveInteger,
   readString,
   round,
+  type OutputFormat,
 } from './_args.js';
 import { McpHttpClient } from './bench-hosted-mcp.js';
 
 type AnswerMode = 'compact' | 'verbose' | 'proof';
-type OutputFormat = 'json' | 'markdown';
 type QaStatus =
   | 'ok'
   | 'degraded'
@@ -47,6 +48,7 @@ interface QaCase {
   expectedAnyIds?: string[];
   forbiddenIds?: string[];
   allowedStatuses?: QaStatus[];
+  maxConfidence?: number;
   maxConfidenceWhenDegraded?: number;
 }
 
@@ -143,7 +145,8 @@ const QA_CASES: Record<string, QaCase[]> = {
       id: 'low_signal_abstain',
       question: 'banana wallpaper coffee quantum spoon',
       mode: 'compact',
-      allowedStatuses: ['not_found', 'ambiguous', 'degraded'],
+      allowedStatuses: ['not_found', 'ambiguous', 'degraded', 'unsupported'],
+      maxConfidence: 0.3,
       maxConfidenceWhenDegraded: 0.5,
     },
   ],
@@ -282,6 +285,15 @@ export async function runQaCase(
   }
   if (status === 'degraded' && confidence !== null) {
     failures.push(`degraded answer confidence was ${confidence ?? '<missing>'} instead of null`);
+  }
+  if (typeof testCase.maxConfidence === 'number' && status !== 'degraded') {
+    if (typeof confidence !== 'number') {
+      failures.push(`confidence was ${confidence ?? '<missing>'} instead of a number`);
+    } else if (confidence > testCase.maxConfidence) {
+      failures.push(
+        `confidence ${confidence} exceeded ${testCase.maxConfidence}`,
+      );
+    }
   }
   if (
     degraded &&
@@ -436,13 +448,6 @@ async function runSessionCheck(
     sessionIds,
     primeIds,
   };
-}
-
-function readOutputFormat(value: string): OutputFormat {
-  if (value === 'json' || value === 'markdown') {
-    return value;
-  }
-  throw new Error(`Unknown format: ${value}`);
 }
 
 function asStringArray(value: unknown, label: string, issues: string[]): string[] {

--- a/scripts/smoke-hosted-mcp.ts
+++ b/scripts/smoke-hosted-mcp.ts
@@ -1,41 +1,12 @@
 import { HOSTED_MCP_ENDPOINT } from '../src/adapters/hosted/endpoints.js';
-
-const EXPECTED_PUBLIC_TOOLS = [
-  'browse_fpf_catalog',
-  'search_fpf',
-  'ask_fpf',
-  'query_fpf_spec',
-  'read_fpf_doc',
-  'get_fpf_index_status',
-] as const;
+import { asRecord, assert } from './_args.js';
+import {
+  EXPECTED_PUBLIC_TOOLS,
+  McpHttpClient,
+} from './bench-hosted-mcp.js';
 
 const endpoint = process.env.FPF_MCP_SMOKE_URL ?? process.argv[2] ?? HOSTED_MCP_ENDPOINT;
 const requestTimeoutMs = parseIntegerEnv('FPF_MCP_SMOKE_TIMEOUT_MS', 60_000);
-
-let nextId = 1;
-let sessionId: string | undefined;
-
-interface JsonRpcError {
-  code: number;
-  message: string;
-  data?: unknown;
-}
-
-interface JsonRpcResponse {
-  jsonrpc: '2.0';
-  id: string | number | null;
-  result?: unknown;
-  error?: JsonRpcError;
-}
-
-interface ToolListResult {
-  tools?: Array<{ name?: unknown }>;
-}
-
-interface ToolCallResult {
-  structuredContent?: unknown;
-  isError?: unknown;
-}
 
 await main().catch((error) => {
   process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
@@ -45,37 +16,13 @@ await main().catch((error) => {
 async function main(): Promise<void> {
   assert(endpoint.startsWith('https://'), 'FPF_MCP_SMOKE_URL must be an https:// URL.');
 
-  const initialize = asRecord(
-    await rpc('initialize', {
-      protocolVersion: '2025-06-18',
-      capabilities: {},
-      clientInfo: {
-        name: 'fpf-memory-http-smoke',
-        version: '1.0.0',
-      },
-    }),
-    'initialize result',
-  );
-  assert(initialize.serverInfo !== undefined, 'initialize did not return serverInfo.');
-  assert(
-    asRecord(initialize.serverInfo, 'serverInfo').name === 'fpf_memory',
-    'initialize returned an unexpected server name.',
-  );
+  const client = new McpHttpClient(endpoint, requestTimeoutMs);
+  await client.initialize('fpf-reference-http-smoke');
 
-  await notify('notifications/initialized');
-
-  const toolsList = asRecord(await rpc('tools/list'), 'tools/list result') as ToolListResult;
-  const toolNames = (toolsList.tools ?? []).map((tool) => tool.name);
+  const toolNames = await client.listTools();
   assertArrayEquals(toolNames, EXPECTED_PUBLIC_TOOLS, 'tools/list did not return the public surface.');
 
-  const statusCall = asRecord(
-    await rpc('tools/call', {
-      name: 'get_fpf_index_status',
-      arguments: {},
-    }),
-    'get_fpf_index_status result',
-  ) as ToolCallResult;
-  assert(statusCall.isError !== true, 'get_fpf_index_status returned isError=true.');
+  const statusCall = await client.callTool('get_fpf_index_status', {});
   const status = asRecord(statusCall.structuredContent, 'get_fpf_index_status structuredContent');
   assert(status.snapshotExists === true, 'get_fpf_index_status did not report snapshotExists=true.');
   assert(status.fresh === true, 'get_fpf_index_status did not report fresh=true.');
@@ -84,18 +31,11 @@ async function main(): Promise<void> {
     'get_fpf_index_status did not report compilerMode=local_vectorless.',
   );
 
-  const queryCall = asRecord(
-    await rpc('tools/call', {
-      name: 'query_fpf_spec',
-      arguments: {
-        question:
-          'Project kickoff: align a project information system with roles and adoption next steps',
-        mode: 'compact',
-      },
-    }),
-    'query_fpf_spec result',
-  ) as ToolCallResult;
-  assert(queryCall.isError !== true, 'query_fpf_spec returned isError=true.');
+  const queryCall = await client.callTool('query_fpf_spec', {
+    question:
+      'Project kickoff: align a project information system with roles and adoption next steps',
+    mode: 'compact',
+  });
   const query = asRecord(queryCall.structuredContent, 'query_fpf_spec structuredContent');
   assert(query.status === 'ok', 'query_fpf_spec did not return status=ok.');
   assert(
@@ -103,14 +43,14 @@ async function main(): Promise<void> {
     'query_fpf_spec did not include route:project-alignment.',
   );
 
-  const sseStatus = await checkSseGet();
+  const sseStatus = await client.checkSseGet();
 
   process.stdout.write(
     `${JSON.stringify(
       {
         endpoint,
         initialized: true,
-        sessionId: sessionId ?? null,
+        sessionId: client.getSessionId() ?? null,
         publicTools: toolNames,
         index: {
           sourceHash: status.sourceHash ?? null,
@@ -129,116 +69,6 @@ async function main(): Promise<void> {
   );
 }
 
-async function rpc(method: string, params?: Record<string, unknown>): Promise<unknown> {
-  const id = nextId++;
-  const response = await fetch(endpoint, {
-    method: 'POST',
-    headers: requestHeaders(),
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      id,
-      method,
-      ...(params ? { params } : {}),
-    }),
-    signal: AbortSignal.timeout(requestTimeoutMs),
-  });
-  captureSessionId(response);
-
-  const message = await readJsonRpcResponse(response);
-  assert(
-    response.ok,
-    `${method} returned HTTP ${response.status}: ${message.error?.message ?? 'no JSON-RPC error'}`,
-  );
-  assert(message.id === id, `${method} returned response id ${String(message.id)} instead of ${id}.`);
-  assert(message.error === undefined, `${method} returned JSON-RPC error: ${message.error?.message}`);
-  return message.result;
-}
-
-async function notify(method: string, params?: Record<string, unknown>): Promise<void> {
-  const response = await fetch(endpoint, {
-    method: 'POST',
-    headers: requestHeaders(),
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      method,
-      ...(params ? { params } : {}),
-    }),
-    signal: AbortSignal.timeout(requestTimeoutMs),
-  });
-  captureSessionId(response);
-
-  if ([200, 202, 204].includes(response.status)) {
-    await response.body?.cancel().catch(() => undefined);
-    return;
-  }
-
-  const body = await response.text().catch(() => '');
-  throw new Error(`${method} notification returned HTTP ${response.status}: ${body}`);
-}
-
-async function checkSseGet(): Promise<{ status: number; contentType: string }> {
-  const response = await fetch(endpoint, {
-    method: 'GET',
-    headers: {
-      Accept: 'text/event-stream',
-      'MCP-Protocol-Version': '2025-06-18',
-      ...(sessionId ? { 'MCP-Session-Id': sessionId } : {}),
-    },
-    signal: AbortSignal.timeout(5_000),
-  });
-  captureSessionId(response);
-  const contentType = response.headers.get('content-type') ?? '';
-  await response.body?.cancel().catch(() => undefined);
-
-  assert(
-    response.status === 200 || response.status === 405,
-    `GET SSE returned unexpected HTTP ${response.status}.`,
-  );
-  if (response.status === 200) {
-    assert(
-      contentType.includes('text/event-stream'),
-      `GET SSE returned content-type ${contentType || '<empty>'}.`,
-    );
-  }
-
-  return { status: response.status, contentType };
-}
-
-async function readJsonRpcResponse(response: Response): Promise<JsonRpcResponse> {
-  const contentType = response.headers.get('content-type') ?? '';
-  const body = await response.text();
-
-  if (contentType.includes('text/event-stream')) {
-    return parseSseJsonRpc(body);
-  }
-
-  assert(body.trim().length > 0, `HTTP ${response.status} returned an empty response body.`);
-  return JSON.parse(body) as JsonRpcResponse;
-}
-
-function parseSseJsonRpc(body: string): JsonRpcResponse {
-  const dataLines = body
-    .split('\n')
-    .map((line) => line.trimEnd())
-    .filter((line) => line.startsWith('data:'))
-    .map((line) => line.slice('data:'.length).trim());
-  assert(dataLines.length > 0, 'SSE response did not contain any data lines.');
-  return JSON.parse(dataLines.join('\n')) as JsonRpcResponse;
-}
-
-function requestHeaders(): Record<string, string> {
-  return {
-    'Content-Type': 'application/json',
-    Accept: 'application/json, text/event-stream',
-    'MCP-Protocol-Version': '2025-06-18',
-    ...(sessionId ? { 'MCP-Session-Id': sessionId } : {}),
-  };
-}
-
-function captureSessionId(response: Response): void {
-  sessionId = response.headers.get('MCP-Session-Id') ?? sessionId;
-}
-
 function parseIntegerEnv(name: string, fallback: number): number {
   const value = process.env[name]?.trim();
   if (!value) return fallback;
@@ -246,27 +76,14 @@ function parseIntegerEnv(name: string, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function asRecord(value: unknown, label: string): Record<string, unknown> {
-  assert(
-    typeof value === 'object' && value !== null && !Array.isArray(value),
-    `${label} was not an object.`,
-  );
-  return value as Record<string, unknown>;
-}
-
-function assert(condition: unknown, message: string): asserts condition {
-  if (!condition) {
-    throw new Error(message);
-  }
-}
-
 function assertArrayEquals(
   actual: readonly unknown[],
-  expected: readonly string[],
+  expected: readonly unknown[],
   message: string,
 ): void {
   assert(
-    actual.length === expected.length && expected.every((value, index) => actual[index] === value),
-    `${message}\nexpected: ${expected.join(', ')}\nactual: ${actual.join(', ')}`,
+    actual.length === expected.length &&
+      actual.every((value, index) => value === expected[index]),
+    `${message} Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}.`,
   );
 }

--- a/src/adapters/infra/config/env.ts
+++ b/src/adapters/infra/config/env.ts
@@ -5,6 +5,11 @@ import {
   DEFAULT_ARTIFACT_DIR,
   DEFAULT_SOURCE_PATH,
 } from '../../../core/constants.js';
+import {
+  DEFAULT_LM_STUDIO_BASE_URL,
+  DEFAULT_LM_STUDIO_MODEL,
+  DEFAULT_LM_STUDIO_TIMEOUT_MS,
+} from './lm-studio-defaults.js';
 import type {
   BuildConfig,
   DocsConfig,
@@ -24,9 +29,6 @@ const DEFAULT_DIST_DIR = 'dist';
 const DEFAULT_SERVER_PORT = 4111;
 const MAX_TCP_PORT = 65_535;
 const DEFAULT_MAX_SESSIONS = 50;
-const DEFAULT_LM_STUDIO_BASE_URL = 'http://localhost:1234/v1';
-const DEFAULT_LM_STUDIO_MODEL = 'google/gemma-4-31b';
-const DEFAULT_LM_STUDIO_TIMEOUT_MS = 20_000;
 
 const answerModeSchema = z.enum(['compact', 'verbose', 'proof']);
 const mcpSurfaceSchema = z.enum(['public', 'full']);
@@ -153,7 +155,7 @@ export function parseBuildConfig(env: NodeJS.ProcessEnv): BuildConfig {
     runtimeArtifactDir: parseString(env.FPF_RUNTIME_ARTIFACT_DIR, DEFAULT_ARTIFACT_DIR),
     distDir: parseString(env.FPF_DIST_DIR, DEFAULT_DIST_DIR),
     hostedPublicDir: parseString(env.FPF_HOSTED_PUBLIC_DIR, DEFAULT_HOSTED_PUBLIC_DIR),
-    docsRoot: parseString(env.FPF_DOCS_ROOT, DEFAULT_DOCS_ROOT),
+    docsOutDir: parseString(env.FPF_DOCS_OUT_DIR, DEFAULT_DOCS_OUT_DIR),
   };
 }
 

--- a/src/adapters/infra/config/lm-studio-defaults.ts
+++ b/src/adapters/infra/config/lm-studio-defaults.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_LM_STUDIO_BASE_URL = 'http://localhost:1234/v1';
+export const DEFAULT_LM_STUDIO_MODEL = 'google/gemma-4-31b';
+export const DEFAULT_LM_STUDIO_TIMEOUT_MS = 20_000;

--- a/src/adapters/infra/config/types.ts
+++ b/src/adapters/infra/config/types.ts
@@ -58,5 +58,5 @@ export interface BuildConfig {
   runtimeArtifactDir: string;
   distDir: string;
   hostedPublicDir: string;
-  docsRoot: string;
+  docsOutDir: string;
 }

--- a/src/build/vercel-origin-build.ts
+++ b/src/build/vercel-origin-build.ts
@@ -31,8 +31,10 @@ const OUTPUT_DIR = '.vercel/output';
 const FUNCTION_NAME = '_origin';
 const FUNCTION_DIR = `${OUTPUT_DIR}/functions/${FUNCTION_NAME}.func`;
 const FUNCTION_DEST = `/${FUNCTION_NAME}`;
+export const VERCEL_FUNCTION_RUNTIME = 'nodejs24.x';
+export const VERCEL_FUNCTION_MEMORY_MB = 2048;
+export const VERCEL_FUNCTION_MAX_DURATION_SECONDS = 300;
 const STATIC_DIR = `${OUTPUT_DIR}/static`;
-const DOCS_BUILD_DIR = process.env.FPF_DOCS_OUT_DIR ?? 'doc_build';
 
 export type VercelOriginRoute =
   | {
@@ -67,7 +69,7 @@ export async function buildVercelOrigin(
   const outputDir = resolve(rootDir, OUTPUT_DIR);
   const functionDir = resolve(rootDir, FUNCTION_DIR);
   const staticDir = resolve(rootDir, STATIC_DIR);
-  const docsBuildDir = resolve(rootDir, DOCS_BUILD_DIR);
+  const docsBuildDir = resolve(rootDir, buildConfig.docsOutDir);
 
   await rm(outputDir, { recursive: true, force: true });
   await mkdir(functionDir, { recursive: true });
@@ -135,11 +137,15 @@ export function createVercelOriginOutputConfig(): VercelOriginOutputConfig {
 }
 
 async function writeFunctionConfig(functionDir: string): Promise<void> {
-  await writeJson(resolve(functionDir, '.vc-config.json'), {
-    runtime: 'nodejs22.x',
+  await writeJson(resolve(functionDir, '.vc-config.json'), createVercelFunctionConfig());
+}
+
+export function createVercelFunctionConfig() {
+  return {
+    runtime: VERCEL_FUNCTION_RUNTIME,
     handler: 'index.mjs',
-    memory: 2048,
-    maxDuration: 300,
+    memory: VERCEL_FUNCTION_MEMORY_MB,
+    maxDuration: VERCEL_FUNCTION_MAX_DURATION_SECONDS,
     regions: ['iad1'],
     supportsResponseStreaming: true,
     launcherType: 'Nodejs',
@@ -150,7 +156,7 @@ async function writeFunctionConfig(functionDir: string): Promise<void> {
     // off so the request stream stays readable for the transport.
     shouldAddHelpers: false,
     shouldAddSourcemapSupport: true,
-  });
+  };
 }
 
 async function copyHostedStage(

--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -7,6 +7,10 @@ import type {
   RouteRecord,
   Snapshot,
 } from './types.js';
+import {
+  OPTIONAL_TERM_LINKS,
+  resolveOptionalTermPatternId,
+} from './optional-term-links.js';
 import { normalizeForLookup, unique } from './text.js';
 
 export interface GeneratedDocPage {
@@ -525,9 +529,15 @@ function renderHomeMarkdown(
     '',
     `Hosted **FPF Reference** MCP server + slim wiki projection of the **First Principles Framework (FPF)**. ${patternCount} pattern pages, ${routeCount} working routes, and the preface — addressable by stable FPF IDs, browsable here and queryable through MCP.`,
     '',
-    '[Start here](/start-here) · [Connect MCP](/connect-mcp) · [Open the catalog](/patterns) · [Routes](/generated/routes/index)',
+    '## Navigate',
     '',
-    `> ${provenanceDetail}`,
+    renderHomeNavigateLine(snapshot),
+    '',
+    '## Published from',
+    '',
+    provenanceDetail,
+    '',
+    'Production readiness is checked with hosted status, MCP smoke, Q&A benchmark, and Vercel bundle-size gates.',
     '',
     '## FPF Reference MCP — what this server does',
     '',
@@ -560,12 +570,34 @@ function renderHomeMarkdown(
   return `${lines.join('\n')}\n`;
 }
 
+function renderHomeNavigateLine(snapshot: Snapshot): string {
+  const links: DocsNavLink[] = [
+    { text: 'Start here', link: '/start-here' },
+    { text: 'Connect MCP', link: '/connect-mcp' },
+    { text: 'Patterns', link: '/generated/patterns/index' },
+    { text: 'Routes', link: '/generated/routes/index' },
+  ];
+
+  const orderedPatterns = sortedPatterns(snapshot);
+  for (const candidate of OPTIONAL_TERM_LINKS) {
+    const patternId = resolveOptionalTermPatternId(orderedPatterns, candidate.key);
+    const pattern = patternId ? snapshot.patternGraph.nodes[patternId] : undefined;
+    if (pattern) {
+      links.push({
+        text: candidate.label,
+        link: patternDocRef(pattern.id).staticPath,
+      });
+    }
+  }
+
+  return links.map((link) => `[${link.text}](${link.link})`).join(' · ');
+}
+
 function renderHomeProvenanceDetail(manifest?: PublicationManifestSummary): string {
   if (!manifest) {
     return 'Generated reference pages, route IDs, and source status remain discoverable in the site chrome and reference catalog.';
   }
 
-  const shortHash = manifest.sourceHash.replace(/^sha256:/, '').slice(0, 8);
   const shortRef = manifest.upstreamRef.slice(0, 8);
 
   // Prefer upstream commit metadata when present: link the date to the
@@ -575,12 +607,12 @@ function renderHomeProvenanceDetail(manifest?: PublicationManifestSummary): stri
     const upstreamDate = formatPublishedDate(manifest.upstreamCommittedAt);
     const commitUrl = `${manifest.upstreamRepoUrl}/commit/${manifest.upstreamRef}`;
     const repoLabel = manifest.upstreamRepoUrl.replace(/^https:\/\/github\.com\//, '');
-    return `Upstream FPF commit [${upstreamDate}](${commitUrl}) (\`${shortRef}\`) in [${repoLabel}](${manifest.upstreamRepoUrl}) · source ${shortHash}.`;
+    return `Upstream FPF commit [${upstreamDate}](${commitUrl}) (\`${shortRef}\`) in [${repoLabel}](${manifest.upstreamRepoUrl}) · source hash \`${manifest.sourceHash}\`.`;
   }
 
   // Fallback for older snapshots without upstream commit metadata.
   const publishedAt = formatPublishedDate(manifest.publishedAt);
-  return `Published ${publishedAt} · upstream ${shortRef} · source ${shortHash}.`;
+  return `Published ${publishedAt} · upstream ${shortRef} · source hash \`${manifest.sourceHash}\`.`;
 }
 
 function formatPublishedDate(value: string): string {

--- a/src/core/optional-term-links.ts
+++ b/src/core/optional-term-links.ts
@@ -1,0 +1,61 @@
+import { normalizeForLookup } from './text.js';
+
+export type OptionalTermLinkKey = 'glossary' | 'changeLog';
+
+export interface OptionalTermLinkDefinition {
+  key: OptionalTermLinkKey;
+  label: string;
+}
+
+export interface OptionalTermPatternCandidate {
+  id: string;
+  title?: string;
+  aliases?: string[];
+  part?: string;
+}
+
+export const OPTIONAL_TERM_LINKS: OptionalTermLinkDefinition[] = [
+  { key: 'glossary', label: 'Glossary' },
+  { key: 'changeLog', label: 'Change log' },
+];
+
+const OPTIONAL_TERM_MATCHERS: Record<
+  OptionalTermLinkKey,
+  { partIncludes: string[]; titleIncludes: string[] }
+> = {
+  glossary: {
+    partIncludes: ['glossary'],
+    titleIncludes: ['glossary'],
+  },
+  changeLog: {
+    partIncludes: ['annex'],
+    titleIncludes: ['change log', 'changelog'],
+  },
+};
+
+export function resolveOptionalTermPatternId(
+  patterns: Iterable<OptionalTermPatternCandidate>,
+  key: OptionalTermLinkKey,
+): string | undefined {
+  const matcher = OPTIONAL_TERM_MATCHERS[key];
+  return Array.from(patterns).find(
+    (pattern) =>
+      matchesAny(pattern.part, matcher.partIncludes)
+      && [pattern.title, ...(pattern.aliases ?? [])].some((label) =>
+        matchesAny(label, matcher.titleIncludes),
+      ),
+  )?.id;
+}
+
+function matchesAny(value: string | undefined, needles: string[]): boolean {
+  if (!value) return false;
+  const normalizedValue = normalizeOptionalTermLabel(value);
+  return needles.some((needle) => normalizedValue.includes(normalizeOptionalTermLabel(needle)));
+}
+
+function normalizeOptionalTermLabel(value: string): string {
+  return normalizeForLookup(value)
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/src/evaluation/fpf-work-evaluator.ts
+++ b/src/evaluation/fpf-work-evaluator.ts
@@ -8,6 +8,13 @@ import {
   PUBLISHED_MANIFEST_PATH,
   PUBLISHED_SPEC_PATH,
 } from '../core/constants.js';
+import {
+  OPTIONAL_TERM_LINKS,
+  resolveOptionalTermPatternId,
+  type OptionalTermLinkDefinition,
+  type OptionalTermLinkKey,
+  type OptionalTermPatternCandidate,
+} from '../core/optional-term-links.js';
 import type { FpfWorkEvaluationFormat, FpfWorkEvaluationTarget } from './types.js';
 
 export type FpfRubricStatus = 'pass' | 'partial' | 'missing' | 'not_applicable';
@@ -386,15 +393,15 @@ function scoreUnifiedTermSheet(
   const hasSlimNavigation =
     contains(facts, 'docsIndex', '[Patterns](/generated/patterns/index)') &&
     contains(facts, 'docsIndex', '[Routes](/generated/routes/index)');
-  const hasTermRoutes =
-    contains(facts, 'docsIndex', '[Glossary](/generated/patterns/H.1)') &&
-    contains(facts, 'docsIndex', '[Change log](/generated/patterns/I.3)');
+  const hasTermRoutes = OPTIONAL_TERM_LINKS.every((link) =>
+    containsOptionalTermLink(facts, link),
+  );
 
   if (hasSlimNavigation && hasTermRoutes) {
     return rubricPass(
       'term-sheet',
       anchor,
-      'The slim wiki landing page exposes routes, patterns, glossary, and change log entry points.',
+      'The slim wiki landing page exposes routes, patterns, and available glossary/change-log entry points.',
       'Keep terminology links short and plain-language oriented as generated docs grow.',
       evidenceIds,
     );
@@ -766,6 +773,76 @@ function readAnchorPresence(specText: string): Record<FpfAnchorId, boolean> {
 
 function contains(facts: FpfWorkFacts, file: KnownWorkFile, needle: string): boolean {
   return facts.fileTexts[file]?.includes(needle) ?? false;
+}
+
+interface EvaluationSnapshotPattern {
+  id?: unknown;
+  title?: unknown;
+  aliases?: unknown;
+  part?: unknown;
+}
+
+interface EvaluationSnapshot {
+  patternGraph?: {
+    nodes?: Record<string, EvaluationSnapshotPattern>;
+  };
+}
+
+function containsOptionalTermLink(
+  facts: FpfWorkFacts,
+  link: OptionalTermLinkDefinition,
+): boolean {
+  const targetPath = resolveOptionalTermPatternPath(facts, link.key);
+  if (targetPath === undefined) return false;
+  if (targetPath === null) {
+    return !containsGeneratedPatternLinkLabel(facts, 'docsIndex', link.label);
+  }
+  return contains(facts, 'docsIndex', `[${link.label}](${targetPath})`);
+}
+
+function containsGeneratedPatternLinkLabel(
+  facts: FpfWorkFacts,
+  file: KnownWorkFile,
+  label: string,
+): boolean {
+  const text = facts.fileTexts[file];
+  if (!text) return false;
+  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  return new RegExp(`\\[${escapedLabel}\\]\\(/generated/patterns/[^)]+\\)`, 'u').test(text);
+}
+
+function resolveOptionalTermPatternPath(
+  facts: FpfWorkFacts,
+  key: OptionalTermLinkKey,
+): string | null | undefined {
+  const snapshot = parseEvaluationSnapshot(facts);
+  const nodes = snapshot?.patternGraph?.nodes;
+  if (!nodes) return undefined;
+
+  const patterns: OptionalTermPatternCandidate[] = Object.entries(nodes).map(([nodeId, pattern]) => {
+    const id = typeof pattern.id === 'string' ? pattern.id : nodeId;
+    return {
+      id,
+      title: typeof pattern.title === 'string' ? pattern.title : undefined,
+      aliases: Array.isArray(pattern.aliases)
+        ? pattern.aliases.filter((alias): alias is string => typeof alias === 'string')
+        : undefined,
+      part: typeof pattern.part === 'string' ? pattern.part : undefined,
+    };
+  });
+  const patternId = resolveOptionalTermPatternId(patterns, key);
+
+  return patternId ? `/generated/patterns/${patternId}` : null;
+}
+
+function parseEvaluationSnapshot(facts: FpfWorkFacts): EvaluationSnapshot | undefined {
+  const snapshotText = facts.fileTexts.publishedSnapshot;
+  if (!snapshotText) return undefined;
+  try {
+    return JSON.parse(snapshotText) as EvaluationSnapshot;
+  } catch {
+    return undefined;
+  }
 }
 
 function isDefined<T>(value: T | undefined): value is T {

--- a/src/runtime/lm-studio-synthesizer.ts
+++ b/src/runtime/lm-studio-synthesizer.ts
@@ -7,6 +7,11 @@ import {
   parseObservabilityConfig,
 } from '../adapters/infra/config/env.js';
 import type { ObservabilityConfig } from '../adapters/infra/config/types.js';
+import {
+  DEFAULT_LM_STUDIO_BASE_URL,
+  DEFAULT_LM_STUDIO_MODEL,
+  DEFAULT_LM_STUDIO_TIMEOUT_MS,
+} from '../adapters/infra/config/lm-studio-defaults.js';
 import type {
   AnswerSlice,
   AnswerSynthesizerInput,
@@ -16,6 +21,12 @@ import type {
   LocalAnswerSynthesizerInfo,
 } from './types.js';
 import { createAiTraceRecorderFromPath } from './ai-trace-log.js';
+
+export {
+  DEFAULT_LM_STUDIO_BASE_URL,
+  DEFAULT_LM_STUDIO_MODEL,
+  DEFAULT_LM_STUDIO_TIMEOUT_MS,
+} from '../adapters/infra/config/lm-studio-defaults.js';
 
 export type FetchLike = (
   input: URL | RequestInfo,
@@ -66,10 +77,6 @@ export interface LmStudioHealthCheckResult {
     error?: string;
   };
 }
-
-export const DEFAULT_LM_STUDIO_BASE_URL = 'http://localhost:1234/v1';
-export const DEFAULT_LM_STUDIO_MODEL = 'google/gemma-4-31b';
-export const DEFAULT_LM_STUDIO_TIMEOUT_MS = 20_000;
 
 interface AnthropicMessagesPayload {
   content?: Array<{

--- a/tests/config-contexts.test.ts
+++ b/tests/config-contexts.test.ts
@@ -87,7 +87,7 @@ describe('context config parsing', () => {
       runtimeArtifactDir: '/tmp/fpf/.runtime/fpf-index',
       distDir: '/tmp/fpf/dist',
       hostedPublicDir: '/tmp/fpf/public',
-      docsRoot: '/tmp/fpf/docs',
+      docsOutDir: '/tmp/fpf/doc_build',
     });
   });
 

--- a/tests/deploy-staging.test.ts
+++ b/tests/deploy-staging.test.ts
@@ -78,7 +78,7 @@ describe('stageFromPublished', () => {
         runtimeArtifactDir: publishedArtifactDir,
         distDir: resolve(tempRoot, 'dist'),
         hostedPublicDir,
-        docsRoot: resolve(tempRoot, 'docs'),
+        docsOutDir: resolve(tempRoot, 'doc_build'),
       },
       {
         publishedSpecPath,
@@ -176,7 +176,7 @@ describe('stageFromPublished', () => {
           runtimeArtifactDir: publishedArtifactDir,
           distDir: resolve(tempRoot, 'dist'),
           hostedPublicDir,
-          docsRoot: resolve(tempRoot, 'docs'),
+          docsOutDir: resolve(tempRoot, 'doc_build'),
         },
         {
           publishedSpecPath,
@@ -197,7 +197,7 @@ describe('stageFromPublished', () => {
           runtimeArtifactDir: publishedArtifactDir,
           distDir: resolve(tempRoot, 'dist'),
           hostedPublicDir,
-          docsRoot: resolve(tempRoot, 'docs'),
+          docsOutDir: resolve(tempRoot, 'doc_build'),
         },
         {
           publishedSpecPath,
@@ -218,7 +218,7 @@ describe('stageFromPublished', () => {
           runtimeArtifactDir: publishedArtifactDir,
           distDir: resolve(tempRoot, 'dist'),
           hostedPublicDir,
-          docsRoot: resolve(tempRoot, 'docs'),
+          docsOutDir: resolve(tempRoot, 'doc_build'),
         },
         {
           publishedSpecPath,
@@ -253,7 +253,7 @@ describe('stageFromPublished', () => {
           runtimeArtifactDir: publishedArtifactDir,
           distDir: resolve(tempRoot, 'dist'),
           hostedPublicDir,
-          docsRoot: resolve(tempRoot, 'docs'),
+          docsOutDir: resolve(tempRoot, 'doc_build'),
         },
         {
           publishedSpecPath,

--- a/tests/docs-projection.test.ts
+++ b/tests/docs-projection.test.ts
@@ -14,6 +14,7 @@ import {
   buildDocsProjection,
   resolveDocTarget,
 } from '../src/core/documents.js';
+import { normalizeForLookup } from '../src/core/text.js';
 import { compileFpfSource } from '../src/runtime/compiler.js';
 import type { Snapshot } from '../src/runtime/types.js';
 
@@ -39,6 +40,25 @@ function routeGeneratedMarkdownPath(routeId: string) {
 function routeGeneratedHtmlPath(routeId: string) {
   const slug = routeId.replace(/^route:/, '');
   return `generated/routes/route_${slug}.html`;
+}
+
+function findPatternByTitleFragment(snapshot: Snapshot, fragment: string) {
+  const normalizedFragment = normalizeHomeNavTitle(fragment);
+  const pattern = Object.values(snapshot.patternGraph.nodes).find((candidate) => {
+    const labels = [candidate.title, ...candidate.aliases].map(normalizeHomeNavTitle);
+    return labels.some((label) => label.includes(normalizedFragment));
+  });
+  if (!pattern) {
+    throw new Error(`Expected a pattern title or alias containing ${fragment}`);
+  }
+  return pattern;
+}
+
+function normalizeHomeNavTitle(value: string): string {
+  return normalizeForLookup(value)
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 async function copyNonGeneratedDocs(srcRoot: string, dstRoot: string) {
@@ -449,10 +469,10 @@ describe('docs projection', () => {
       expect(
         await readFile(resolve(docsRoot, 'generated/patterns/index.md'), 'utf8'),
       ).toContain('# Pattern Catalog');
-      // The site root `/` is now a plain chapter list: a slim header (title,
-      // intro line, three CTAs, provenance line) followed by the same
-      // Part-by-Part chapter listing as `/patterns`. Same information, no
-      // curation — visitors scan one list and click straight through.
+      // The site root `/` is now a plain chapter list: a slim header,
+      // navigation/provenance sections, and the same Part-by-Part chapter
+      // listing as `/patterns`. Same information, no curation — visitors
+      // scan one list and click straight through.
       const rootIndex = await readFile(resolve(docsRoot, 'index.md'), 'utf8');
       expect(rootIndex).toContain('title: "FPF Reference"');
       expect(rootIndex).not.toContain('pageType: home');
@@ -466,10 +486,26 @@ describe('docs projection', () => {
       expect(rootIndex).toContain('Anatoly Levenchuk');
       expect(rootIndex).toContain('https://github.com/ailev/FPF');
       expect(rootIndex).toContain('Cite this spec');
+      expect(rootIndex).toContain('## Navigate');
       expect(rootIndex).toContain('[Start here](/start-here)');
       expect(rootIndex).toContain('[Connect MCP](/connect-mcp)');
-      expect(rootIndex).toContain('[Open the catalog](/patterns)');
+      expect(rootIndex).toContain('[Patterns](/generated/patterns/index)');
       expect(rootIndex).toContain('[Routes](/generated/routes/index)');
+      const glossaryTarget = resolveDocTarget(
+        snapshot,
+        findPatternByTitleFragment(snapshot, 'alphabetic glossary').id,
+      );
+      const changeLogTarget = resolveDocTarget(
+        snapshot,
+        findPatternByTitleFragment(snapshot, 'change log').id,
+      );
+      expect(glossaryTarget).toBeDefined();
+      expect(changeLogTarget).toBeDefined();
+      expect(rootIndex).toContain(`[Glossary](${glossaryTarget?.docRef.staticPath})`);
+      expect(rootIndex).toContain(`[Change log](${changeLogTarget?.docRef.staticPath})`);
+      expect(rootIndex).toContain('## Published from');
+      expect(rootIndex).toContain('source hash `sha256:');
+      expect(rootIndex).toContain('Production readiness is checked with hosted status');
       // Chapter list — at least Part A through the last canonical Part should
       // be present as ## headings.
       expect(rootIndex).toMatch(/^## Part A\b/m);
@@ -495,6 +531,32 @@ describe('docs projection', () => {
       await rm(tempRoot, { recursive: true, force: true });
     }
   }, 20_000);
+
+  it('omits optional home navigation links when the selected spec lacks those IDs', () => {
+    const optionalHomePatternIds = new Set([
+      findPatternByTitleFragment(snapshot, 'alphabetic glossary').id,
+      findPatternByTitleFragment(snapshot, 'change log').id,
+    ]);
+    const alternateSnapshot: Snapshot = {
+      ...snapshot,
+      patternGraph: {
+        ...snapshot.patternGraph,
+        nodes: Object.fromEntries(
+          Object.entries(snapshot.patternGraph.nodes).filter(
+            ([id]) => !optionalHomePatternIds.has(id),
+          ),
+        ),
+      },
+    };
+
+    const rootIndex =
+      buildDocsProjection(alternateSnapshot).pagesByMarkdownPath['docs/index.md']?.markdown ?? '';
+
+    expect(rootIndex).toContain('[Start here](/start-here)');
+    expect(rootIndex).toContain('[Patterns](/generated/patterns/index)');
+    expect(rootIndex).not.toContain('[Glossary](/generated/patterns/');
+    expect(rootIndex).not.toContain('[Change log](/generated/patterns/');
+  });
 
   it('builds rspress output into a disposable outDir', async () => {
     // Rspress's `pageType: home` layout detection requires the docsRoot to
@@ -535,13 +597,15 @@ describe('docs projection', () => {
       );
 
       // `/` now renders as a plain chapter list. The headline title, the
-      // three CTAs, and at least one Part heading should be present in the
-      // built HTML.
+      // navigation/provenance links, and at least one Part heading should be
+      // present in the built HTML.
       const indexHtml = await readFile(resolve(outDir, 'index.html'), 'utf8');
       expect(indexHtml).toContain('FPF Reference');
       expect(indexHtml).toContain('Start here');
       expect(indexHtml).toContain('Connect MCP');
-      expect(indexHtml).toContain('Open the catalog');
+      expect(indexHtml).toContain('Patterns');
+      expect(indexHtml).toContain('Glossary');
+      expect(indexHtml).toContain('Published from');
       expect(indexHtml).toContain('Part A');
 
       // `/patterns` is the short-URL Pattern Catalog. Verify it lists Part A

--- a/tests/fpf-work-evaluator.test.ts
+++ b/tests/fpf-work-evaluator.test.ts
@@ -79,6 +79,74 @@ describe('FPF work evaluator', () => {
     expect(report.overallStatus).toBe('needs_work');
   });
 
+  it('requires optional term links to point at the matching generated pages when present', () => {
+    const facts = makeFacts({
+      fileTexts: {
+        ...defaultFileTexts(),
+        docsIndex: [
+          '# FPF Reference',
+          '## Navigate',
+          '[Patterns](/generated/patterns/index)',
+          '[Routes](/generated/routes/index)',
+          '[Glossary](/generated/patterns/A.0)',
+          '[Change log](/generated/patterns/renumbered-change-log)',
+          '## Published from',
+        ].join('\n'),
+      },
+    });
+
+    const report = evaluateFpfWorkFacts(facts);
+    const termSheet = report.scorecard.find((item) => item.id === 'term-sheet');
+
+    expect(termSheet?.status).toBe('partial');
+    expect(report.overallStatus).toBe('usable_with_followups');
+  });
+
+  it('does not require optional term links when matching pages are absent from the snapshot', () => {
+    const facts = makeFacts({
+      fileTexts: {
+        ...defaultFileTexts(),
+        docsIndex: [
+          '# FPF Reference',
+          '## Navigate',
+          '[Patterns](/generated/patterns/index)',
+          '[Routes](/generated/routes/index)',
+          '## Published from',
+        ].join('\n'),
+        publishedSnapshot: '{"sourceHash":"sha256:test","patternGraph":{"nodes":{}}}',
+      },
+    });
+
+    const report = evaluateFpfWorkFacts(facts);
+    const termSheet = report.scorecard.find((item) => item.id === 'term-sheet');
+
+    expect(termSheet?.status).toBe('pass');
+    expect(report.overallStatus).toBe('aligned');
+  });
+
+  it('rejects stale optional term links when matching pages are absent from the snapshot', () => {
+    const facts = makeFacts({
+      fileTexts: {
+        ...defaultFileTexts(),
+        docsIndex: [
+          '# FPF Reference',
+          '## Navigate',
+          '[Patterns](/generated/patterns/index)',
+          '[Routes](/generated/routes/index)',
+          '[Glossary](/generated/patterns/stale-glossary)',
+          '## Published from',
+        ].join('\n'),
+        publishedSnapshot: '{"sourceHash":"sha256:test","patternGraph":{"nodes":{}}}',
+      },
+    });
+
+    const report = evaluateFpfWorkFacts(facts);
+    const termSheet = report.scorecard.find((item) => item.id === 'term-sheet');
+
+    expect(termSheet?.status).toBe('partial');
+    expect(report.overallStatus).toBe('usable_with_followups');
+  });
+
   it('fails clearly when the evaluation spec is missing', () => {
     tempRoot = mkdtempSync(resolve(tmpdir(), 'fpf-work-evaluator-'));
 
@@ -167,8 +235,8 @@ function defaultFileTexts(): FpfWorkFacts['fileTexts'] {
       '## Navigate',
       '[Patterns](/generated/patterns/index)',
       '[Routes](/generated/routes/index)',
-      '[Glossary](/generated/patterns/H.1)',
-      '[Change log](/generated/patterns/I.3)',
+      '[Glossary](/generated/patterns/renumbered-glossary)',
+      '[Change log](/generated/patterns/renumbered-change-log)',
       '## Published from',
     ].join('\n'),
     ciWorkflow: [
@@ -193,7 +261,25 @@ function defaultFileTexts(): FpfWorkFacts['fileTexts'] {
       '"deploy": "bun run vercel:origin:deploy:prod"',
     ].join(',\n'),
     publishedSpec: '# FPF',
-    publishedSnapshot: '{"sourceHash":"sha256:test"}',
+    publishedSnapshot: JSON.stringify({
+      sourceHash: 'sha256:test',
+      patternGraph: {
+        nodes: {
+          'renumbered-glossary': {
+            id: 'renumbered-glossary',
+            title: 'Alphabetic Glossary',
+            aliases: ['Alphabetic Glossary'],
+            part: 'Part H - Glossary & Definitional Pattern Index',
+          },
+          'renumbered-change-log': {
+            id: 'renumbered-change-log',
+            title: 'Change-Log (auto-generated)',
+            aliases: ['Change-Log (auto-generated)'],
+            part: 'Part I - Annexes & Extended Tutorials',
+          },
+        },
+      },
+    }),
     publishedManifest:
       '{"sourceHash":"sha256:test","upstreamRef":"abc","publishedAt":"2026-04-30T00:00:00.000Z","compilerFingerprint":"sha256:test"}',
   };

--- a/tests/hosted-mcp-bench.test.ts
+++ b/tests/hosted-mcp-bench.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from '@rstest/core';
 import {
   buildOperationPlan,
   formatMarkdownSummary,
+  McpHttpClient,
   parseBenchArgs,
   readJsonRpcResponse,
   summarizeDurations,
@@ -156,6 +157,40 @@ describe('hosted MCP benchmark harness', () => {
       id: 2,
       result: { ok: true },
     });
+  });
+
+  it('rejects malformed tool descriptors instead of hiding them from smoke checks', async () => {
+    const originalFetch = globalThis.fetch;
+    const mockedFetch = (async () =>
+      new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            tools: [
+              { name: 'browse_fpf_catalog' },
+              { name: 123 },
+            ],
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      )) as unknown as typeof fetch;
+    mockedFetch.preconnect = originalFetch.preconnect;
+    globalThis.fetch = mockedFetch;
+
+    try {
+      const client = new McpHttpClient(
+        'https://example.test/api/mcp/fpf_memory/mcp',
+        1_000,
+      );
+
+      await expect(client.listTools()).rejects.toThrow('tool 1 name was not a string');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it('preserves HTTP status context for non-JSON error bodies', () => {

--- a/tests/mcp-qa-bench.test.ts
+++ b/tests/mcp-qa-bench.test.ts
@@ -176,6 +176,110 @@ describe('MCP Q&A benchmark harness', () => {
     expect(result.ok).toBe(true);
   });
 
+  it('accepts low-confidence unsupported abstentions for low-signal cases', async () => {
+    const fakeClient = {
+      async callTool() {
+        return {
+          result: {},
+          httpStatus: 200,
+          contentType: 'application/json',
+          bodyBytes: 2,
+          structuredContent: {
+            status: 'unsupported',
+            confidence: 0.2,
+            ids: [],
+            candidateIds: ['C.26'],
+            gaps: ['Re-ask with the work context and desired output.'],
+          },
+        };
+      },
+    };
+
+    const result = await runQaCase(
+      fakeClient as never,
+      {
+        id: 'low_signal_abstain',
+        question: 'banana wallpaper coffee quantum spoon',
+        mode: 'compact',
+        allowedStatuses: ['not_found', 'ambiguous', 'degraded', 'unsupported'],
+        maxConfidence: 0.3,
+      },
+      new Set(['C.26']),
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('flags overconfident low-signal abstentions', async () => {
+    const fakeClient = {
+      async callTool() {
+        return {
+          result: {},
+          httpStatus: 200,
+          contentType: 'application/json',
+          bodyBytes: 2,
+          structuredContent: {
+            status: 'unsupported',
+            confidence: 0.6,
+            ids: [],
+            candidateIds: ['C.26'],
+            gaps: ['Re-ask with the work context and desired output.'],
+          },
+        };
+      },
+    };
+
+    const result = await runQaCase(
+      fakeClient as never,
+      {
+        id: 'low_signal_abstain',
+        question: 'banana wallpaper coffee quantum spoon',
+        mode: 'compact',
+        allowedStatuses: ['not_found', 'ambiguous', 'degraded', 'unsupported'],
+        maxConfidence: 0.3,
+      },
+      new Set(['C.26']),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('confidence 0.6 exceeded 0.3');
+  });
+
+  it('requires numeric confidence for low-signal max-confidence gates', async () => {
+    const fakeClient = {
+      async callTool() {
+        return {
+          result: {},
+          httpStatus: 200,
+          contentType: 'application/json',
+          bodyBytes: 2,
+          structuredContent: {
+            status: 'unsupported',
+            confidence: null,
+            ids: [],
+            candidateIds: ['C.26'],
+            gaps: ['Re-ask with the work context and desired output.'],
+          },
+        };
+      },
+    };
+
+    const result = await runQaCase(
+      fakeClient as never,
+      {
+        id: 'low_signal_abstain',
+        question: 'banana wallpaper coffee quantum spoon',
+        mode: 'compact',
+        allowedStatuses: ['not_found', 'ambiguous', 'degraded', 'unsupported'],
+        maxConfidence: 0.3,
+      },
+      new Set(['C.26']),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('confidence was <missing> instead of a number');
+  });
+
   it('requires degraded answers to null confidence', async () => {
     const fakeClient = {
       async callTool() {

--- a/tests/optional-term-links.test.ts
+++ b/tests/optional-term-links.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from '@rstest/core';
+
+import { resolveOptionalTermPatternId } from '../src/core/optional-term-links.js';
+
+describe('optional term links', () => {
+  it('resolves the glossary from the glossary part instead of any glossary title', () => {
+    const patterns = [
+      {
+        id: 'A.0',
+        title: 'Onboarding Glossary',
+        aliases: ['Onboarding Glossary'],
+        part: 'Part A - Kernel Architecture Cluster',
+      },
+      {
+        id: 'H.renumbered',
+        title: 'Glossary',
+        aliases: ['Glossary'],
+        part: 'Part H - Glossary & Definitional Pattern Index',
+      },
+    ];
+
+    expect(resolveOptionalTermPatternId(patterns, 'glossary')).toBe('H.renumbered');
+  });
+
+  it('resolves a retitled changelog from the annex part', () => {
+    const patterns = [
+      {
+        id: 'A.3.3',
+        title: 'U.Dynamics: The Law of Change',
+        aliases: ['U.Dynamics: The Law of Change'],
+        part: 'Part A - Kernel Architecture Cluster',
+      },
+      {
+        id: 'I.renumbered',
+        title: 'Changelog',
+        aliases: ['Changelog'],
+        part: 'Part I - Annexes & Extended Tutorials',
+      },
+    ];
+
+    expect(resolveOptionalTermPatternId(patterns, 'changeLog')).toBe('I.renumbered');
+  });
+});

--- a/tests/vercel-origin-config.test.ts
+++ b/tests/vercel-origin-config.test.ts
@@ -4,7 +4,10 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from '@rstest/core';
 
 import { HOSTED_FPF_STATUS_ROUTE } from '../src/adapters/hosted/status-page.js';
-import { createVercelOriginOutputConfig } from '../src/build/vercel-origin-build.js';
+import {
+  createVercelFunctionConfig,
+  createVercelOriginOutputConfig,
+} from '../src/build/vercel-origin-build.js';
 import {
   HOSTED_MCP_ROUTE,
   LEGACY_HOSTED_MCP_ROUTE,
@@ -12,6 +15,8 @@ import {
 
 interface VercelConfig {
   buildCommand?: string | null;
+  framework?: string | null;
+  installCommand?: string | null;
 }
 
 describe('Vercel MCP origin config', () => {
@@ -20,6 +25,8 @@ describe('Vercel MCP origin config', () => {
       await readFile(resolve(process.cwd(), 'vercel.json'), 'utf8'),
     ) as VercelConfig;
 
+    expect(config.framework).toBeNull();
+    expect(config.installCommand).toBe('bun install --frozen-lockfile');
     expect(config.buildCommand).toBe('bun run vercel:origin:build');
   });
 
@@ -39,6 +46,40 @@ describe('Vercel MCP origin config', () => {
     expect(
       Object.keys(packageJson.scripts).some((script) => script.startsWith(retiredScriptPrefix)),
     ).toBe(false);
+  });
+
+  it('keeps the package Node floor separate from the generated Vercel function runtime', async () => {
+    const packageJson = JSON.parse(
+      await readFile(resolve(process.cwd(), 'package.json'), 'utf8'),
+    ) as { engines: Record<string, string> };
+    const functionConfig = createVercelFunctionConfig();
+
+    expect(packageJson.engines.node).toBe('>=22.13.0');
+    expect(functionConfig.runtime).toBe('nodejs24.x');
+  });
+
+  it('caps the origin function duration while keeping the current memory allocation explicit', () => {
+    const functionConfig = createVercelFunctionConfig();
+
+    expect(functionConfig.memory).toBe(2048);
+    expect(functionConfig.maxDuration).toBe(300);
+  });
+
+  it('documents canonical Vercel aliases and historical preview-error policy', async () => {
+    const readme = await readFile(resolve(process.cwd(), 'README.md'), 'utf8');
+    const codexConfig = await readFile(resolve(process.cwd(), '.codex/config.toml'), 'utf8');
+
+    expect(readme).toContain('https://fpf.sh/');
+    expect(readme).toContain('https://mcp.fpf.sh/api/mcp/fpf_reference/mcp');
+    expect(readme).toContain('https://mcp.fpf.sh/api/mcp/fpf_memory/mcp');
+    expect(readme).toContain(
+      '`fpf-memory-mcp-vercel-origin.vercel.app` is a legacy compatibility alias only',
+    );
+    expect(readme).toContain('Historical errored preview deployments can remain in Vercel');
+    expect(codexConfig).toContain(
+      'url = "https://mcp.fpf.sh/api/mcp/fpf_reference/mcp"',
+    );
+    expect(codexConfig).not.toContain('fpf-memory-mcp-vercel-origin.vercel.app');
   });
 
   it('routes the hosted freshness status endpoint through the Vercel origin function', () => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "bun install --frozen-lockfile",
   "buildCommand": "bun run vercel:origin:build"
 }


### PR DESCRIPTION
## What

Aligns the Vercel-origin release path with the canonical `fpf_reference` hosted MCP endpoint, keeps the legacy `fpf_memory` endpoint as compatibility, and makes deploy readiness depend on explicit smoke, Q&A, benchmark, and bundle-size gates.

## Why

The Vercel origin and docs surface should describe the current production aliases and validate the actual hosted MCP endpoint, without treating historical preview deployment errors as production readiness failures.

## Type

- `fix` — bug fix

## Changes

- Refactors hosted MCP smoke/bench scripts to share the HTTP client, output-format parsing, and public-tool expectations.
- Moves LM Studio defaults into a shared infra config module.
- Renames build config output path wiring to `docsOutDir` and exposes Vercel function runtime/memory/duration config for tests.
- Updates docs/homepage provenance and optional glossary/change-log navigation resolution across generated docs and evaluator checks.
- Sets Vercel install/framework config and keeps canonical `fpf_reference` docs while preserving the legacy endpoint.

## Validation

- `bun run lint` passes locally: 0 lint errors, 0 type errors, 0 warnings across 151 files.
- `bun run check` passes locally.
- `bun run test` passes locally: 44 files, 364 tests, 0 failures.
- No new warnings introduced in lint output.
- `bun run build` succeeds: runtime and MCP bundles built.
- `bun run vercel:origin:build` succeeds: docs generated 982 files; Vercel function bundle 99.97 MB with 140.03 MB fail-threshold headroom.
- `bun run validate:published` succeeds: source hash `sha256:73c08fb554cc5920f4bf5497e0d356ab6d3bcd5bdb605f8dcc2f82587565005e`, upstream ref `2e112078bb209e5e3a511c3bd1aa6b1b2e299efe`, spec bytes 7999874.
- `bun run cli -- evaluate-work --target working-tree --format json` reports `overallStatus: aligned` with no findings.
- `FPF_MCP_SMOKE_URL=https://mcp.fpf.sh/api/mcp/fpf_reference/mcp bun run smoke:mcp:http` succeeds: initialized, 6 public tools, fresh index, project-alignment query `ok`, SSE GET 200.
- `bun run bench:mcp:qa -- --name vercel-origin --url https://mcp.fpf.sh/api/mcp/fpf_reference/mcp --format markdown` succeeds: 8/0 cases, known IDs 786.
- `bun run bench:mcp -- --name vercel-origin --url https://mcp.fpf.sh/api/mcp/fpf_reference/mcp --format markdown` succeeds: 60/0 operations, SSE GET 200, fresh source hash.
- `/Users/stas-studio/.codex/skills/autoreview/scripts/autoreview --mode branch --base origin/main --model codex=gpt-5.3-codex` reports clean: no accepted/actionable findings.
- End-to-end verification command + output excerpt: `bun run vercel:origin:build` -> `PASS: bundle is within the configured budget.`
- Caveats or blocker: local worktree still has unrelated untracked `.agents/ralph/**` files intentionally left out of this PR.

## TPR fast-track

- [ ] Enable TPR review/merge timer

Use this only for small, reversible PRs from trusted maintainers or collaborators. The timer does not fake approval or bypass branch protection:

- after 1 hour without a non-author review signal, automation comments `@codex review`;
- after 2 hours, automation enables auto-merge only when checks pass, no trusted reviewer requested changes, and at least one trusted non-author approval exists for the current head commit.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | 019e7a41-bc25-7831-a050-f8dc0d69536e |
| Prompt  | Create PR, checks, merge, publish, validate with autoreview |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production Vercel function runtime (nodejs24.x), hosted MCP smoke/QA contracts, and public docs URLs; changes are mostly validation and documentation but affect deploy and client expectations.
> 
> **Overview**
> This PR aligns **Vercel-origin production readiness** with the canonical **`fpf_reference`** hosted MCP surface while keeping **`fpf_memory`** as a documented legacy path.
> 
> **Hosted MCP validation** is consolidated: smoke, benchmark, and Q&A scripts share **`McpHttpClient`**, **`EXPECTED_PUBLIC_TOOLS`**, and **`readOutputFormat`**. Initialize checks expect server name **`fpf_reference`**, and **`tools/list`** now fails fast on malformed tool names. Q&A adds **`maxConfidence`** gates for low-signal **`unsupported`** abstentions.
> 
> **Deploy/build wiring** moves LM Studio defaults into **`lm-studio-defaults.ts`**, renames build output config to **`docsOutDir`**, and pins the Vercel function to **`nodejs24.x`** with exported runtime/memory/duration helpers. **`vercel.json`** sets **`framework: null`** and a frozen **`bun install`**.
> 
> **Docs and evaluation** refresh the home page (**Navigate**, full **source hash**, readiness gates) and resolve **Glossary** / **Change log** links from the snapshot via **`optional-term-links`** instead of hardcoded pattern IDs; the work evaluator follows the same rules.
> 
> **README** documents canonical **`fpf.sh`** / **`mcp.fpf.sh/.../fpf_reference`** URLs and clarifies that old preview errors are not production-readiness failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c69f1504966d56a58ee8c26dadcbc6fb8369f7c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->