### PR TITLE
docs: clarify MCP GET health check

### DIFF
--- a/docs/automation-playbook.md
+++ b/docs/automation-playbook.md
@@ -105,7 +105,7 @@ Done means each claim has current evidence. Do not treat a green local build, a 
 
 2. **MCP protocol surface**
    - `https://mcp.fpf.sh/api/fpf/status` returns `200` with `status: ok`.
-   - `GET https://mcp.fpf.sh/api/mcp/fpf_reference/mcp` returns the expected method-level response, not a Vercel `404`.
+   - `GET https://mcp.fpf.sh/api/mcp/fpf_reference/mcp` returns `405` with the JSON-RPC disabled payload, not a Vercel `404`.
    - JSON-RPC initialize and one tool call succeed against `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`.
    - The public tool list is limited to the intended public tools.
 


### PR DESCRIPTION
## What

Clarifies the Executive Production Checklist entry for `GET https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`.

## Why

This addresses the review comment on PR #163. The MCP server intentionally returns `405` with the JSON-RPC disabled payload for standalone GET requests, so the checklist should name that exact expected response instead of saying only "expected method-level response".

## Type

- `docs` — documentation only

## Changes

- Updates `docs/automation-playbook.md` to require `405` with the JSON-RPC disabled payload, not a Vercel `404`.

## Validation

- `bun run docs:build` passes locally.
- `git diff --check` passes locally.
- End-to-end verification command + output excerpt: `bun run docs:build` generated 982 docs files and completed the Rspress build successfully.
- Caveats or blocker: Local worktree has unrelated uncommitted edits in `scripts/monitor-vercel-spend.ts` and `src/build/vercel-origin-build.ts`; this PR contains only `docs/automation-playbook.md`.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added.
- No vector database or remote indexing introduced.
- No Python code added.
- MCP tool contracts are unchanged in `src/mcp/tool-contracts.ts`.

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | Codex Desktop |
| Prompt  | have you check comments to PR? |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an operational checklist; no application or deployment logic is modified.
> 
> **Overview**
> Updates the **Executive Production Checklist** in `docs/automation-playbook.md` so the MCP health check for `GET https://mcp.fpf.sh/api/mcp/fpf_reference/mcp` matches production behavior: expect **`405`** with the **JSON-RPC disabled** body, explicitly **not** a Vercel **`404`**.
> 
> This aligns the playbook with the intentional standalone-GET response described in review feedback on PR #163; no runtime, routes, or MCP tool contracts change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2f1443a65efe5cae25da229058290c348d3b72c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->