### PR TITLE
fix(deploy): route MCP homepage through function

### DIFF
--- a/src/build/vercel-origin-build.ts
+++ b/src/build/vercel-origin-build.ts
@@ -12,6 +12,7 @@ import {
 } from '../core/constants.js';
 import {
   HOSTED_FPF_STATUS_ROUTE,
+  HOSTED_HOME_ROUTES,
   HOSTED_MCP_ROUTES,
 } from '../composition/hosted.js';
 
@@ -147,6 +148,7 @@ export function createVercelMcpOutputConfig(): VercelDeploymentOutputConfig {
   return {
     version: 3,
     routes: [
+      ...HOSTED_HOME_ROUTES.map((route) => ({ src: `^${route}$`, dest })),
       { src: `^${HOSTED_FPF_STATUS_ROUTE}$`, dest },
       ...HOSTED_MCP_ROUTES.map((route) => ({ src: `^${route}$`, dest })),
     ],

--- a/tests/vercel-origin-config.test.ts
+++ b/tests/vercel-origin-config.test.ts
@@ -10,6 +10,7 @@ import {
   createVercelWebsiteOutputConfig,
 } from '../src/build/vercel-origin-build.js';
 import {
+  HOSTED_HOME_ROUTES,
   HOSTED_MCP_ROUTE,
   LEGACY_HOSTED_MCP_ROUTE,
 } from '../src/composition/hosted.js';
@@ -170,6 +171,17 @@ describe('Vercel deployment configs', () => {
     });
   });
 
+  it('routes hosted home pages through the MCP deployment function', () => {
+    const config = createVercelMcpOutputConfig();
+
+    for (const route of HOSTED_HOME_ROUTES) {
+      expect(config.routes).toContainEqual({
+        src: `^${route}$`,
+        dest: '/_mcp',
+      });
+    }
+  });
+
   it('keeps website output static-only with clean URL fallback', () => {
     const config = createVercelWebsiteOutputConfig();
     const srcRoutes = config.routes.flatMap((route) =>
@@ -201,13 +213,16 @@ describe('Vercel deployment configs', () => {
     expect(ci).toContain('test -f .vercel/output/static/fpf-publication-manifest.json');
   });
 
-  it('keeps MCP output API-only without static docs routes', () => {
+  it('keeps MCP output function-only without static docs fallback routes', () => {
     const config = createVercelMcpOutputConfig();
     const srcRoutes = config.routes.flatMap((route) =>
       'src' in route ? [route.src] : [],
     );
 
     expect(config.routes.some((route) => 'handle' in route)).toBe(false);
+    for (const route of HOSTED_HOME_ROUTES) {
+      expect(srcRoutes).toContain(`^${route}$`);
+    }
     expect(srcRoutes).toContain(`^${HOSTED_FPF_STATUS_ROUTE}$`);
     expect(srcRoutes).toContain(`^${HOSTED_MCP_ROUTE}$`);
     expect(srcRoutes).toContain(`^${LEGACY_HOSTED_MCP_ROUTE}$`);


### PR DESCRIPTION
## What

Route the hosted MCP home pages (`/` and `/connect-mcp`) through the MCP Vercel function.

## Why

The hosted app already rendered the FPF Reference MCP connection page, but the generated MCP Vercel output only routed status and JSON-RPC paths to the function. As a result, `https://mcp.fpf.sh/` returned Vercel `404_NOT_FOUND` even though the MCP runtime was healthy.

## Type

- `fix` — bug fix

## Changes

- Adds `HOSTED_HOME_ROUTES` to the generated MCP Vercel route table.
- Adds focused coverage that the MCP deployment routes homepage paths through `/_mcp` while still avoiding static docs fallback routes.

## Validation

- `bunx rstest run tests/vercel-origin-config.test.ts tests/hosted-home-page.test.ts` passed: 18 tests.
- `bun run vercel:mcp:build` passed: bundle 99.92 MB, fail-threshold headroom 140.08 MB.
- `bun run vercel:mcp:deploy:prod` passed and aliased `https://mcp.fpf.sh` to `https://fpf-reference-7cp4fqn90-venikmans-projects.vercel.app`.
- `curl https://mcp.fpf.sh/` returned HTTP 200 and `<title>FPF Reference MCP</title>`.
- `curl https://mcp.fpf.sh/connect-mcp` returned HTTP 200 and `<title>FPF Reference MCP</title>`.
- `curl https://mcp.fpf.sh/api/fpf/status` returned HTTP 200 with `status: ok`.
- `FPF_MCP_SMOKE_URL=https://mcp.fpf.sh/api/mcp/fpf_reference/mcp bun run smoke:mcp:http` passed: initialized true, public tools listed, query status ok.
- `bun run check` passed.
- `git diff --check` passed.
- Caveats or blocker: None.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added.
- No vector database or remote indexing introduced.
- No Python code added.
- MCP tool contracts are unchanged in `src/mcp/tool-contracts.ts`.

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | Codex Desktop |
| Prompt  | our mcp server homepage is down |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy routing-only change with no auth, data, or MCP contract changes; validated by config tests and production curls.
> 
> **Overview**
> The MCP Vercel deployment config now sends **`HOSTED_HOME_ROUTES`** (`/` and `/connect-mcp`) to the **`/_mcp`** function, alongside existing status and MCP JSON-RPC routes. Previously those paths were not in the generated route table, so the hosted connection homepage could 404 even when the MCP runtime was fine.
> 
> Tests assert each home route maps to **`/_mcp`**, and the “function-only” MCP output test now also expects home paths while still excluding static **`^/(.*)$`** fallback routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10c15841caeecb0768a3187436fb10fce183fc5b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->