### PR TITLE
[codex] harden hosted MCP cost guardrails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ FPF_SYNC_MONITOR_STATUS_URL=https://fpf.sh/api/fpf/status
 FPF_SYNC_MONITOR_MAX_DRIFT_HOURS=10
 FPF_RUNTIME_ARTIFACT_DIR=.runtime/fpf-index
 FPF_QUERY_DEFAULT_MODE=verbose
+# Emergency production switch: when true, hosted /api/mcp/* returns a cheap 503
+# before loading the MCP runtime. Static docs and /api/fpf/status stay available.
+FPF_HOSTED_MCP_DISABLED=false
 # Optional LM Studio path. If you set either base URL or model, the missing half
 # falls back to the repo defaults below.
 # The runtime talks to LM Studio's Anthropic-compatible endpoints only:

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Copy `.env.example` to `.env`. The most common settings:
 | `FPF_SYNC_MONITOR_MAX_DRIFT_HOURS`        | `10`                                 | Allowed upstream-to-production drift before monitor failure.           |
 | `FPF_RUNTIME_ARTIFACT_DIR`                | `.runtime/fpf-index`                 | Where compiled artifacts are written.                                 |
 | `FPF_QUERY_DEFAULT_MODE`                  | `verbose`                            | Default `mode` for `query_fpf_spec` and `ask_fpf`.                    |
+| `FPF_HOSTED_MCP_DISABLED`                 | `false`                              | Emergency hosted `/api/mcp/*` shutoff; returns `503` before loading the MCP runtime. |
 | `FPF_LOCAL_LLM_BASE_URL`                  | `http://localhost:1234/v1`           | Optional LM Studio endpoint. Omit to stay fully deterministic.        |
 | `FPF_LOCAL_LLM_MODEL`                     | `google/gemma-4-31b`                 | Optional LM Studio model.                                             |
 | `FPF_LOCAL_LLM_API_KEY`                   | *(empty)*                            | LM Studio API token (Developer → Server Settings → Manage Tokens).    |
@@ -250,13 +251,13 @@ url = "https://mcp.fpf.sh/api/mcp/fpf_reference/mcp"
 
 This repo ships the same project-scoped configuration at `.codex/config.toml` and `.mcp.json`. Once the project is trusted, Codex can load the hosted `fpf_reference` server directly from the repo.
 
-The legacy `fpf_memory` client name and endpoint remain available for existing users:
+The legacy `fpf_memory` client name and endpoint are blocked during the May 2026 cost incident mitigation:
 
 ```text
 https://mcp.fpf.sh/api/mcp/fpf_memory/mcp
 ```
 
-Do not remove the legacy endpoint before the scheduled compatibility review on 2026-06-30. The rename is intentionally small so parallel deployment and publication-sync work can merge without replacing this branch's compatibility contract. The detailed compatibility note lives in [`docs/fpf-reference-mcp-rename.md`](docs/fpf-reference-mcp-rename.md).
+Do not remove the legacy route before the scheduled compatibility review on 2026-06-30; keep it explicitly routed so stale clients fail cheaply with a migration signal. The rename is intentionally small so parallel deployment and publication-sync work can merge without replacing this branch's compatibility contract. The detailed compatibility note lives in [`docs/fpf-reference-mcp-rename.md`](docs/fpf-reference-mcp-rename.md).
 
 **Recommended Codex tasks** (public surface):
 
@@ -301,7 +302,7 @@ For a proof-style grounded answer, add `mode: "proof"`. For the raw structured e
 
 The direct Vercel origin is canonical for clients. There is no separate Vercel forwarding project in this repo.
 The canonical client aliases are `https://fpf.sh/` for the static reference and `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp` for MCP clients.
-`https://mcp.fpf.sh/api/mcp/fpf_memory/mcp` remains a legacy compatibility endpoint during the transition.
+`https://mcp.fpf.sh/api/mcp/fpf_memory/mcp` is the legacy compatibility path and is blocked during the May 2026 cost incident mitigation; new and working clients must use the canonical `fpf_reference` endpoint.
 `fpf-memory-mcp-vercel-origin.vercel.app` is a legacy compatibility alias only; do not add it to new docs, scripts, or client setup examples.
 Historical errored preview deployments can remain in Vercel as audit records.
 Treat current production readiness as the latest `fpf.sh` production alias plus status, smoke, QA, and bundle-size gates, not as an absence of old preview errors.

--- a/docs/automation-playbook.md
+++ b/docs/automation-playbook.md
@@ -184,7 +184,7 @@ The current material:
 - Website: https://fpf.sh/
 - Connect MCP: https://fpf.sh/connect-mcp
 - Hosted endpoint: https://mcp.fpf.sh/api/mcp/fpf_reference/mcp
-- Legacy endpoint during transition: https://mcp.fpf.sh/api/mcp/fpf_memory/mcp
+- Legacy endpoint during transition: https://mcp.fpf.sh/api/mcp/fpf_memory/mcp (blocked during May 2026 cost incident mitigation)
 
 The claim I am comfortable making right now is narrow: it is useful for bounded FPF lookup and agent workflows that need evidence-backed framework context. I am not claiming broad adoption or benchmark superiority yet.
 

--- a/docs/connect-mcp.md
+++ b/docs/connect-mcp.md
@@ -16,15 +16,15 @@ https://mcp.fpf.sh/api/mcp/fpf_reference/mcp
 
 This endpoint is the direct Vercel-hosted MCP origin over streamable HTTP. It exposes the public FPF Reference tools for catalog browsing, search, compact answers, exact generated doc reads, and index health.
 
-The legacy endpoint remains available during the compatibility window:
+The legacy endpoint is blocked during the May 2026 cost incident mitigation:
 
 ```txt
 https://mcp.fpf.sh/api/mcp/fpf_memory/mcp
 ```
 
-Do not remove the legacy endpoint before the scheduled compatibility review on 2026-06-30. Existing users may still have the old URL or `fpf_memory` client name in their local MCP configs.
+Keep the route entry until the scheduled compatibility review on 2026-06-30 so old clients fail cheaply with a migration signal instead of falling through to an expensive timeout. Existing users with the old URL or `fpf_memory` client name should move to the canonical endpoint above.
 
-It is a JSON-RPC endpoint, not a web page. A bare browser GET returns **406 Not Acceptable** because the MCP server requires `Accept: application/json, text/event-stream`. Paste the URL into your client's MCP config; do not open it in a tab.
+It is a JSON-RPC endpoint, not a web page. A bare browser GET returns **405 Method Not Allowed** because standalone MCP SSE streams are disabled on the hosted endpoint. Paste the canonical URL into your client's MCP config; do not open it in a tab.
 
 For a browser-readable health check, use the freshness page instead:
 

--- a/docs/fpf-reference-mcp-rename.md
+++ b/docs/fpf-reference-mcp-rename.md
@@ -16,13 +16,13 @@ This PR makes `fpf_reference` the canonical hosted MCP server name and endpoint:
 https://mcp.fpf.sh/api/mcp/fpf_reference/mcp
 ```
 
-It keeps the legacy `fpf_memory` endpoint live:
+It keeps the legacy `fpf_memory` route entry present, but the route is blocked during the May 2026 cost incident mitigation:
 
 ```txt
 https://mcp.fpf.sh/api/mcp/fpf_memory/mcp
 ```
 
-The old route stays available because users may already have it in ChatGPT, Claude, Codex, VS Code, Zed, Pi, or other MCP client configs.
+The old route stays explicitly routed so users with stale ChatGPT, Claude, Codex, VS Code, Zed, Pi, or other MCP client configs fail cheaply with a migration signal instead of falling through to an expensive hosted runtime timeout.
 
 ## Naming model
 
@@ -34,7 +34,7 @@ The repo name can remain `fpf-memory`. Repository identity, package history, and
 
 ## What this PR does not change
 
-- It does not remove `/api/mcp/fpf_memory/mcp`.
+- It does not remove `/api/mcp/fpf_memory/mcp`; it keeps the route but blocks it while the cost incident mitigation is active.
 - It does not rename the repository or npm package.
 - It does not change public MCP tool names.
 - It does not change FPF compilation, chunking, retrieval, publication sync, or `published/current/**`.
@@ -48,12 +48,12 @@ FPF Reference should cooperate with GStack, Superpowers, and project instruction
 
 ## Parallel-work contract
 
-Until the compatibility review date, any deployment, sync, docs, or Vercel-origin branch must preserve both entries in `HOSTED_MCP_ROUTES`:
+Until the compatibility review date, any deployment, sync, docs, or Vercel-origin branch must preserve both route entries in `HOSTED_MCP_ROUTES`:
 
 - `/api/mcp/fpf_reference/mcp` as canonical
-- `/api/mcp/fpf_memory/mcp` as legacy compatibility
+- `/api/mcp/fpf_memory/mcp` as blocked legacy compatibility
 
-If a merge conflict touches hosted routing, Vercel output routes, `.mcp.json`, `.codex/config.toml`, or client setup docs, resolve it by keeping the canonical `fpf_reference` examples and the legacy route. Do not delete the legacy route before 2026-06-30.
+If a merge conflict touches hosted routing, Vercel output routes, `.mcp.json`, `.codex/config.toml`, or client setup docs, resolve it by keeping the canonical `fpf_reference` examples and the blocked legacy route. Do not delete the legacy route before 2026-06-30.
 
 ## Cleanup review
 

--- a/src/adapters/hosted/home-page.ts
+++ b/src/adapters/hosted/home-page.ts
@@ -435,7 +435,7 @@ export function renderHostedHomePage(): string {
         <div class="endpoint">
           <span>Streamable HTTP endpoint</span>
           <code>${HOSTED_MCP_ENDPOINT}</code>
-          <small>Legacy <code>${LEGACY_HOSTED_MCP_ENDPOINT}</code> remains available during the transition.</small>
+          <small>Legacy <code>${LEGACY_HOSTED_MCP_ENDPOINT}</code> is blocked during the May 2026 mitigation; use the endpoint above.</small>
         </div>
       </section>
 

--- a/src/adapters/infra/config/env.ts
+++ b/src/adapters/infra/config/env.ts
@@ -138,6 +138,7 @@ export function parseHostedConfig(env: NodeJS.ProcessEnv): HostedConfig {
   return {
     port: parsePort(env.PORT),
     surface: parseMcpSurface(env.FPF_MCP_SURFACE),
+    mcpDisabled: parseBoolean(env.FPF_HOSTED_MCP_DISABLED, false),
   };
 }
 

--- a/src/adapters/infra/config/types.ts
+++ b/src/adapters/infra/config/types.ts
@@ -45,6 +45,7 @@ export interface McpConfig {
 export interface HostedConfig {
   port: number;
   surface: McpSurface;
+  mcpDisabled: boolean;
 }
 
 export interface DocsConfig {

--- a/src/build/vercel-origin-build.ts
+++ b/src/build/vercel-origin-build.ts
@@ -33,7 +33,7 @@ const FUNCTION_DIR = `${OUTPUT_DIR}/functions/${FUNCTION_NAME}.func`;
 const FUNCTION_DEST = `/${FUNCTION_NAME}`;
 export const VERCEL_FUNCTION_RUNTIME = 'nodejs24.x';
 export const VERCEL_FUNCTION_MEMORY_MB = 1024;
-export const VERCEL_FUNCTION_MAX_DURATION_SECONDS = 60;
+export const VERCEL_FUNCTION_MAX_DURATION_SECONDS = 20;
 const STATIC_DIR = `${OUTPUT_DIR}/static`;
 
 export type VercelOriginRoute =

--- a/src/composition/hosted.ts
+++ b/src/composition/hosted.ts
@@ -82,7 +82,13 @@ export function createHostedComposition(env: NodeJS.ProcessEnv) {
     }
   });
   for (const route of HOSTED_MCP_ROUTES) {
-    app.all(route, (c) => mcpServer.handleStreamableHttp(c.req.raw));
+    if (hostedConfig.mcpDisabled) {
+      app.all(route, () => createHostedMcpDisabledResponse());
+    } else if (route === LEGACY_HOSTED_MCP_ROUTE) {
+      app.all(route, () => createHostedLegacyMcpDisabledResponse());
+    } else {
+      app.all(route, (c) => mcpServer.handleStreamableHttp(c.req.raw));
+    }
   }
 
   return {
@@ -97,14 +103,99 @@ export function createHostedErrorLogger(env: NodeJS.ProcessEnv) {
   return getRuntimeLogger(parseLoggingConfig(env));
 }
 
-export function tryHandleHostedMcpNodeGet(
+export function tryHandleHostedMcpNodeGuard(
   request: IncomingMessage,
   response: ServerResponse,
 ): boolean {
+  if (parseHostedConfig(process.env).mcpDisabled) {
+    writeHostedMcpDisabledNodeResponse(response);
+    return true;
+  }
+
+  if (isHostedMcpRoute(request, LEGACY_HOSTED_MCP_ROUTE)) {
+    writeHostedLegacyMcpDisabledNodeResponse(response);
+    return true;
+  }
+
   if (!isStandaloneMcpGet(request.method)) {
     return false;
   }
 
   writeMcpGetDisabledNodeResponse(response);
   return true;
+}
+
+function isHostedMcpRoute(
+  request: IncomingMessage,
+  route: (typeof HOSTED_MCP_ROUTES)[number],
+): boolean {
+  const url = new URL(request.url ?? '/', 'https://localhost');
+  return url.pathname === route;
+}
+
+function createHostedLegacyMcpDisabledResponse(): Response {
+  return createHostedMcpBlockedResponse(
+    403,
+    'Legacy FPF MCP endpoint is disabled; use https://mcp.fpf.sh/api/mcp/fpf_reference/mcp.',
+    {
+      'X-Vercel-Mitigated': 'deny',
+      Link: '<https://mcp.fpf.sh/api/mcp/fpf_reference/mcp>; rel="successor-version"',
+    },
+  );
+}
+
+function createHostedMcpDisabledResponse(): Response {
+  return createHostedMcpBlockedResponse(503, 'Hosted FPF MCP is temporarily disabled.', {
+    'Retry-After': '3600',
+  });
+}
+
+function createHostedMcpBlockedResponse(
+  status: number,
+  message: string,
+  headers: Record<string, string>,
+): Response {
+  return new Response(JSON.stringify(createHostedMcpBlockedPayload(message)), {
+    status,
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Type': 'application/json; charset=utf-8',
+      ...headers,
+    },
+  });
+}
+
+function writeHostedLegacyMcpDisabledNodeResponse(response: ServerResponse): void {
+  response.statusCode = 403;
+  response.setHeader('Cache-Control', 'no-store');
+  response.setHeader('Content-Type', 'application/json; charset=utf-8');
+  response.setHeader('X-Vercel-Mitigated', 'deny');
+  response.setHeader(
+    'Link',
+    '<https://mcp.fpf.sh/api/mcp/fpf_reference/mcp>; rel="successor-version"',
+  );
+  response.end(JSON.stringify(createHostedMcpBlockedPayload(
+    'Legacy FPF MCP endpoint is disabled; use https://mcp.fpf.sh/api/mcp/fpf_reference/mcp.',
+  )));
+}
+
+function writeHostedMcpDisabledNodeResponse(response: ServerResponse): void {
+  response.statusCode = 503;
+  response.setHeader('Cache-Control', 'no-store');
+  response.setHeader('Content-Type', 'application/json; charset=utf-8');
+  response.setHeader('Retry-After', '3600');
+  response.end(JSON.stringify(createHostedMcpBlockedPayload(
+    'Hosted FPF MCP is temporarily disabled.',
+  )));
+}
+
+function createHostedMcpBlockedPayload(message: string) {
+  return {
+    jsonrpc: '2.0',
+    error: {
+      code: -32000,
+      message,
+    },
+    id: null,
+  } as const;
 }

--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -552,7 +552,7 @@ function renderHomeMarkdown(
     '- `read_fpf_doc` — exact canonical page for a selector (preview + full modes)',
     '- `get_fpf_index_status` — snapshot freshness, source hash, build time',
     '',
-    'Endpoint: `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp` · Legacy: `https://mcp.fpf.sh/api/mcp/fpf_memory/mcp` · Status: [`mcp.fpf.sh/api/fpf/status`](https://mcp.fpf.sh/api/fpf/status) · [Connect setup →](/connect-mcp)',
+    'Endpoint: `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp` · Legacy blocked during May 2026 mitigation: `https://mcp.fpf.sh/api/mcp/fpf_memory/mcp` · Status: [`mcp.fpf.sh/api/fpf/status`](https://mcp.fpf.sh/api/fpf/status) · [Connect setup →](/connect-mcp)',
     '',
     '## FPF — the framework this server projects',
     '',

--- a/src/entrypoints/vercel-function.ts
+++ b/src/entrypoints/vercel-function.ts
@@ -7,7 +7,7 @@ import {
   createHostedComposition,
   createHostedErrorLogger,
   HOSTED_MCP_ROUTES,
-  tryHandleHostedMcpNodeGet,
+  tryHandleHostedMcpNodeGuard,
 } from '../composition/hosted.js';
 
 type HostedComposition = ReturnType<typeof createHostedComposition>;
@@ -20,7 +20,7 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (isMcpRoute(request)) {
-      if (tryHandleHostedMcpNodeGet(request, response)) {
+      if (tryHandleHostedMcpNodeGuard(request, response)) {
         return;
       }
 

--- a/tests/config-contexts.test.ts
+++ b/tests/config-contexts.test.ts
@@ -76,6 +76,7 @@ describe('context config parsing', () => {
     expect(parseHostedConfig(env)).toEqual({
       port: 4112,
       surface: 'full',
+      mcpDisabled: false,
     });
     expect(parseDocsConfig(env)).toEqual({
       sourcePath: '/tmp/fpf/FPF-spec.md',
@@ -119,6 +120,20 @@ describe('context config parsing', () => {
     expect(parseHostedConfig(env)).toEqual({
       port: 65535,
       surface: 'public',
+      mcpDisabled: false,
+    });
+  });
+
+  it('parses the hosted MCP emergency disable flag', () => {
+    expect(parseHostedConfig({
+      FPF_HOSTED_MCP_DISABLED: 'true',
+    } as NodeJS.ProcessEnv)).toMatchObject({
+      mcpDisabled: true,
+    });
+    expect(parseHostedConfig({
+      FPF_HOSTED_MCP_DISABLED: 'false',
+    } as NodeJS.ProcessEnv)).toMatchObject({
+      mcpDisabled: false,
     });
   });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -9,7 +9,9 @@ import { afterEach, describe, expect, it } from '@rstest/core';
 
 import {
   createHostedComposition,
+  HOSTED_MCP_ROUTE,
   HOSTED_MCP_ROUTES,
+  LEGACY_HOSTED_MCP_ROUTE,
 } from '../src/composition/hosted.js';
 import { DEFAULT_SOURCE_PATH } from '../src/core/constants.js';
 import vercelHandler from '../src/entrypoints/vercel-function.js';
@@ -550,10 +552,18 @@ describe('direct MCP server', () => {
                 name: 'rstest-vercel-node-adapter',
                 version: '1.0.0',
               },
-          },
+            },
           }),
           signal: AbortSignal.timeout(5_000),
         });
+
+        if (route === LEGACY_HOSTED_MCP_ROUTE) {
+          expect(response.status).toBe(403);
+          expect(response.headers.get('x-vercel-mitigated')).toBe('deny');
+          const payload = await response.json() as JsonRpcResponse;
+          expect(payload.error?.message).toContain('Legacy FPF MCP endpoint is disabled');
+          continue;
+        }
 
         expect(response.status).toBe(200);
         expect(response.headers.get('content-type')).toContain('application/json');
@@ -594,21 +604,86 @@ describe('direct MCP server', () => {
       expect(typeof address).toBe('object');
       expect(address).not.toBeNull();
       const port = (address as { port: number }).port;
+      const response = await fetch(`http://127.0.0.1:${port}${HOSTED_MCP_ROUTE}`, {
+        method: 'GET',
+        headers: {
+          accept: 'text/event-stream',
+          'MCP-Protocol-Version': '2025-06-18',
+        },
+        signal: AbortSignal.timeout(5_000),
+      });
+      await response.body?.cancel().catch(() => undefined);
+
+      expect(response.status).toBe(405);
+      expect(response.headers.get('allow')).toBe('POST, DELETE');
+    } finally {
+      await new Promise<void>((resolveClose, rejectClose) => {
+        server.close((error) => {
+          if (error) {
+            rejectClose(error);
+            return;
+          }
+          resolveClose();
+        });
+      });
+    }
+  });
+
+  it('short-circuits all hosted MCP routes when the production disable flag is set', async () => {
+    const previous = process.env.FPF_HOSTED_MCP_DISABLED;
+    process.env.FPF_HOSTED_MCP_DISABLED = 'true';
+    const server = createServer((request, response) => {
+      vercelHandler(request, response).catch((error: unknown) => {
+        response.statusCode = 500;
+        response.end(error instanceof Error ? error.message : String(error));
+      });
+    });
+
+    await new Promise<void>((resolveListen) => {
+      server.listen(0, '127.0.0.1', resolveListen);
+    });
+
+    try {
+      const address = server.address();
+      expect(typeof address).toBe('object');
+      expect(address).not.toBeNull();
+      const port = (address as { port: number }).port;
       for (const route of HOSTED_MCP_ROUTES) {
         const response = await fetch(`http://127.0.0.1:${port}${route}`, {
-          method: 'GET',
+          method: 'POST',
           headers: {
-            accept: 'text/event-stream',
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream',
             'MCP-Protocol-Version': '2025-06-18',
           },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+              protocolVersion: '2025-06-18',
+              capabilities: {},
+              clientInfo: {
+                name: 'rstest-disabled-hosted-mcp',
+                version: '1.0.0',
+              },
+            },
+          }),
           signal: AbortSignal.timeout(5_000),
         });
-        await response.body?.cancel().catch(() => undefined);
 
-        expect(response.status).toBe(405);
-        expect(response.headers.get('allow')).toBe('POST, DELETE');
+        expect(response.status).toBe(503);
+        expect(response.headers.get('cache-control')).toBe('no-store');
+        expect(response.headers.get('retry-after')).toBe('3600');
+        const payload = await response.json() as JsonRpcResponse;
+        expect(payload.error?.message).toContain('temporarily disabled');
       }
     } finally {
+      if (previous === undefined) {
+        delete process.env.FPF_HOSTED_MCP_DISABLED;
+      } else {
+        process.env.FPF_HOSTED_MCP_DISABLED = previous;
+      }
       await new Promise<void>((resolveClose, rejectClose) => {
         server.close((error) => {
           if (error) {

--- a/tests/vercel-origin-config.test.ts
+++ b/tests/vercel-origin-config.test.ts
@@ -62,7 +62,7 @@ describe('Vercel MCP origin config', () => {
     const functionConfig = createVercelFunctionConfig();
 
     expect(functionConfig.memory).toBe(1024);
-    expect(functionConfig.maxDuration).toBe(60);
+    expect(functionConfig.maxDuration).toBe(20);
   });
 
   it('documents canonical Vercel aliases and historical preview-error policy', async () => {
@@ -102,7 +102,7 @@ describe('Vercel MCP origin config', () => {
     );
     expect(srcRoutes).not.toContain('^/$');
     expect(srcRoutes).not.toContain('^/connect-mcp$');
-    // API routes remain, including the temporary legacy MCP alias.
+    // API routes remain, including the blocked legacy MCP alias.
     expect(srcRoutes).toContain(`^${HOSTED_MCP_ROUTE}$`);
     expect(srcRoutes).toContain(`^${LEGACY_HOSTED_MCP_ROUTE}$`);
   });


### PR DESCRIPTION
## Summary
- keep canonical /api/mcp/fpf_reference/mcp live while blocking legacy /api/mcp/fpf_memory/mcp cheaply
- add FPF_HOSTED_MCP_DISABLED emergency shutoff before hosted runtime composition
- reject hosted standalone MCP GETs and reduce Vercel function maxDuration to 20 seconds
- update docs/homepage/tests so blocked legacy status is explicit

## Validation
- bun run test tests/mcp-server.test.ts tests/vercel-origin-config.test.ts tests/config-contexts.test.ts
- bun run check
- git diff --check origin/main...HEAD
- bun run vercel:origin:build
- autoreview --mode local via Codex CLI 0.135.0: clean, no accepted/actionable findings

## Production evidence
- deployed prebuilt production artifact to fpf.sh and mcp.fpf.sh
- live checks after deploy: fpf.sh 200, canonical MCP POST 200, canonical GET 405, legacy MCP POST 403
- Vercel metrics after mitigation showed /_origin function-duration GB-hr collapsed to near-zero/zero buckets and zero 5xx in the checked window

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production MCP routing and Vercel function limits; misconfiguration of FPF_HOSTED_MCP_DISABLED would take down all hosted MCP, though static docs and /api/fpf/status remain available.
> 
> **Overview**
> This PR hardens **hosted MCP cost controls** during the May 2026 incident while keeping **`fpf_reference`** live.
> 
> **Runtime behavior:** `/api/mcp/fpf_memory/mcp` now returns a cheap **403** JSON-RPC error with migration headers instead of loading the MCP stack. **`FPF_HOSTED_MCP_DISABLED`** adds an emergency **503** on all `/api/mcp/*` routes before composition (Hono + Vercel Node guard). Standalone MCP **GET/SSE** on the canonical route is rejected with **405** (`Allow: POST, DELETE`). Vercel origin **`maxDuration`** drops from 60s to **20s**.
> 
> **Docs & UX:** README, connect/rename docs, automation playbook, homepage, and generated home copy state that the legacy URL is **blocked** (route kept until 2026-06-30) and document the env kill switch.
> 
> **Tests:** Coverage for legacy 403, global disable 503, GET 405, config parsing, and duration guardrails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68d6d75ca69f336a6dbcb5af0ba8e0052614d137. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->