### PR TITLE
fix(vercel): use metrics-accessible monitor scope

### DIFF
--- a/.github/workflows/vercel-spend-monitor.yml
+++ b/.github/workflows/vercel-spend-monitor.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   BUN_VERSION: '1.3.5'
   FPF_VERCEL_PROJECT: fpf-reference-mcp
-  FPF_VERCEL_SCOPE: team_CnO1I5xd2OS0lzbbc4RkW7Ym
+  FPF_VERCEL_SCOPE: venikmans-projects
   FPF_VERCEL_SPEND_WINDOW_MINUTES: ${{ github.event.inputs.window_minutes || '30' }}
   FPF_VERCEL_SPEND_MAX_FUNCTION_DURATION_GBHR: ${{ github.event.inputs.max_function_duration_gbhr || '0.25' }}
   FPF_VERCEL_SPEND_MAX_LEGACY_INVOCATIONS: '0'

--- a/tests/vercel-spend-workflow.test.ts
+++ b/tests/vercel-spend-workflow.test.ts
@@ -13,7 +13,7 @@ describe('Vercel spend monitor workflow', () => {
     expect(workflow).toContain("- cron: '*/15 * * * *'");
     expect(workflow).toContain('issues: write');
     expect(workflow).toContain('FPF_VERCEL_PROJECT: fpf-reference-mcp');
-    expect(workflow).toContain('FPF_VERCEL_SCOPE: team_CnO1I5xd2OS0lzbbc4RkW7Ym');
+    expect(workflow).toContain('FPF_VERCEL_SCOPE: venikmans-projects');
     expect(workflow).toContain('FPF_VERCEL_SPEND_WINDOW_MINUTES');
     expect(workflow).toContain('FPF_VERCEL_SPEND_MAX_FUNCTION_DURATION_GBHR');
     expect(workflow).toContain('FPF_VERCEL_SPEND_MAX_LEGACY_INVOCATIONS:');


### PR DESCRIPTION
## What

Restores the Vercel spend monitor workflow scope to venikmans-projects after the manual workflow dispatch proved the repository token cannot access team_CnO1I5xd2OS0lzbbc4RkW7Ym.

## Why

Run 26726380434 failed with Vercel scope-not-a before producing metrics when the workflow used the team id. The local monitor succeeds with venikmans-projects, and this keeps scheduled monitoring operational with the configured repository secrets.

## Validation

- bunx rstest run tests/vercel-spend-workflow.test.ts
- bun run check
- bun run lint
- git diff --check
- FPF_VERCEL_SCOPE=venikmans-projects bun run monitor:vercel:spend -- --project fpf-reference-mcp --window-minutes 30 --format markdown --fail-on-breach

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only scope change for the spend monitor workflow and its test; no auth, deploy, or application runtime logic changes.
> 
> **Overview**
> Updates the scheduled **Vercel spend monitor** workflow so `FPF_VERCEL_SCOPE` is **`venikmans-projects`** instead of the previous **team id** scope, matching what the repository’s Vercel token can use when calling metrics APIs.
> 
> The workflow test expectation for that env line is updated in lockstep so CI still asserts the configured scope string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 730787215278e4f4950c75db77ca3091c9c93bd7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->