### PR TITLE
fix(ci): classify Vercel spend monitor config errors

### DIFF
--- a/.github/workflows/vercel-spend-monitor.yml
+++ b/.github/workflows/vercel-spend-monitor.yml
@@ -55,10 +55,6 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          if [ -z "${VERCEL_TOKEN:-}" ]; then
-            echo "::error::VERCEL_TOKEN is required for scheduled Vercel metrics monitoring."
-            exit 1
-          fi
           bun run monitor:vercel:spend -- --format markdown --fail-on-breach
 
       - name: Open or update spend breach issue
@@ -85,17 +81,31 @@ jobs:
           )"
 
           body="$(
-            printf '%s\n' \
-              'The scheduled Vercel spend monitor failed or breached.' \
-              '' \
-              "- State: $STATE" \
-              "- Summary: $SUMMARY" \
-              "- Function Duration: $FUNCTION_DURATION_GBHR GB-hours (threshold $MAX_FUNCTION_DURATION_GBHR)" \
-              "- Legacy route function invocations: $LEGACY_INVOCATIONS" \
-              "- Function error-code invocations: $ERROR_INVOCATIONS" \
-              "- Run: $RUN_URL" \
-              '' \
-              'Check the workflow summary for the full metric table before changing billing or deploy settings.'
+            if [ "$STATE" = "config_error" ]; then
+              printf '%s\n' \
+                'The scheduled Vercel spend monitor failed before querying metrics.' \
+                '' \
+                "- State: $STATE" \
+                "- Summary: $SUMMARY" \
+                "- Function Duration: not queried" \
+                "- Legacy route function invocations: not queried" \
+                "- Function error-code invocations: not queried" \
+                "- Run: $RUN_URL" \
+                '' \
+                'Fix the monitor configuration or repository secrets and rerun before changing billing or deploy settings.'
+            else
+              printf '%s\n' \
+                'The scheduled Vercel spend monitor failed or reported a breach.' \
+                '' \
+                "- State: $STATE" \
+                "- Summary: $SUMMARY" \
+                "- Function Duration: $FUNCTION_DURATION_GBHR GB-hours (threshold $MAX_FUNCTION_DURATION_GBHR)" \
+                "- Legacy route function invocations: $LEGACY_INVOCATIONS" \
+                "- Function error-code invocations: $ERROR_INVOCATIONS" \
+                "- Run: $RUN_URL" \
+                '' \
+                'Check the workflow summary for the full metric table before changing billing or deploy settings.'
+            fi
           )"
 
           if [ -n "$existing" ]; then

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Out:
 - Work performed: download `FPF-Spec.md`, run `publish:current`, validate `published/current/**`, build the static docs, build the Vercel-origin MCP bundle, and open a publication PR only when files changed.
 - Hosted MCP handoff: before opening a new PR, the workflow closes superseded `chore/sync-fpf-*` PRs. After the review window and required checks pass, it squash-merges the current PR. The resulting `main` push gives Vercel's Git integration the refreshed `fpf.sh` inputs.
 - Monitor: `.github/workflows/fpf-sync-monitor.yml` runs hourly, checks `ailev/FPF` HEAD against `https://fpf.sh/api/fpf/status`, triggers `sync-fpf.yml` when upstream is ahead, and redispatches it when a current generated PR exists but no worker is queued or running. It fails only when drift exceeds the configured SLO or the hosted runtime is internally stale.
-- Spend guardrail: `.github/workflows/vercel-spend-monitor.yml` runs every 15 minutes with `VERCEL_TOKEN`, checks Vercel Function Duration GB-hours, platform error-code rows, and legacy `/api/mcp/fpf_memory` function invocations, then fails the run when a configured cost-risk threshold is breached.
+- Spend guardrail: `.github/workflows/vercel-spend-monitor.yml` runs every 15 minutes with `VERCEL_TOKEN`, checks Vercel Function Duration GB-hours, platform error-code rows, and legacy `/api/mcp/fpf_memory` function invocations, then fails the run when a configured cost-risk threshold is breached. If `VERCEL_TOKEN` is missing, the monitor reports `config_error` before querying metrics; fix the secret and rerun before treating the issue as a spend breach.
 
 Minimal dispatch payload:
 

--- a/docs/automation-playbook.md
+++ b/docs/automation-playbook.md
@@ -105,7 +105,7 @@ Operational defaults:
 - `sync-fpf.yml` accepts `fpf-origin-updated` and `fpf-sync-updated` dispatches or manual runs, closes superseded sync PRs, opens a current PR, runs validation/build/preview, then auto-merges only after the review window and required evidence pass.
 - `fpf-sync-monitor.yml` polls hourly, runs `bun run monitor:sync`, triggers `sync-fpf.yml` when upstream is ahead and no sync worker is queued or running, and fails the monitor if `fpf.sh` exceeds the drift SLO or the hosted runtime is stale. If a current generated PR already exists, the dispatch is a retry path for CI and merge eligibility rather than a duplicate PR path.
 - The default drift SLO is 10 hours: hourly detection plus a 2-hour review window plus operational margin.
-- `vercel-spend-monitor.yml` polls Vercel metrics every 15 minutes with `bun run monitor:vercel:spend`, failing when Function Duration exceeds the configured GB-hour window, the legacy MCP route reaches Functions again, or Vercel reports function error-code rows. It requires the repo secret `VERCEL_TOKEN`.
+- `vercel-spend-monitor.yml` polls Vercel metrics every 15 minutes with `bun run monitor:vercel:spend`, failing when Function Duration exceeds the configured GB-hour window, the legacy MCP route reaches Functions again, or Vercel reports function error-code rows. It requires the repo secret `VERCEL_TOKEN`; missing credentials report `config_error` and must be fixed before interpreting the alert as spend evidence.
 
 ## Publishing and outreach packets
 

--- a/scripts/monitor-vercel-spend.ts
+++ b/scripts/monitor-vercel-spend.ts
@@ -2,6 +2,7 @@ import { appendFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 
 import {
+  createVercelSpendConfigErrorReport,
   createVercelSpendSnapshot,
   DEFAULT_LEGACY_FUNCTION_DURATION_USD_PER_GBHR,
   DEFAULT_VERCEL_SPEND_LEGACY_PATH,
@@ -62,84 +63,103 @@ const legacyPath = readString(
   process.env.FPF_VERCEL_SPEND_LEGACY_PATH ?? DEFAULT_VERCEL_SPEND_LEGACY_PATH,
 );
 
-const common = [
-  '--project',
-  project,
-  '--since',
-  `${windowMinutes}m`,
-  '--granularity',
-  '5m',
-  '--format',
-  'json',
-  ...(scope ? ['--scope', scope] : []),
-  ...(token ? ['--token', token] : []),
-];
+const thresholds = {
+  maxFunctionDurationGbhr,
+  maxLegacyFunctionInvocations,
+  maxErrorFunctionInvocations,
+  functionDurationUsdPerGbhr,
+};
 
-const functionDurationMetrics = runVercelMetrics([
-  'vercel.function_invocation.function_duration_gbhr',
-  '--aggregation',
-  'sum',
-  '--group-by',
-  'request_path',
-  '--group-by',
-  'error_code',
-  ...common,
-]);
-const legacyInvocationMetrics = runVercelMetrics([
-  'vercel.function_invocation.count',
-  '--group-by',
-  'request_path',
-  '--filter',
-  `contains(request_path, '${escapeODataString(legacyPath)}')`,
-  ...common,
-]);
-const errorInvocationMetrics = runVercelMetrics([
-  'vercel.function_invocation.count',
-  '--group-by',
-  'request_path',
-  '--group-by',
-  'error_code',
-  '--filter',
-  "error_code ne ''",
-  ...common,
-]);
+const report = token
+  ? evaluateVercelSpendMonitor({
+    project,
+    windowMinutes,
+    legacyPath,
+    now: new Date(),
+    thresholds,
+    metrics: createVercelSpendSnapshot({
+      functionDurationMetrics: runVercelMetrics([
+        'vercel.function_invocation.function_duration_gbhr',
+        '--aggregation',
+        'sum',
+        '--group-by',
+        'request_path',
+        '--group-by',
+        'error_code',
+        ...commonMetricArgs(token),
+      ]),
+      legacyInvocationMetrics: runVercelMetrics([
+        'vercel.function_invocation.count',
+        '--group-by',
+        'request_path',
+        '--filter',
+        `contains(request_path, '${escapeODataString(legacyPath)}')`,
+        ...commonMetricArgs(token),
+      ]),
+      errorInvocationMetrics: runVercelMetrics([
+        'vercel.function_invocation.count',
+        '--group-by',
+        'request_path',
+        '--group-by',
+        'error_code',
+        '--filter',
+        "error_code ne ''",
+        ...commonMetricArgs(token),
+      ]),
+    }),
+  })
+  : createVercelSpendConfigErrorReport({
+    project,
+    windowMinutes,
+    legacyPath,
+    now: new Date(),
+    thresholds,
+    message:
+      'VERCEL_TOKEN is required for scheduled Vercel metrics monitoring; configure the repository secret and rerun before treating this as a spend breach.',
+  });
 
-const report = evaluateVercelSpendMonitor({
-  project,
-  windowMinutes,
-  legacyPath,
-  now: new Date(),
-  thresholds: {
-    maxFunctionDurationGbhr,
-    maxLegacyFunctionInvocations,
-    maxErrorFunctionInvocations,
-    functionDurationUsdPerGbhr,
-  },
-  metrics: createVercelSpendSnapshot({
-    functionDurationMetrics,
-    legacyInvocationMetrics,
-    errorInvocationMetrics,
-  }),
-});
 const markdown = formatVercelSpendMonitorMarkdown(report);
 
-if (process.env.GITHUB_OUTPUT) {
-  await appendFile(process.env.GITHUB_OUTPUT, renderGithubOutput(report), 'utf8');
-}
-if (process.env.GITHUB_STEP_SUMMARY) {
-  await appendFile(process.env.GITHUB_STEP_SUMMARY, markdown, 'utf8');
-}
+await emitReport(report, markdown);
 
-if (format === 'markdown') {
-  process.stdout.write(markdown);
-} else if (format === 'json') {
-  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
-} else {
-  throw new Error('--format must be json or markdown.');
-}
-
-if (failOnBreach && report.breached) {
+if (!token || (failOnBreach && report.breached)) {
   process.exitCode = 1;
+}
+
+function commonMetricArgs(requiredToken: string): string[] {
+  return [
+    '--project',
+    project,
+    '--since',
+    `${windowMinutes}m`,
+    '--granularity',
+    '5m',
+    '--format',
+    'json',
+    ...(scope ? ['--scope', scope] : []),
+    '--token',
+    requiredToken,
+  ];
+}
+
+async function emitReport(
+  report: VercelSpendMonitorReport,
+  markdown: string,
+): Promise<void> {
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(process.env.GITHUB_OUTPUT, renderGithubOutput(report), 'utf8');
+  }
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, markdown, 'utf8');
+  }
+
+  if (format === 'markdown') {
+    process.stdout.write(markdown);
+  } else if (format === 'json') {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    throw new Error('--format must be json or markdown.');
+  }
 }
 
 function runVercelMetrics(args: string[]): unknown {
@@ -166,17 +186,30 @@ function runVercelMetrics(args: string[]): unknown {
 }
 
 function renderGithubOutput(report: VercelSpendMonitorReport): string {
+  const metricsWereQueried = report.state !== 'config_error';
   return [
     ['state', report.state],
     ['ok', String(report.ok)],
     ['breached', String(report.breached)],
     ['project', report.project],
     ['window_minutes', String(report.windowMinutes)],
-    ['function_duration_gbhr', String(report.metrics.functionDurationGbhr)],
+    [
+      'function_duration_gbhr',
+      metricsWereQueried ? String(report.metrics.functionDurationGbhr) : 'not_queried',
+    ],
     ['max_function_duration_gbhr', String(report.thresholds.maxFunctionDurationGbhr)],
-    ['estimated_function_duration_usd', String(report.estimatedFunctionDurationUsd)],
-    ['legacy_function_invocations', String(report.metrics.legacyFunctionInvocations)],
-    ['function_error_invocations', String(report.metrics.errorFunctionInvocations)],
+    [
+      'estimated_function_duration_usd',
+      metricsWereQueried ? String(report.estimatedFunctionDurationUsd) : 'not_queried',
+    ],
+    [
+      'legacy_function_invocations',
+      metricsWereQueried ? String(report.metrics.legacyFunctionInvocations) : 'not_queried',
+    ],
+    [
+      'function_error_invocations',
+      metricsWereQueried ? String(report.metrics.errorFunctionInvocations) : 'not_queried',
+    ],
     ['summary', report.summary],
   ].map(([key, value]) => `${key}=${sanitizeOutputValue(value)}\n`).join('');
 }

--- a/src/build/vercel-spend-monitor.ts
+++ b/src/build/vercel-spend-monitor.ts
@@ -32,7 +32,7 @@ export const VERCEL_SPEND_QA_ANCHORS = [
   },
 ] as const;
 
-export type VercelSpendMonitorState = 'ok' | 'breach';
+export type VercelSpendMonitorState = 'ok' | 'breach' | 'config_error';
 
 export interface VercelMetricRow {
   value: number;
@@ -149,6 +149,46 @@ export function evaluateVercelSpendMonitor(input: {
   };
 }
 
+export function createVercelSpendConfigErrorReport(input: {
+  project: string;
+  windowMinutes: number;
+  legacyPath: string;
+  now: Date;
+  thresholds: VercelSpendMonitorThresholds;
+  message: string;
+}): VercelSpendMonitorReport {
+  const metrics = emptyVercelSpendSnapshot();
+  return {
+    state: 'config_error',
+    ok: false,
+    breached: false,
+    generatedAt: input.now.toISOString(),
+    project: input.project,
+    windowMinutes: input.windowMinutes,
+    legacyPath: input.legacyPath,
+    thresholds: input.thresholds,
+    metrics,
+    estimatedFunctionDurationUsd: 0,
+    quality: [
+      {
+        characteristic: 'monitor-configuration',
+        status: 'fail',
+        evidence: input.message,
+        fpf: ['B.5.1', 'A.10'],
+      },
+      {
+        characteristic: 'traceability',
+        status: 'pass',
+        evidence: `project=${input.project}, window=${input.windowMinutes}m, generatedAt=${input.now.toISOString()}`,
+        fpf: ['A.10'],
+      },
+    ],
+    fpfAnchors: VERCEL_SPEND_QA_ANCHORS,
+    summary:
+      `Vercel spend monitor configuration failed before metrics were queried: ${input.message}`,
+  };
+}
+
 export function createVercelSpendSnapshot(input: {
   functionDurationMetrics: unknown;
   legacyInvocationMetrics: unknown;
@@ -177,6 +217,17 @@ export function createVercelSpendSnapshot(input: {
   };
 }
 
+function emptyVercelSpendSnapshot(): VercelSpendMetricSnapshot {
+  return {
+    functionDurationGbhr: 0,
+    legacyFunctionInvocations: 0,
+    errorFunctionInvocations: 0,
+    functionDurationRows: [],
+    legacyInvocationRows: [],
+    errorInvocationRows: [],
+  };
+}
+
 export function parseVercelMetricsJson(output: string): unknown {
   const start = output.indexOf('{');
   const end = output.lastIndexOf('}');
@@ -195,6 +246,13 @@ export function formatVercelSpendMonitorMarkdown(report: VercelSpendMonitorRepor
   const anchorRows = report.fpfAnchors
     .map((anchor) => `- ${anchor.id} ${anchor.title}: ${anchor.use}`)
     .join('\n');
+  const observed = report.state === 'config_error'
+    ? '- Metrics were not queried because the monitor configuration failed before Vercel metrics access.'
+    : [
+      `- Function Duration: ${formatNumber(report.metrics.functionDurationGbhr)} GB-hours (~$${formatNumber(report.estimatedFunctionDurationUsd)})`,
+      `- Legacy function invocations: ${formatNumber(report.metrics.legacyFunctionInvocations)}`,
+      `- Function error-code invocations: ${formatNumber(report.metrics.errorFunctionInvocations)}`,
+    ].join('\n');
 
   return `# Vercel Spend Monitor
 
@@ -215,9 +273,7 @@ ${qualityRows}
 
 ## Observed
 
-- Function Duration: ${formatNumber(report.metrics.functionDurationGbhr)} GB-hours (~$${formatNumber(report.estimatedFunctionDurationUsd)})
-- Legacy function invocations: ${formatNumber(report.metrics.legacyFunctionInvocations)}
-- Function error-code invocations: ${formatNumber(report.metrics.errorFunctionInvocations)}
+${observed}
 
 ## Strategy Anchors
 

--- a/tests/vercel-spend-monitor.test.ts
+++ b/tests/vercel-spend-monitor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@rstest/core';
 
 import {
+  createVercelSpendConfigErrorReport,
   createVercelSpendSnapshot,
   DEFAULT_LEGACY_FUNCTION_DURATION_USD_PER_GBHR,
   DEFAULT_VERCEL_SPEND_LEGACY_PATH,
@@ -57,6 +58,26 @@ describe('Vercel spend monitor', () => {
     expect(report.state).toBe('breach');
     expect(report.summary).toContain('legacy MCP route reached 1 function invocations');
     expect(report.quality.find((item) => item.characteristic === 'legacy-route-isolation')?.status)
+      .toBe('fail');
+  });
+
+  it('reports missing Vercel metrics credentials as configuration failure, not spend breach', () => {
+    const report = createVercelSpendConfigErrorReport({
+      project: 'fpf-sh',
+      windowMinutes: 30,
+      legacyPath: DEFAULT_VERCEL_SPEND_LEGACY_PATH,
+      now: new Date('2026-05-31T01:56:00Z'),
+      thresholds: makeThresholds(),
+      message:
+        'VERCEL_TOKEN is required for scheduled Vercel metrics monitoring; configure the repository secret and rerun before treating this as a spend breach.',
+    });
+
+    expect(report.state).toBe('config_error');
+    expect(report.ok).toBe(false);
+    expect(report.breached).toBe(false);
+    expect(report.summary).toContain('failed before metrics were queried');
+    expect(report.summary).toContain('VERCEL_TOKEN is required');
+    expect(report.quality.find((item) => item.characteristic === 'monitor-configuration')?.status)
       .toBe('fail');
   });
 
@@ -119,6 +140,26 @@ ${JSON.stringify(metricResponse([]))}
     expect(markdown).toContain('Legacy function invocations: 0');
     expect(markdown).toContain('B.5.1');
     expect(markdown).toContain('A.10');
+  });
+
+  it('renders config failures without implying observed spend', () => {
+    const report = createVercelSpendConfigErrorReport({
+      project: 'fpf-sh',
+      windowMinutes: 30,
+      legacyPath: DEFAULT_VERCEL_SPEND_LEGACY_PATH,
+      now: new Date('2026-05-31T01:56:00Z'),
+      thresholds: makeThresholds(),
+      message: 'VERCEL_TOKEN is required for scheduled Vercel metrics monitoring.',
+    });
+
+    const markdown = formatVercelSpendMonitorMarkdown(report);
+    const observedSection = markdown.slice(markdown.indexOf('## Observed'));
+
+    expect(markdown).toContain('State: **config_error**');
+    expect(markdown).toContain('monitor-configuration | fail');
+    expect(markdown).toContain('Metrics were not queried');
+    expect(observedSection).not.toContain('Function Duration: 0 GB-hours');
+    expect(observedSection).not.toContain('Legacy function invocations: 0');
   });
 });
 

--- a/tests/vercel-spend-workflow.test.ts
+++ b/tests/vercel-spend-workflow.test.ts
@@ -1,5 +1,8 @@
 import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
 
 import { describe, expect, it } from '@rstest/core';
 
@@ -21,8 +24,14 @@ describe('Vercel spend monitor workflow', () => {
     expect(workflow).toContain(
       'bun run monitor:vercel:spend -- --format markdown --fail-on-breach',
     );
+    expect(workflow).not.toContain(
+      'VERCEL_TOKEN is required for scheduled Vercel metrics monitoring.',
+    );
     expect(workflow).toContain('Open or update spend breach issue');
     expect(workflow).toContain('Investigate Vercel spend monitor breach');
+    expect(workflow).toContain('failed or reported a breach');
+    expect(workflow).toContain('failed before querying metrics');
+    expect(workflow).toContain('Fix the monitor configuration or repository secrets');
     expect(workflow).toContain('Fail workflow on spend breach');
   });
 
@@ -35,4 +44,59 @@ describe('Vercel spend monitor workflow', () => {
       'bun scripts/monitor-vercel-spend.ts',
     );
   });
+
+  it('emits structured config_error outputs before spawning Vercel metrics without a token', () => {
+    const tempDir = mkdtempSync(resolve(tmpdir(), 'fpf-vercel-spend-'));
+    const outputPath = resolve(tempDir, 'github-output.txt');
+    const summaryPath = resolve(tempDir, 'github-summary.md');
+    const bun = resolveBunBinary();
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      GITHUB_OUTPUT: outputPath,
+      GITHUB_STEP_SUMMARY: summaryPath,
+      PATH: dirname(bun),
+    };
+    delete env.VERCEL_TOKEN;
+
+    try {
+      const result = spawnSync(
+        bun,
+        ['run', 'monitor:vercel:spend', '--', '--format', 'json'],
+        {
+          cwd: process.cwd(),
+          env,
+          encoding: 'utf8',
+        },
+      );
+
+      expect(result.status).toBe(1);
+      const report = JSON.parse(
+        result.stdout.slice(result.stdout.indexOf('{'), result.stdout.lastIndexOf('}') + 1),
+      ) as { state: string; breached: boolean; summary: string };
+      expect(report.state).toBe('config_error');
+      expect(report.breached).toBe(false);
+      expect(report.summary).toContain('before metrics were queried');
+
+      const outputs = readFileSync(outputPath, 'utf8');
+      expect(outputs).toContain('state=config_error');
+      expect(outputs).toContain('breached=false');
+      expect(outputs).toContain('function_duration_gbhr=not_queried');
+      expect(readFileSync(summaryPath, 'utf8')).toContain('Metrics were not queried');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });
+
+function resolveBunBinary(): string {
+  const npmExecPath = process.env.npm_execpath;
+  if (npmExecPath?.endsWith('/bun') || npmExecPath?.endsWith('/bun.exe')) {
+    return npmExecPath;
+  }
+
+  const lookup = spawnSync('which', ['bun'], { encoding: 'utf8' });
+  if (lookup.status !== 0) {
+    throw new Error('Could not locate bun binary for monitor CLI regression.');
+  }
+  return lookup.stdout.trim();
+}


### PR DESCRIPTION
## What

Fix the Vercel spend monitor so missing metrics credentials are reported as a monitor configuration failure instead of an ambiguous spend breach.

## Why

Issue #154 showed `unknown` metrics because the workflow exited before querying Vercel when `VERCEL_TOKEN` was missing. That alert should remain visible, but it should not imply Function Duration, legacy route traffic, or error-code invocations were observed.

## Type

- `fix` — bug fix

## Changes

- Add `config_error` monitor reports with `breached=false` and explicit “metrics not queried” output.
- Let the workflow call the monitor script directly so GitHub outputs and summaries are populated even when credentials are missing.
- Update the issue body and docs to tell operators to fix secrets/config before changing billing or deploy settings.
- Add helper, workflow, and CLI regression coverage for the missing-token path.

## Validation

- `bun run test -- tests/vercel-spend-monitor.test.ts tests/vercel-spend-workflow.test.ts` passes locally: 11 tests, 0 failures
- `bun run lint` passes locally: 0 lint errors, 0 type errors, 0 warnings
- `bun run check` passes locally
- `bun run test` passes locally: 363 tests, 0 failures
- No new warnings introduced
- `bun run vercel:origin:build` succeeds: docs build completed, Vercel origin bundle built, function bundle 99.99 MB with 140.01 MB fail-threshold headroom
- Relevant docs updated: README and automation playbook
- End-to-end verification command + output excerpt:
  - `GITHUB_OUTPUT=/tmp/fpf-vercel-spend-output.txt GITHUB_STEP_SUMMARY=/tmp/fpf-vercel-spend-summary.md env -u VERCEL_TOKEN bun run monitor:vercel:spend -- --format json`
  - exited `1`, emitted `state=config_error`, `breached=false`, `function_duration_gbhr=not_queried`, and summary `Metrics were not queried`
- Caveats or blocker:
  - Live Vercel metrics still cannot be queried until a repo owner/admin adds `VERCEL_TOKEN` with metrics access.
  - First autoreview run failed because the local Codex CLI does not support the helper default `gpt-5.5`; rerun with Codex engine and compatible `gpt-5.3-codex` was clean.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | local Codex Desktop |
| Prompt  | Implement triage plan, create PR, trigger subagent/autoreview, deploy/verify no degradation |

Related: #154

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/monitoring and docs only; no runtime, auth, or billing logic changes beyond clearer failure classification when secrets are missing.
> 
> **Overview**
> Missing **`VERCEL_TOKEN`** on the scheduled Vercel spend monitor is now a **`config_error`** (not a spend breach): the CLI skips Vercel metrics, sets **`breached=false`**, and still writes GitHub outputs/summaries with **`not_queried`** metric fields.
> 
> The workflow no longer fails early in shell; it branches issue text so **`config_error`** tells operators to fix secrets before treating alerts as spend evidence. **README** and the automation playbook document this behavior. Tests cover the new report path, markdown wording, workflow expectations, and a CLI regression without a token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 544275a1d91bb5dcaf2c3b8cb39153df7fb0c604. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->