### PR TITLE
fix(deploy): alias canonical production domains

### DIFF
--- a/scripts/deploy-production-surfaces.ts
+++ b/scripts/deploy-production-surfaces.ts
@@ -4,6 +4,8 @@ import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 
 import {
+  extractInspectedDeployment,
+  extractInspectedDeploymentUrl,
   extractLatestProductionDeploymentUrl,
   extractStagedDeploymentUrl,
 } from '../src/build/vercel-deploy-output.js';
@@ -11,6 +13,7 @@ import {
 interface Surface {
   id: string;
   project: string;
+  domain: string;
   config: string;
   buildScript: string;
   verifyOutput: (outputDir: string) => Promise<void>;
@@ -19,9 +22,11 @@ interface Surface {
 interface PreparedSurface {
   surface: Surface;
   outputDir: string;
-  previousProductionUrl: string;
+  previousProjectProductionUrl: string;
+  previousDomainDeploymentUrl: string;
   stagedDeploymentUrl?: string;
-  promoted: boolean;
+  projectPromoted: boolean;
+  domainAliased: boolean;
 }
 
 const rootDir = process.cwd();
@@ -33,6 +38,7 @@ const surfaces: Surface[] = [
   {
     id: 'website',
     project: 'fpf-sh',
+    domain: 'fpf.sh',
     config: 'vercel.json',
     buildScript: 'vercel:website:build',
     verifyOutput: assertWebsiteOutput,
@@ -40,18 +46,22 @@ const surfaces: Surface[] = [
   {
     id: 'mcp',
     project: 'fpf-reference-mcp',
+    domain: 'mcp.fpf.sh',
     config: 'vercel.mcp.json',
     buildScript: 'vercel:mcp:build',
     verifyOutput: assertMcpOutput,
   },
 ];
+const canonicalWebsiteBaseUrl = `https://${requiredSurface('website').domain}`;
+const canonicalMcpStatusUrl = `https://${requiredSurface('mcp').domain}/api/fpf/status`;
 
 try {
   run('bun', ['run', 'deploy:validate']);
 
   const prepared: PreparedSurface[] = [];
   for (const surface of surfaces) {
-    const previousProductionUrl = latestProductionDeploymentUrl(surface);
+    const previousProjectProductionUrl = latestProjectProductionDeploymentUrl(surface);
+    const previousDomainDeploymentUrl = currentDomainDeploymentUrl(surface);
     run('bun', ['run', surface.buildScript]);
     await surface.verifyOutput(outputDir);
 
@@ -60,8 +70,10 @@ try {
     prepared.push({
       surface,
       outputDir: surfaceOutputDir,
-      previousProductionUrl,
-      promoted: false,
+      previousProjectProductionUrl,
+      previousDomainDeploymentUrl,
+      projectPromoted: false,
+      domainAliased: false,
     });
   }
 
@@ -72,9 +84,21 @@ try {
   try {
     for (const state of prepared) {
       promoteDeployment(state.surface, requiredUrl(state));
-      state.promoted = true;
+      state.projectPromoted = true;
+      aliasCanonicalDomain(state.surface, requiredUrl(state));
+      state.domainAliased = true;
+      assertCanonicalDomainDeployment(state);
     }
-    run('bun', ['run', 'monitor:sync', '--', '--format', 'markdown', '--fail-on-breach']);
+    run('bun', [
+      'run',
+      'monitor:sync',
+      '--',
+      '--format',
+      'markdown',
+      '--fail-on-breach',
+      '--status-url',
+      canonicalMcpStatusUrl,
+    ]);
     run('bun', [
       'run',
       'monitor:content',
@@ -84,6 +108,10 @@ try {
       '--format',
       'markdown',
       '--fail-on-breach',
+      '--base-url',
+      canonicalWebsiteBaseUrl,
+      '--status-url',
+      canonicalMcpStatusUrl,
     ]);
   } catch (error) {
     rollbackPromotions(prepared);
@@ -127,7 +155,7 @@ async function deployStagedProduction(state: PreparedSurface): Promise<string> {
   return deploymentUrl;
 }
 
-function latestProductionDeploymentUrl(surface: Surface): string {
+function latestProjectProductionDeploymentUrl(surface: Surface): string {
   const output = runVercelCapture([
     'ls',
     surface.project,
@@ -140,10 +168,49 @@ function latestProductionDeploymentUrl(surface: Surface): string {
   ]);
   const deploymentUrl = extractLatestProductionDeploymentUrl(
     output,
-    `${surface.id} previous production deployment`,
+    `${surface.id} previous project production deployment`,
   );
-  process.stdout.write(`Previous ${surface.id} production deployment: ${deploymentUrl}\n`);
+  process.stdout.write(`Previous ${surface.id} project production deployment: ${deploymentUrl}\n`);
   return deploymentUrl;
+}
+
+function currentDomainDeploymentUrl(surface: Surface): string {
+  const output = runVercelCapture(['inspect', surface.domain, ...vercelScopeArgs()]);
+  const deploymentUrl = extractInspectedDeploymentUrl(
+    output,
+    `${surface.id} previous canonical domain deployment`,
+  );
+  process.stdout.write(
+    `Previous ${surface.id} canonical domain deployment: ${deploymentUrl}\n`,
+  );
+  return deploymentUrl;
+}
+
+function assertCanonicalDomainDeployment(state: PreparedSurface): void {
+  const expectedUrl = requiredUrl(state);
+  const output = runVercelCapture(['inspect', state.surface.domain, ...vercelScopeArgs()]);
+  const inspected = extractInspectedDeployment(
+    output,
+    `${state.surface.id} canonical domain deployment`,
+  );
+  const status = inspected.status?.toLowerCase() ?? '';
+  const target = inspected.target?.toLowerCase();
+  const failures = [
+    inspected.url === expectedUrl ? undefined : `url=${inspected.url}`,
+    inspected.name === state.surface.project ? undefined : `name=${inspected.name ?? 'unknown'}`,
+    target === 'production' ? undefined : `target=${inspected.target ?? 'unknown'}`,
+    status.includes('ready') ? undefined : `status=${inspected.status ?? 'unknown'}`,
+  ].filter((failure): failure is string => Boolean(failure));
+
+  if (failures.length > 0) {
+    throw new Error(
+      `${state.surface.domain} did not resolve to ${state.surface.project} ${expectedUrl}: ${failures.join(', ')}`,
+    );
+  }
+
+  process.stdout.write(
+    `Verified ${state.surface.domain} -> ${inspected.name} ${inspected.url} (${inspected.target}, ${inspected.status})\n`,
+  );
 }
 
 function promoteDeployment(surface: Surface, deploymentUrl: string): void {
@@ -158,17 +225,35 @@ function promoteDeployment(surface: Surface, deploymentUrl: string): void {
   ]);
 }
 
+function aliasCanonicalDomain(surface: Surface, deploymentUrl: string): void {
+  process.stdout.write(
+    `Aliasing ${surface.domain} to ${surface.id} deployment: ${deploymentUrl}\n`,
+  );
+  runVercel(['alias', 'set', deploymentUrl, surface.domain, ...vercelScopeArgs()]);
+}
+
 function rollbackPromotions(states: PreparedSurface[]): void {
   const rollbackFailures: string[] = [];
   for (const state of [...states].reverse()) {
-    if (!state.promoted) continue;
-    try {
-      process.stderr.write(
-        `Rolling back ${state.surface.id} to ${state.previousProductionUrl}\n`,
-      );
-      promoteDeployment(state.surface, state.previousProductionUrl);
-    } catch (error) {
-      rollbackFailures.push(`${state.surface.id}: ${errorMessage(error)}`);
+    if (state.projectPromoted) {
+      try {
+        process.stderr.write(
+          `Rolling back ${state.surface.id} project aliases to ${state.previousProjectProductionUrl}\n`,
+        );
+        promoteDeployment(state.surface, state.previousProjectProductionUrl);
+      } catch (error) {
+        rollbackFailures.push(`${state.surface.id} project aliases: ${errorMessage(error)}`);
+      }
+    }
+    if (state.projectPromoted || state.domainAliased) {
+      try {
+        process.stderr.write(
+          `Rolling back ${state.surface.domain} to ${state.previousDomainDeploymentUrl}\n`,
+        );
+        aliasCanonicalDomain(state.surface, state.previousDomainDeploymentUrl);
+      } catch (error) {
+        rollbackFailures.push(`${state.surface.domain}: ${errorMessage(error)}`);
+      }
     }
   }
 
@@ -232,6 +317,14 @@ function runVercelCapture(args: string[]): string {
 
 function vercelScopeArgs(): string[] {
   return scope ? ['--scope', scope] : [];
+}
+
+function requiredSurface(id: string): Surface {
+  const surface = surfaces.find((candidate) => candidate.id === id);
+  if (!surface) {
+    throw new Error(`Missing ${id} deployment surface.`);
+  }
+  return surface;
 }
 
 function run(command: string, args: string[], options?: { capture?: boolean }): string {

--- a/src/build/vercel-deploy-output.ts
+++ b/src/build/vercel-deploy-output.ts
@@ -1,3 +1,10 @@
+export interface InspectedDeployment {
+  name?: string;
+  status?: string;
+  target?: string;
+  url: string;
+}
+
 export function extractStagedDeploymentUrl(output: string, label: string): string {
   const jsonUrl = extractJsonDeploymentUrl(output);
   if (jsonUrl) {
@@ -19,6 +26,41 @@ export function extractLatestProductionDeploymentUrl(output: string, label: stri
     throw new Error(`Could not parse ${label} URL from Vercel output.`);
   }
   return url;
+}
+
+export function extractInspectedDeploymentUrl(output: string, label: string): string {
+  return extractInspectedDeployment(output, label).url;
+}
+
+export function extractInspectedDeployment(
+  output: string,
+  label: string,
+): InspectedDeployment {
+  const details: Partial<InspectedDeployment> = {};
+  for (const line of stripAnsi(output).split(/\r?\n/u)) {
+    const fields = line.trim().split(/\s+/u);
+    const key = fields[0]?.toLowerCase();
+    if (key === 'name' || key === 'status' || key === 'target') {
+      details[key] = fields.slice(1).join(' ');
+      continue;
+    }
+    if (key === 'url') {
+      const url = fields.find(isVercelDeploymentUrl);
+      if (url) {
+        details.url = url;
+      }
+    }
+  }
+
+  if (!details.url) {
+    const matches = deploymentUrlMatches(output);
+    details.url = matches.length === 1 ? matches[0] : undefined;
+  }
+
+  if (!details.url) {
+    throw new Error(`Could not parse unique ${label} URL from Vercel inspect output.`);
+  }
+  return details as InspectedDeployment;
 }
 
 function extractLastDeploymentUrl(output: string, label: string): string {

--- a/tests/deploy-production-surfaces-workflow.test.ts
+++ b/tests/deploy-production-surfaces-workflow.test.ts
@@ -1,0 +1,263 @@
+import { spawnSync } from 'node:child_process';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from '@rstest/core';
+
+const oldWebsiteDeployment = 'https://fpf-oldsite-venikmans-projects.vercel.app';
+const newWebsiteDeployment = 'https://fpf-newsite-venikmans-projects.vercel.app';
+const oldMcpDeployment = 'https://fpf-memory-old-venikmans-projects.vercel.app';
+const newMcpDeployment = 'https://fpf-reference-new-venikmans-projects.vercel.app';
+
+let tempRoot: string | undefined;
+
+describe('production deployment workflow', () => {
+  afterEach(async () => {
+    if (tempRoot) {
+      await rm(tempRoot, { recursive: true, force: true });
+      tempRoot = undefined;
+    }
+  });
+
+  it('aliases mcp.fpf.sh from the old fpf-memory deployment to the new fpf-reference deployment', async () => {
+    const { logPath, env } = await createStubbedDeploymentWorkspace();
+
+    const result = runProductionDeploy(env);
+
+    expect(result.status).toBe(0);
+    const commands = await readCommands(logPath);
+    const mcpInspect = indexOfCommand(commands, 'inspect mcp.fpf.sh --scope team_test');
+    const mcpDeploy = indexOfCommand(commands, 'deploy ', 'mcp-deploy', '--skip-domain');
+    const mcpPromote = indexOfCommand(commands, `promote ${newMcpDeployment}`);
+    const mcpAlias = indexOfCommand(
+      commands,
+      `alias set ${newMcpDeployment} mcp.fpf.sh --scope team_test`,
+    );
+    const mcpVerify = lastIndexOfCommand(commands, 'inspect mcp.fpf.sh --scope team_test');
+
+    expect(mcpInspect).toBeGreaterThan(-1);
+    expect(mcpDeploy).toBeGreaterThan(mcpInspect);
+    expect(mcpPromote).toBeGreaterThan(mcpDeploy);
+    expect(mcpAlias).toBeGreaterThan(mcpPromote);
+    expect(mcpVerify).toBeGreaterThan(mcpAlias);
+    expect(commands).toContain(
+      'bun run monitor:sync -- --format markdown --fail-on-breach --status-url https://mcp.fpf.sh/api/fpf/status',
+    );
+    expect(commands).toContain(
+      'bun run monitor:content -- --mode live --format markdown --fail-on-breach --base-url https://fpf.sh --status-url https://mcp.fpf.sh/api/fpf/status',
+    );
+    expect(
+      commands.some((command) =>
+        command.includes(`alias set ${oldMcpDeployment} mcp.fpf.sh`),
+      ),
+    ).toBe(false);
+  });
+
+  it('restores the canonical MCP domain when aliasing fails after project promotion', async () => {
+    const { logPath, env } = await createStubbedDeploymentWorkspace({
+      failAliasDeployment: newMcpDeployment,
+    });
+
+    const result = runProductionDeploy(env);
+
+    expect(result.status).not.toBe(0);
+    const commands = await readCommands(logPath);
+    const failedAlias = indexOfCommand(
+      commands,
+      `alias set ${newMcpDeployment} mcp.fpf.sh --scope team_test`,
+    );
+    const rollbackAlias = indexOfCommand(
+      commands,
+      `alias set ${oldMcpDeployment} mcp.fpf.sh --scope team_test`,
+    );
+
+    expect(failedAlias).toBeGreaterThan(-1);
+    expect(rollbackAlias).toBeGreaterThan(failedAlias);
+  });
+});
+
+async function createStubbedDeploymentWorkspace(options?: {
+  failAliasDeployment?: string;
+}): Promise<{ env: NodeJS.ProcessEnv; logPath: string }> {
+  tempRoot = await mkdtemp(resolve(tmpdir(), 'fpf-prod-deploy-test-'));
+  const binDir = resolve(tempRoot, 'bin');
+  await mkdir(binDir, { recursive: true });
+  const logPath = resolve(tempRoot, 'commands.log');
+
+  await writeExecutable(
+    resolve(binDir, 'bun'),
+    `#!/bin/sh
+set -eu
+printf 'bun %s\\n' "$*" >> "$FPF_DEPLOY_COMMAND_LOG"
+if [ "$1" = "run" ]; then
+  case "$2" in
+    deploy:validate|monitor:sync|monitor:content)
+      exit 0
+      ;;
+    vercel:website:build)
+      rm -rf .vercel/output
+      mkdir -p .vercel/output/static
+      printf '<html></html>\\n' > .vercel/output/static/index.html
+      printf '{}\\n' > .vercel/output/static/fpf-publication-manifest.json
+      exit 0
+      ;;
+    vercel:mcp:build)
+      rm -rf .vercel/output
+      mkdir -p .vercel/output/functions/_mcp.func/hosted
+      printf 'export default {}\\n' > .vercel/output/functions/_mcp.func/index.mjs
+      printf '{}\\n' > .vercel/output/functions/_mcp.func/hosted/manifest.json
+      exit 0
+      ;;
+  esac
+fi
+echo "unexpected bun command: $*" >&2
+exit 64
+`,
+  );
+
+  await writeExecutable(
+    resolve(binDir, 'npx'),
+    `#!/bin/sh
+set -eu
+printf 'npx %s\\n' "$*" >> "$FPF_DEPLOY_COMMAND_LOG"
+if [ "$1" = "--yes" ] && [ "$2" = "vercel@latest" ]; then
+  shift 2
+fi
+command="$1"
+shift
+case "$command" in
+  ls)
+    project="$1"
+    if [ "$project" = "fpf-sh" ]; then
+      printf 'Production deployments for fpf-sh\\n1m  ${oldWebsiteDeployment}  Ready\\n${oldWebsiteDeployment}\\n'
+      exit 0
+    fi
+    if [ "$project" = "fpf-reference-mcp" ]; then
+      printf 'Production deployments for fpf-reference-mcp\\n1m  ${oldMcpDeployment}  Ready\\n${oldMcpDeployment}\\n'
+      exit 0
+    fi
+    ;;
+  inspect)
+    domain="$1"
+    if [ "$domain" = "fpf.sh" ]; then
+      deployment="$(cat "$FPF_FAKE_WEBSITE_DOMAIN_FILE")"
+      printf 'General\\n  name  fpf-sh\\n  target  production\\n  status  ● Ready\\n  url  %s\\nAliases\\n  https://fpf.sh\\n' "$deployment"
+      exit 0
+    fi
+    if [ "$domain" = "mcp.fpf.sh" ]; then
+      deployment="$(cat "$FPF_FAKE_MCP_DOMAIN_FILE")"
+      name="fpf-memory-mcp"
+      case "$deployment" in
+        *fpf-reference*) name="fpf-reference-mcp" ;;
+      esac
+      printf 'General\\n  name  %s\\n  target  production\\n  status  ● Ready\\n  url  %s\\nAliases\\n  https://mcp.fpf.sh\\n' "$name" "$deployment"
+      exit 0
+    fi
+    ;;
+  link)
+    exit 0
+    ;;
+  deploy)
+    deploy_root="$1"
+    case "$deploy_root" in
+      *website-deploy*)
+        printf '{"deployment":{"url":"${newWebsiteDeployment}"}}\\n'
+        exit 0
+        ;;
+      *mcp-deploy*)
+        printf '{"deployment":{"url":"${newMcpDeployment}"}}\\n'
+        exit 0
+        ;;
+    esac
+    ;;
+  promote)
+    exit 0
+    ;;
+  alias)
+    subcommand="$1"
+    deployment="$2"
+    domain="$3"
+    if [ "$subcommand" = "set" ] && [ "$deployment" = "$FPF_FAKE_FAIL_ALIAS_DEPLOYMENT" ]; then
+      echo "fake alias failure for $deployment" >&2
+      exit 70
+    fi
+    if [ "$subcommand" = "set" ] && [ "$domain" = "fpf.sh" ]; then
+      printf '%s\\n' "$deployment" > "$FPF_FAKE_WEBSITE_DOMAIN_FILE"
+      exit 0
+    fi
+    if [ "$subcommand" = "set" ] && [ "$domain" = "mcp.fpf.sh" ]; then
+      printf '%s\\n' "$deployment" > "$FPF_FAKE_MCP_DOMAIN_FILE"
+      exit 0
+    fi
+    exit 0
+    ;;
+esac
+echo "unexpected npx command: $command $*" >&2
+exit 65
+`,
+  );
+  const websiteDomainFile = resolve(tempRoot, 'website-domain.txt');
+  const mcpDomainFile = resolve(tempRoot, 'mcp-domain.txt');
+  await writeFile(websiteDomainFile, `${oldWebsiteDeployment}\n`);
+  await writeFile(mcpDomainFile, `${oldMcpDeployment}\n`);
+
+  return {
+    logPath,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ''}`,
+      FPF_DEPLOY_COMMAND_LOG: logPath,
+      FPF_FAKE_FAIL_ALIAS_DEPLOYMENT: options?.failAliasDeployment ?? '',
+      FPF_FAKE_MCP_DOMAIN_FILE: mcpDomainFile,
+      FPF_FAKE_WEBSITE_DOMAIN_FILE: websiteDomainFile,
+      FPF_VERCEL_SCOPE: 'team_test',
+    },
+  };
+}
+
+function runProductionDeploy(env: NodeJS.ProcessEnv): ReturnType<typeof spawnSync> {
+  if (!tempRoot) {
+    throw new Error('Missing deployment test workspace.');
+  }
+  const bunPath = resolveBunExecutable();
+  const scriptPath = resolve(process.cwd(), 'scripts/deploy-production-surfaces.ts');
+  return spawnSync(bunPath, [scriptPath], {
+    cwd: tempRoot,
+    encoding: 'utf8',
+    env,
+  });
+}
+
+function resolveBunExecutable(): string {
+  const result = spawnSync('which', ['bun'], { encoding: 'utf8' });
+  const path = result.stdout.trim();
+  if (result.status !== 0 || !path) {
+    throw new Error('Could not resolve bun executable for deployment workflow test.');
+  }
+  return path;
+}
+
+async function writeExecutable(path: string, content: string): Promise<void> {
+  await writeFile(path, content);
+  await chmod(path, 0o755);
+}
+
+async function readCommands(logPath: string): Promise<string[]> {
+  return (await readFile(logPath, 'utf8')).trim().split('\n');
+}
+
+function indexOfCommand(commands: string[], ...needles: string[]): number {
+  return commands.findIndex((command) =>
+    needles.every((needle) => command.includes(needle)),
+  );
+}
+
+function lastIndexOfCommand(commands: string[], ...needles: string[]): number {
+  for (let index = commands.length - 1; index >= 0; index -= 1) {
+    if (needles.every((needle) => commands[index]?.includes(needle))) {
+      return index;
+    }
+  }
+  return -1;
+}

--- a/tests/vercel-deploy-output.test.ts
+++ b/tests/vercel-deploy-output.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from '@rstest/core';
 
 import {
+  extractInspectedDeployment,
+  extractInspectedDeploymentUrl,
   extractLatestProductionDeploymentUrl,
   extractStagedDeploymentUrl,
 } from '../src/build/vercel-deploy-output.js';
@@ -57,6 +59,43 @@ describe('Vercel deploy output parsing', () => {
 
     expect(extractLatestProductionDeploymentUrl(output, 'previous website production')).toBe(
       'https://current-production.vercel.app',
+    );
+  });
+
+  it('uses the inspected deployment URL instead of custom aliases', () => {
+    const output = [
+      'Fetching deployment "mcp.fpf.sh" in venikmans-projects',
+      '  General',
+      '    id\t\tdpl_123',
+      '    name\tfpf-reference-mcp',
+      '    target\tproduction',
+      '    status\t● Ready',
+      '    url\t\thttps://fpf-reference-lurp5nppz-venikmans-projects.vercel.app',
+      '  Aliases',
+      '    ╶ https://mcp.fpf.sh',
+      '    ╶ https://fpf-reference-mcp-venikmans-projects.vercel.app',
+    ].join('\n');
+
+    expect(extractInspectedDeploymentUrl(output, 'inspected deployment')).toBe(
+      'https://fpf-reference-lurp5nppz-venikmans-projects.vercel.app',
+    );
+    expect(extractInspectedDeployment(output, 'inspected deployment')).toEqual({
+      name: 'fpf-reference-mcp',
+      status: '● Ready',
+      target: 'production',
+      url: 'https://fpf-reference-lurp5nppz-venikmans-projects.vercel.app',
+    });
+  });
+
+  it('rejects ambiguous inspected output without a deployment URL field', () => {
+    const output = [
+      'Aliases',
+      '  ╶ https://fpf-reference-mcp-venikmans-projects.vercel.app',
+      '  ╶ https://another-project-alias.vercel.app',
+    ].join('\n');
+
+    expect(() => extractInspectedDeploymentUrl(output, 'inspected deployment')).toThrow(
+      'Could not parse unique inspected deployment URL',
     );
   });
 });

--- a/tests/vercel-origin-config.test.ts
+++ b/tests/vercel-origin-config.test.ts
@@ -111,8 +111,12 @@ describe('Vercel deployment configs', () => {
     expect(deployHelper).toContain('vercelScopeArgs(args.scope)');
     expect(prodDeploy).toContain("'--skip-domain'");
     expect(prodDeploy).toContain("'promote'");
+    expect(prodDeploy).toContain("'alias', 'set'");
+    expect(prodDeploy).toContain('currentDomainDeploymentUrl');
+    expect(prodDeploy).toContain('aliasCanonicalDomain');
     expect(prodDeploy).toContain('extractStagedDeploymentUrl');
     expect(prodDeploy).toContain('extractLatestProductionDeploymentUrl');
+    expect(prodDeploy).toContain('extractInspectedDeploymentUrl');
     expect(prodDeploy).toContain('rollbackPromotions');
     expect(prodDeploy).toContain('monitor:sync');
     expect(prodDeploy).toContain('monitor:content');


### PR DESCRIPTION
## Summary
- explicitly bind fpf.sh and mcp.fpf.sh after staged production promotion
- track project production and canonical-domain targets separately for rollback
- make inspected deployment URL parsing fail on ambiguous output

## Validation
- bun run test -- tests/vercel-deploy-output.test.ts tests/vercel-origin-config.test.ts
- bun run check
- bun run lint
- bun run evaluate:work
- /Users/stas-studio/.codex/skills/autoreview/scripts/autoreview --mode local --engine copilot --model auto --prompt "Evidence from this checkout: npx --yes vercel@latest inspect fpf.sh and inspect mcp.fpf.sh both succeeded and returned deployment URL fields, so Vercel CLI 54.6.1 accepts these custom domains for inspect."

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live production routing and rollback for public domains; mistakes could mis-point fpf.sh or mcp.fpf.sh until manual fix.
> 
> **Overview**
> Production deploy now **promotes** staged builds and then **explicitly aliases** each surface’s canonical domain (`fpf.sh`, `mcp.fpf.sh`) via `vercel alias set`, instead of relying on promotion alone to move custom domains.
> 
> Rollback tracks **two independent targets**: the previous project production deployment (from `vercel ls`) and the deployment currently behind the canonical domain (from `vercel inspect` + new `extractInspectedDeploymentUrl`). On failure it can restore project aliases and domain aliases separately.
> 
> `extractInspectedDeploymentUrl` prefers the `url` field in inspect output over alias lines, and **throws** when only ambiguous URLs are present—so rollback snapshots don’t pick the wrong hostname.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec7c87817156021074e8ebdac163ab05c02cc91. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->