### PR TITLE
docs: add executive production checklist

### DIFF
--- a/docs/automation-playbook.md
+++ b/docs/automation-playbook.md
@@ -92,6 +92,54 @@ A PR may be merged by the review/merge role only when:
 
 If any condition is missing, the role should report the exact blocker rather than waiting silently.
 
+## Executive Production Checklist
+
+Use this checklist before declaring FPF Reference production healthy, after a deploy, after an incident fix, and in any manager brief.
+
+Done means each claim has current evidence. Do not treat a green local build, a successful deploy, or a healthy API endpoint as enough by itself.
+
+1. **User-visible surfaces**
+   - `https://fpf.sh/` returns `200` and renders the FPF Reference site.
+   - `https://mcp.fpf.sh/` returns `200` and renders the FPF Reference MCP connection page.
+   - `https://mcp.fpf.sh/connect-mcp` returns `200` and shows the canonical `fpf_reference` endpoint.
+
+2. **MCP protocol surface**
+   - `https://mcp.fpf.sh/api/fpf/status` returns `200` with `status: ok`.
+   - `GET https://mcp.fpf.sh/api/mcp/fpf_reference/mcp` returns the expected method-level response, not a Vercel `404`.
+   - JSON-RPC initialize and one tool call succeed against `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`.
+   - The public tool list is limited to the intended public tools.
+
+3. **Publication freshness**
+   - Hosted status `publication.sourceHash`, `runtime.sourceHash`, and `runtime.currentSourceHash` match.
+   - Hosted status reports `fresh: true`.
+   - The upstream ref in hosted status matches the committed `published/current/manifest.json` for the release being claimed.
+
+4. **Deployment ownership**
+   - `vercel inspect fpf.sh` points to the `fpf-sh` production deployment.
+   - `vercel inspect mcp.fpf.sh` points to the `fpf-reference-mcp` production deployment.
+   - Canonical domains are explicitly aliased after deploy; project production promotion alone is not treated as proof.
+
+5. **Route shape**
+   - Website output remains static-only and has no MCP function routes.
+   - MCP output routes `/`, `/connect-mcp`, `/api/fpf/status`, and the canonical MCP JSON-RPC path through the MCP function.
+   - Legacy compatibility routes are either blocked intentionally or documented with a current mitigation reason.
+
+6. **Quality gates**
+   - The closest focused tests for the changed surface pass.
+   - `bun run check` passes for code changes.
+   - The closest deploy or build command for the changed surface passes.
+   - GitHub PR checks are green before the fix is treated as merged product state.
+
+7. **Cost and risk controls**
+   - MCP function bundle size remains within the configured threshold.
+   - Vercel spend monitor has no current function-duration, legacy-route, or error-code breach.
+   - The rollback target is known before production alias changes.
+
+8. **Evidence packet**
+   - Record exact commands, URLs, status codes, deployment URL, PR URL, and merge commit.
+   - Separate ability from performance: what the system can do, what was actually observed, and what remains unproven.
+   - State residual uncertainty explicitly, especially when relying on cached responses, local DNS, or pending external checks.
+
 ## fpf.sh Sync QA and Monitoring
 
 The production sync loop uses FPF as a quality model:


### PR DESCRIPTION
## What

Adds an Executive Production Checklist to the Automation Playbook.

## Why

After the MCP homepage outage, production health needs an explicit always-check list that separates live user surfaces, MCP protocol health, deployment ownership, route shape, quality gates, cost controls, and evidence packets. This keeps future manager briefs and incident closeouts from treating one green signal as complete proof.

## Type

- `docs` — documentation only

## Changes

- Adds an executive checklist to `docs/automation-playbook.md`.
- Covers user-visible URLs, MCP JSON-RPC checks, publication freshness, Vercel alias ownership, route shape, validation, cost/risk controls, and required evidence.

## Validation

- `bun run docs:build` passes locally.
- `git diff --check` passes locally.
- End-to-end verification command + output excerpt: `bun run docs:build` generated 982 docs files and completed the Rspress build successfully.
- Caveats or blocker: None.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added.
- No vector database or remote indexing introduced.
- No Python code added.
- MCP tool contracts are unchanged in `src/mcp/tool-contracts.ts`.

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | Codex Desktop |
| Prompt  | Push this code to the main branch record |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the automation playbook; no runtime, deploy, or MCP behavior changes.
> 
> **Overview**
> Adds an **Executive Production Checklist** to `docs/automation-playbook.md`, placed after merge policy and before fpf.sh sync monitoring.
> 
> The checklist defines when production can be declared healthy (deploys, incident closeouts, manager briefs) and requires **current evidence** for each claim—not a single green signal. Eight sections cover user-visible URLs (`fpf.sh`, `mcp.fpf.sh`), MCP protocol checks (status, JSON-RPC, public tools), publication/source-hash freshness, Vercel deployment ownership and aliases, static vs MCP route shape, quality gates (`bun run check`, focused tests, PR CI), cost/risk controls (bundle size, spend monitor, rollback target), and a mandatory **evidence packet** (commands, URLs, ability vs observed performance, residual uncertainty).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbd455727f2ac86500aa9fc82aa58dce908a85e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->