### PR TITLE
fix(deploy): parse Vercel deployment URLs safely

### DIFF
--- a/scripts/deploy-production-surfaces.ts
+++ b/scripts/deploy-production-surfaces.ts
@@ -3,6 +3,11 @@ import { cp, mkdir, mkdtemp, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 
+import {
+  extractLatestProductionDeploymentUrl,
+  extractStagedDeploymentUrl,
+} from '../src/build/vercel-deploy-output.js';
+
 interface Surface {
   id: string;
   project: string;
@@ -117,7 +122,7 @@ async function deployStagedProduction(state: PreparedSurface): Promise<string> {
     configPath,
     ...vercelScopeArgs(),
   ]);
-  const deploymentUrl = extractDeploymentUrl(output, `${state.surface.id} staged deployment`);
+  const deploymentUrl = extractStagedDeploymentUrl(output, `${state.surface.id} staged deployment`);
   process.stdout.write(`Staged ${state.surface.id} production deployment: ${deploymentUrl}\n`);
   return deploymentUrl;
 }
@@ -133,7 +138,7 @@ function latestProductionDeploymentUrl(surface: Surface): string {
     '--yes',
     ...vercelScopeArgs(),
   ]);
-  const deploymentUrl = extractFirstDeploymentUrl(
+  const deploymentUrl = extractLatestProductionDeploymentUrl(
     output,
     `${surface.id} previous production deployment`,
   );
@@ -215,33 +220,6 @@ function requiredUrl(state: PreparedSurface): string {
     throw new Error(`Missing staged deployment URL for ${state.surface.id}.`);
   }
   return state.stagedDeploymentUrl;
-}
-
-function extractDeploymentUrl(output: string, label: string): string {
-  const matches = deploymentUrlMatches(output);
-  const url = matches.at(-1)?.[0];
-  if (!url) {
-    throw new Error(`Could not parse ${label} URL from Vercel output.`);
-  }
-  return url;
-}
-
-function extractFirstDeploymentUrl(output: string, label: string): string {
-  const matches = deploymentUrlMatches(output);
-  const url = matches[0]?.[0];
-  if (!url) {
-    throw new Error(`Could not parse ${label} URL from Vercel output.`);
-  }
-  return url;
-}
-
-function deploymentUrlMatches(output: string): RegExpMatchArray[] {
-  const sanitizedOutput = stripAnsi(output);
-  return [...sanitizedOutput.matchAll(/https:\/\/[^\s]+?\.vercel\.app\b/giu)];
-}
-
-function stripAnsi(value: string): string {
-  return value.replace(/\u001b\[[0-9;]*m/gu, '');
 }
 
 function runVercel(args: string[]): void {

--- a/src/build/vercel-deploy-output.ts
+++ b/src/build/vercel-deploy-output.ts
@@ -1,0 +1,122 @@
+export function extractStagedDeploymentUrl(output: string, label: string): string {
+  const jsonUrl = extractJsonDeploymentUrl(output);
+  if (jsonUrl) {
+    return jsonUrl;
+  }
+
+  const productionUrl = extractProductionLineDeploymentUrl(output);
+  if (productionUrl) {
+    return productionUrl;
+  }
+
+  return extractLastDeploymentUrl(output, label);
+}
+
+export function extractLatestProductionDeploymentUrl(output: string, label: string): string {
+  const matches = deploymentUrlMatches(output);
+  const url = matches[0];
+  if (!url) {
+    throw new Error(`Could not parse ${label} URL from Vercel output.`);
+  }
+  return url;
+}
+
+function extractLastDeploymentUrl(output: string, label: string): string {
+  const matches = deploymentUrlMatches(output);
+  const url = matches.at(-1);
+  if (!url) {
+    throw new Error(`Could not parse ${label} URL from Vercel output.`);
+  }
+  return url;
+}
+
+function extractJsonDeploymentUrl(output: string): string | undefined {
+  for (const jsonObject of topLevelJsonObjects(stripAnsi(output))) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonObject);
+    } catch {
+      continue;
+    }
+
+    const deployment = isRecord(parsed) ? parsed.deployment : undefined;
+    const url = isRecord(deployment) ? deployment.url : undefined;
+    if (typeof url === 'string' && isVercelDeploymentUrl(url)) {
+      return url;
+    }
+  }
+  return undefined;
+}
+
+function extractProductionLineDeploymentUrl(output: string): string | undefined {
+  for (const line of stripAnsi(output).split(/\r?\n/u)) {
+    if (!line.toLowerCase().includes('production')) continue;
+    const matches = deploymentUrlMatches(line);
+    const url = matches.at(-1);
+    if (url) {
+      return url;
+    }
+  }
+  return undefined;
+}
+
+function deploymentUrlMatches(output: string): string[] {
+  return [...stripAnsi(output).matchAll(/https:\/\/[^\s]+?\.vercel\.app\b/giu)]
+    .map((match) => match[0]);
+}
+
+function topLevelJsonObjects(output: string): string[] {
+  const objects: string[] = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < output.length; index += 1) {
+    const char = output[index];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === '{') {
+      if (depth === 0) {
+        start = index;
+      }
+      depth += 1;
+      continue;
+    }
+    if (char === '}' && depth > 0) {
+      depth -= 1;
+      if (depth === 0 && start >= 0) {
+        objects.push(output.slice(start, index + 1));
+        start = -1;
+      }
+    }
+  }
+
+  return objects;
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001b\[[0-9;]*m/gu, '');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isVercelDeploymentUrl(value: string): boolean {
+  return /^https:\/\/[^\s]+?\.vercel\.app$/iu.test(value);
+}

--- a/tests/vercel-deploy-output.test.ts
+++ b/tests/vercel-deploy-output.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from '@rstest/core';
+
+import {
+  extractLatestProductionDeploymentUrl,
+  extractStagedDeploymentUrl,
+} from '../src/build/vercel-deploy-output.js';
+
+describe('Vercel deploy output parsing', () => {
+  it('prefers the immutable deployment URL from structured deploy output', () => {
+    const output = [
+      '{',
+      '  "status": "ok",',
+      '  "deployment": {',
+      '    "url": "https://fpf-c1dxzt13t-venikmans-projects.vercel.app"',
+      '  }',
+      '}',
+      '▲ Production  https://fpf-c1dxzt13t-venikmans-projects.vercel.app',
+      '▲ Aliased     https://fpf-sh-venikmans-projects.vercel.app',
+    ].join('\n');
+
+    expect(extractStagedDeploymentUrl(output, 'website staged deployment')).toBe(
+      'https://fpf-c1dxzt13t-venikmans-projects.vercel.app',
+    );
+  });
+
+  it('falls back to the production line before generic URL matching', () => {
+    const output = [
+      'Inspect https://vercel.com/venikmans-projects/fpf-sh/deploy',
+      '▲ Production  https://fpf-c1dxzt13t-venikmans-projects.vercel.app',
+      '▲ Aliased     https://fpf-sh-venikmans-projects.vercel.app',
+    ].join('\n');
+
+    expect(extractStagedDeploymentUrl(output, 'website staged deployment')).toBe(
+      'https://fpf-c1dxzt13t-venikmans-projects.vercel.app',
+    );
+  });
+
+  it('keeps last-match semantics for unstructured deploy output', () => {
+    const output = [
+      'https://old-or-log-url.vercel.app',
+      'deployment complete at https://new-deployment.vercel.app',
+    ].join('\n');
+
+    expect(extractStagedDeploymentUrl(output, 'staged deployment')).toBe(
+      'https://new-deployment.vercel.app',
+    );
+  });
+
+  it('uses the first production deployment from Vercel ls output for rollback', () => {
+    const output = [
+      'Production deployments for venikmans-projects/fpf-sh',
+      '3h  https://current-production.vercel.app  Ready',
+      '4h  https://older-production.vercel.app    Ready',
+      'https://current-production.vercel.app',
+      'https://older-production.vercel.app',
+    ].join('\n');
+
+    expect(extractLatestProductionDeploymentUrl(output, 'previous website production')).toBe(
+      'https://current-production.vercel.app',
+    );
+  });
+});

--- a/tests/vercel-origin-config.test.ts
+++ b/tests/vercel-origin-config.test.ts
@@ -111,7 +111,8 @@ describe('Vercel deployment configs', () => {
     expect(deployHelper).toContain('vercelScopeArgs(args.scope)');
     expect(prodDeploy).toContain("'--skip-domain'");
     expect(prodDeploy).toContain("'promote'");
-    expect(prodDeploy).toContain('extractFirstDeploymentUrl');
+    expect(prodDeploy).toContain('extractStagedDeploymentUrl');
+    expect(prodDeploy).toContain('extractLatestProductionDeploymentUrl');
     expect(prodDeploy).toContain('rollbackPromotions');
     expect(prodDeploy).toContain('monitor:sync');
     expect(prodDeploy).toContain('monitor:content');


### PR DESCRIPTION
## Summary
- parse Vercel deploy output through a tested helper so production promotion uses immutable deployment URLs
- keep rollback lookup on the latest production deployment from Vercel ls output
- add focused parser coverage for JSON, production-line, fallback, and rollback URL shapes

## Validation
- bun run check
- bun run lint
- bun run test -- tests/vercel-deploy-output.test.ts tests/vercel-origin-config.test.ts

Follow-up to #158 after production deploy exposed Vercel CLI 54 output containing both immutable deployment URLs and project aliases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production promotion/rollback URL selection; wrong parsing could promote aliases or fail rollbacks, though behavior is covered by new unit tests.
> 
> **Overview**
> Production deploy URL parsing moves into **`src/build/vercel-deploy-output.ts`** so promotion and rollback no longer rely on ad-hoc regex in the deploy script.
> 
> **Staged deploys** (`extractStagedDeploymentUrl`) now resolve URLs in order: JSON `deployment.url`, then a **Production** line (avoiding **Aliased** project URLs from Vercel CLI 54), then last `.vercel.app` match for unstructured output. **Rollback** still uses the **first** URL from `vercel ls` via `extractLatestProductionDeploymentUrl`.
> 
> `scripts/deploy-production-surfaces.ts` imports these helpers and drops local parsers. **`tests/vercel-deploy-output.test.ts`** covers the priority chain; **`vercel-origin-config`** expectations are updated to the new symbol names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73abc987f6521dd142edc1e0c928b182592430e4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->