### PR TITLE
fix(deploy): reduce Vercel function guardrails

### DIFF
--- a/src/build/vercel-origin-build.ts
+++ b/src/build/vercel-origin-build.ts
@@ -32,8 +32,8 @@ const FUNCTION_NAME = '_origin';
 const FUNCTION_DIR = `${OUTPUT_DIR}/functions/${FUNCTION_NAME}.func`;
 const FUNCTION_DEST = `/${FUNCTION_NAME}`;
 export const VERCEL_FUNCTION_RUNTIME = 'nodejs24.x';
-export const VERCEL_FUNCTION_MEMORY_MB = 2048;
-export const VERCEL_FUNCTION_MAX_DURATION_SECONDS = 300;
+export const VERCEL_FUNCTION_MEMORY_MB = 1024;
+export const VERCEL_FUNCTION_MAX_DURATION_SECONDS = 60;
 const STATIC_DIR = `${OUTPUT_DIR}/static`;
 
 export type VercelOriginRoute =

--- a/src/mcp/tool-contracts.ts
+++ b/src/mcp/tool-contracts.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 // Public, unauthenticated MCP tools accept user-supplied strings; without
-// caps a single 4 MB payload can drive the runtime into Vercel's 5-minute
+// caps a single 4 MB payload can drive the runtime into Vercel's
 // `maxDuration` ceiling. These limits are generous for legitimate use
 // (a 2000-character question is far longer than anything a person types)
 // and refuse pathological input at the schema boundary.

--- a/tests/e2e/mcp.spec.ts
+++ b/tests/e2e/mcp.spec.ts
@@ -129,7 +129,7 @@ test('MCP rejects oversized question payloads at the schema boundary', async ({
 }) => {
   // PR #98 added a 2000-char cap on the question field. A 2500-char payload
   // must produce a structured validation error in milliseconds, not silently
-  // drive the function to its 300s maxDuration.
+  // drive the function to its maxDuration ceiling.
   const huge = 'x'.repeat(2500);
   const response = await request.post(MCP_PATH, {
     headers: MCP_HEADERS,

--- a/tests/vercel-origin-config.test.ts
+++ b/tests/vercel-origin-config.test.ts
@@ -58,11 +58,11 @@ describe('Vercel MCP origin config', () => {
     expect(functionConfig.runtime).toBe('nodejs24.x');
   });
 
-  it('caps the origin function duration while keeping the current memory allocation explicit', () => {
+  it('keeps the origin function on cost guardrails for memory and duration', () => {
     const functionConfig = createVercelFunctionConfig();
 
-    expect(functionConfig.memory).toBe(2048);
-    expect(functionConfig.maxDuration).toBe(300);
+    expect(functionConfig.memory).toBe(1024);
+    expect(functionConfig.maxDuration).toBe(60);
   });
 
   it('documents canonical Vercel aliases and historical preview-error policy', async () => {


### PR DESCRIPTION
## Summary
- lower the generated Vercel origin function memory from 2048 MB to 1024 MB
- lower maxDuration from 300 s to 60 s to cap runaway Fluid Compute exposure
- update tests/comments that pin or describe the deployment guardrails

## Verification
- bun run test tests/vercel-origin-config.test.ts
- bun run lint
- bun run check
- bun run cli -- evaluate-work --target working-tree --format json
- bun run vercel:origin:build
- subagent review: no blockers; stale comments found and fixed

## Cost note
This PR will trigger normal GitHub/Vercel preview automation. I did not run manual Vercel deploys or live production benchmarks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shorter timeouts and less memory can fail or OOM edge-case MCP workloads that previously relied on 5-minute runs or 2 GB; legitimate traffic is still bounded by existing input caps.
> 
> **Overview**
> Tightens **Vercel origin function** cost and runaway limits in `vercel-origin-build.ts`: generated `.vc-config.json` **memory** drops from **2048 MB → 1024 MB** and **maxDuration** from **300 s → 60 s** (Fluid Compute exposure cap).
> 
> Tests and comments that pinned or named the old **300 s** ceiling are updated to the new guardrails—`vercel-origin-config.test.ts` expectations, MCP e2e wording, and `tool-contracts.ts` (still ties oversized payloads to `maxDuration`, without a fixed second count).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0181d77668fc045bc303336658e96108b77e620. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->