### PR TITLE
[codex] reject hosted MCP GET timeout streams

### DIFF
--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -24,6 +24,10 @@ export class FpfMcpServer {
   }
 
   async handleStreamableHttp(request: Request): Promise<Response> {
+    if (isStandaloneMcpGet(request.method)) {
+      return createMcpGetDisabledResponse();
+    }
+
     const transport = new WebStandardStreamableHTTPServerTransport({
       enableJsonResponse: true,
     });
@@ -38,6 +42,11 @@ export class FpfMcpServer {
     request: IncomingMessage,
     response: ServerResponse,
   ): Promise<void> {
+    if (isStandaloneMcpGet(request.method)) {
+      writeMcpGetDisabledNodeResponse(response);
+      return;
+    }
+
     const transport = new StreamableHTTPServerTransport({
       enableJsonResponse: true,
     });
@@ -65,6 +74,25 @@ export class FpfMcpServer {
   }
 }
 
+export function isStandaloneMcpGet(method: string | undefined): boolean {
+  return method?.toUpperCase() === 'GET';
+}
+
+export function createMcpGetDisabledResponse(): Response {
+  return new Response(JSON.stringify(createMcpGetDisabledPayload()), {
+    status: 405,
+    headers: mcpGetDisabledHeaders(),
+  });
+}
+
+export function writeMcpGetDisabledNodeResponse(response: ServerResponse): void {
+  response.statusCode = 405;
+  for (const [key, value] of Object.entries(mcpGetDisabledHeaders())) {
+    response.setHeader(key, value);
+  }
+  response.end(JSON.stringify(createMcpGetDisabledPayload()));
+}
+
 export function createMcpServerSet(
   tools: ReturnType<typeof createMcpTools>,
 ) {
@@ -89,6 +117,26 @@ export function createMcpServerSet(
     fpfReference,
     fpfReferencePublic,
   };
+}
+
+function mcpGetDisabledHeaders(): Record<string, string> {
+  return {
+    Allow: 'POST, DELETE',
+    'Cache-Control': 'no-store',
+    'Content-Type': 'application/json; charset=utf-8',
+  };
+}
+
+function createMcpGetDisabledPayload() {
+  return {
+    jsonrpc: '2.0',
+    error: {
+      code: -32000,
+      message:
+        'Standalone MCP SSE GET is disabled on this endpoint; use POST Streamable HTTP JSON-RPC requests.',
+    },
+    id: null,
+  } as const;
 }
 
 const FPF_REFERENCE_SERVER_INSTRUCTIONS = [

--- a/src/composition/hosted.ts
+++ b/src/composition/hosted.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import {
   parseHostedConfig,
@@ -10,6 +11,10 @@ import {
   HOSTED_FPF_STATUS_ROUTE,
   readHostedFpfStatus,
 } from '../adapters/hosted/status-page.js';
+import {
+  isStandaloneMcpGet,
+  writeMcpGetDisabledNodeResponse,
+} from '../adapters/mcp/server.js';
 import { applyHostedEnvDefaults } from './hosted-env.js';
 import { getSharedMcpComposition } from './mcp.js';
 
@@ -90,4 +95,16 @@ export function createHostedComposition(env: NodeJS.ProcessEnv) {
 
 export function createHostedErrorLogger(env: NodeJS.ProcessEnv) {
   return getRuntimeLogger(parseLoggingConfig(env));
+}
+
+export function tryHandleHostedMcpNodeGet(
+  request: IncomingMessage,
+  response: ServerResponse,
+): boolean {
+  if (!isStandaloneMcpGet(request.method)) {
+    return false;
+  }
+
+  writeMcpGetDisabledNodeResponse(response);
+  return true;
 }

--- a/src/entrypoints/vercel-function.ts
+++ b/src/entrypoints/vercel-function.ts
@@ -7,6 +7,7 @@ import {
   createHostedComposition,
   createHostedErrorLogger,
   HOSTED_MCP_ROUTES,
+  tryHandleHostedMcpNodeGet,
 } from '../composition/hosted.js';
 
 type HostedComposition = ReturnType<typeof createHostedComposition>;
@@ -18,12 +19,17 @@ export default async function handler(
   response: ServerResponse,
 ): Promise<void> {
   try {
-    const { app, mcpServer } = await getHostedComposition();
     if (isMcpRoute(request)) {
+      if (tryHandleHostedMcpNodeGet(request, response)) {
+        return;
+      }
+
+      const { mcpServer } = await getHostedComposition();
       await mcpServer.handleNodeStreamableHttp(request, response);
       return;
     }
 
+    const { app } = await getHostedComposition();
     const webRequest = toWebRequest(request);
     const webResponse = await app.fetch(webRequest);
     await sendWebResponse(response, webResponse);

--- a/tests/e2e/mcp.spec.ts
+++ b/tests/e2e/mcp.spec.ts
@@ -58,7 +58,7 @@ test('MCP initialize returns valid serverInfo', async ({ request }) => {
   expect(body.result?.serverInfo.name).toBe('fpf_reference');
 });
 
-test('legacy MCP alias still initializes during compatibility window', async ({
+test('legacy MCP alias initializes unless edge-blocked during incident mitigation', async ({
   request,
 }) => {
   const response = await request.post(LEGACY_MCP_PATH, {
@@ -74,6 +74,11 @@ test('legacy MCP alias still initializes during compatibility window', async ({
       },
     },
   });
+  if (response.status() === 403) {
+    expect(response.headers()['x-vercel-mitigated']).toBe('deny');
+    return;
+  }
+
   expect(response.status()).toBe(200);
   const body = (await response.json()) as JsonRpcEnvelope<ServerInfoResult>;
   expect(body.error).toBeUndefined();

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -576,6 +576,50 @@ describe('direct MCP server', () => {
       });
     }
   });
+
+  it('rejects standalone hosted MCP GET streams through the Vercel Node adapter', async () => {
+    const server = createServer((request, response) => {
+      vercelHandler(request, response).catch((error: unknown) => {
+        response.statusCode = 500;
+        response.end(error instanceof Error ? error.message : String(error));
+      });
+    });
+
+    await new Promise<void>((resolveListen) => {
+      server.listen(0, '127.0.0.1', resolveListen);
+    });
+
+    try {
+      const address = server.address();
+      expect(typeof address).toBe('object');
+      expect(address).not.toBeNull();
+      const port = (address as { port: number }).port;
+      for (const route of HOSTED_MCP_ROUTES) {
+        const response = await fetch(`http://127.0.0.1:${port}${route}`, {
+          method: 'GET',
+          headers: {
+            accept: 'text/event-stream',
+            'MCP-Protocol-Version': '2025-06-18',
+          },
+          signal: AbortSignal.timeout(5_000),
+        });
+        await response.body?.cancel().catch(() => undefined);
+
+        expect(response.status).toBe(405);
+        expect(response.headers.get('allow')).toBe('POST, DELETE');
+      }
+    } finally {
+      await new Promise<void>((resolveClose, rejectClose) => {
+        server.close((error) => {
+          if (error) {
+            rejectClose(error);
+            return;
+          }
+          resolveClose();
+        });
+      });
+    }
+  });
 });
 
 function asToolPayload(message: JsonRpcResponse): Record<string, unknown> {


### PR DESCRIPTION
## Summary

- Reject standalone hosted MCP `GET` streams with `405` and `Allow: POST, DELETE` before opening an MCP transport.
- Short-circuit Vercel MCP `GET` requests before hosted composition initialization so idle SSE clients cannot hold a function until timeout.
- Keep the Vercel entrypoint dependency direction intact by routing the early MCP `GET` guard through the composition layer.
- Add regression coverage for hosted MCP `GET` through the Vercel Node adapter and align preview E2E with the temporary Vercel firewall block on the legacy alias.

## Root Cause

MCP clients were opening standalone Streamable HTTP/SSE `GET` streams against the hosted MCP endpoints, especially the legacy `/api/mcp/fpf_memory/mcp` route. In serverless Vercel, those streams stayed idle until the 60 s function timeout, driving almost all of the one-day Function Duration spike.

## Impact

Normal JSON-RPC `POST` requests still initialize and call tools when traffic reaches the function. Standalone MCP SSE `GET` is now explicitly disabled on the hosted function surface instead of consuming function duration until timeout.

There is also an active Vercel firewall mitigation named `Temporary block legacy FPF MCP cost spike` that denies `/api/mcp/fpf_memory/mcp` before the function. That protects cost immediately, but means live preview/prod E2E should treat a Vercel-marked `403` on the legacy alias as intentional while the mitigation is active.

## Validation

- `bun install --frozen-lockfile`
- `bunx rstest run tests/mcp-server.test.ts` -> 7 passed
- `bun run check` -> passed
- `bun run lint` -> 0 lint errors, 0 type errors, 0 warnings
- `bun run check:boundaries` -> passed
- `bun run vercel:origin:build` -> passed; Vercel function bundle `99.98 MB`, headroom `140.02 MB`
- `FPF_E2E_BASE_URL=https://fpf-72chlwsyx-venikmans-projects.vercel.app bun run test:e2e` -> 26 passed

## Operations Note

The equivalent function hotfix path was already production-deployed and live-verified on the canonical MCP route: canonical MCP `GET` returns `405`, MCP `POST initialize` returns `200`, and `/api/fpf/status` returns `200`. The legacy MCP path is currently stopped earlier by Vercel Firewall with `x-vercel-mitigated: deny`.
