### PR TITLE
fix(vercel): address spend monitor review comments

### DIFF
--- a/.github/workflows/vercel-spend-monitor.yml
+++ b/.github/workflows/vercel-spend-monitor.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   BUN_VERSION: '1.3.5'
   FPF_VERCEL_PROJECT: fpf-reference-mcp
-  FPF_VERCEL_SCOPE: venikmans-projects
+  FPF_VERCEL_SCOPE: team_CnO1I5xd2OS0lzbbc4RkW7Ym
   FPF_VERCEL_SPEND_WINDOW_MINUTES: ${{ github.event.inputs.window_minutes || '30' }}
   FPF_VERCEL_SPEND_MAX_FUNCTION_DURATION_GBHR: ${{ github.event.inputs.max_function_duration_gbhr || '0.25' }}
   FPF_VERCEL_SPEND_MAX_LEGACY_INVOCATIONS: '0'

--- a/scripts/monitor-vercel-spend.ts
+++ b/scripts/monitor-vercel-spend.ts
@@ -33,7 +33,7 @@ const scope = readOptionalString(flags, 'scope', process.env.FPF_VERCEL_SCOPE);
 const token = readOptionalString(
   flags,
   'token',
-  process.env.VERCEL_SPEND_MONITOR_TOKEN ?? process.env.VERCEL_TOKEN,
+  process.env.VERCEL_SPEND_MONITOR_TOKEN || process.env.VERCEL_TOKEN,
 );
 const windowMinutes = readPositiveNumber(
   flags,

--- a/tests/vercel-spend-workflow.test.ts
+++ b/tests/vercel-spend-workflow.test.ts
@@ -13,7 +13,7 @@ describe('Vercel spend monitor workflow', () => {
     expect(workflow).toContain("- cron: '*/15 * * * *'");
     expect(workflow).toContain('issues: write');
     expect(workflow).toContain('FPF_VERCEL_PROJECT: fpf-reference-mcp');
-    expect(workflow).toContain('FPF_VERCEL_SCOPE: venikmans-projects');
+    expect(workflow).toContain('FPF_VERCEL_SCOPE: team_CnO1I5xd2OS0lzbbc4RkW7Ym');
     expect(workflow).toContain('FPF_VERCEL_SPEND_WINDOW_MINUTES');
     expect(workflow).toContain('FPF_VERCEL_SPEND_MAX_FUNCTION_DURATION_GBHR');
     expect(workflow).toContain('FPF_VERCEL_SPEND_MAX_LEGACY_INVOCATIONS:');
@@ -51,5 +51,8 @@ describe('Vercel spend monitor workflow', () => {
     );
     expect(monitorScript).toContain('DEFAULT_VERCEL_SPEND_PROJECT');
     expect(monitorScript).toContain('VERCEL_SPEND_MONITOR_TOKEN');
+    expect(monitorScript).toContain(
+      'process.env.VERCEL_SPEND_MONITOR_TOKEN || process.env.VERCEL_TOKEN',
+    );
   });
 });


### PR DESCRIPTION
## What

Addresses the actionable review comments left on PR #165.

## Why

PR #165 was merged with two review comments still applicable: token fallback should still use `VERCEL_TOKEN` when `VERCEL_SPEND_MONITOR_TOKEN` is present but empty, and the spend monitor must query the same Vercel scope as production deploy automation.

## Type

- `fix` — bug fix

## Changes

- Uses `VERCEL_SPEND_MONITOR_TOKEN || VERCEL_TOKEN` for the monitor script token fallback.
- Restores the Vercel spend monitor workflow scope to `team_CnO1I5xd2OS0lzbbc4RkW7Ym`, matching production deploy automation.
- Updates focused workflow tests for both expectations.

## Validation

- `bunx rstest run tests/vercel-spend-workflow.test.ts` passed: 2 tests.
- `bun run check` passed.
- `bun run lint` passed with 0 lint errors, 0 type errors, and 0 warnings.
- `git diff --check` passed.
- End-to-end verification command + output excerpt: focused workflow test confirms the scheduled monitor scope and token fallback contract.
- Caveats or blocker: None.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added.
- No vector database or remote indexing introduced.
- No Python code added.
- MCP tool contracts are unchanged in `src/mcp/tool-contracts.ts`.

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Session | Codex Desktop |
| Prompt  | if its' ready to merge - do it |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI workflow env, local monitor script env resolution, and tests—no runtime MCP or auth surface changes.
> 
> **Overview**
> Fixes two post-merge review items on the **Vercel spend monitor** so scheduled guardrails query the right team and still authenticate when the dedicated secret is unset or empty.
> 
> **Scope:** `FPF_VERCEL_SCOPE` in `.github/workflows/vercel-spend-monitor.yml` is switched from `venikmans-projects` to **`team_CnO1I5xd2OS0lzbbc4RkW7Ym`**, aligning metrics with production deploy automation in `sync-fpf.yml`.
> 
> **Token fallback:** `scripts/monitor-vercel-spend.ts` now resolves the API token with **`VERCEL_SPEND_MONITOR_TOKEN || VERCEL_TOKEN`** instead of nullish coalescing (`??`), so an empty monitor token does not block falling back to `VERCEL_TOKEN`.
> 
> Workflow tests are updated to assert the new scope and token expression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 513fd35968cfd16246c47136cd7446478e0ff87a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->