### PR TITLE
Add semantic production smoke checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,13 @@ jobs:
           test -f "$VERCEL_MCP_FUNCTION_BUNDLE_PATH/hosted/fpf-index/snapshot.json"
           test ! -d .vercel/output/static
 
+      - name: Run semantic production smoke against local build
+        # Exercise the same semantic assertions used for production against
+        # local docs + hosted MCP surfaces. This catches name, route, status,
+        # and standalone GET drift without depending on live production from
+        # pull-request CI.
+        run: bun run smoke:production -- --local --format markdown --fail-on-breach
+
   # Single green check for branch protection: this is the only required
   # status. It goes green iff every parallel job above succeeded. The job
   # ID stays `ci` (no `name:` override) so the status-check context

--- a/.github/workflows/fpf-content-quality.yml
+++ b/.github/workflows/fpf-content-quality.yml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Evaluate hosted generated and curated pages
         run: bun run monitor:content -- --mode live --format markdown --fail-on-breach
+
+      - name: Evaluate semantic production smoke
+        run: bun run smoke:production -- --format markdown --fail-on-breach

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "evaluate:work": "bun src/cli.ts evaluate-work --target current-pr --base origin/main --format markdown",
     "stage:from-published": "bun scripts/stage-from-published.ts",
     "smoke:mcp:http": "bun scripts/smoke-hosted-mcp.ts",
+    "smoke:production": "bun scripts/smoke-production.ts",
     "bench:mcp": "bun scripts/bench-hosted-mcp.ts",
     "bench:mcp:qa": "bun scripts/bench-mcp-qa.ts",
     "bench:mcp:series": "bun scripts/bench-hosted-mcp-series.ts",

--- a/scripts/deploy-production-surfaces.ts
+++ b/scripts/deploy-production-surfaces.ts
@@ -113,6 +113,7 @@ try {
       '--status-url',
       canonicalMcpStatusUrl,
     ]);
+    run('bun', ['run', 'smoke:production', '--', '--format', 'markdown', '--fail-on-breach']);
   } catch (error) {
     rollbackPromotions(prepared);
     throw error;

--- a/scripts/smoke-production.ts
+++ b/scripts/smoke-production.ts
@@ -1,0 +1,206 @@
+import { appendFile, readFile } from 'node:fs/promises';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { extname, normalize, resolve, sep } from 'node:path';
+
+import {
+  DEFAULT_PRODUCTION_SMOKE_MCP_BASE_URL,
+  DEFAULT_PRODUCTION_SMOKE_WEBSITE_BASE_URL,
+  formatProductionSmokeMarkdown,
+  runProductionSmoke,
+  type ProductionSmokeReport,
+} from '../src/build/production-smoke.js';
+import vercelHandler from '../src/entrypoints/vercel-function.js';
+import {
+  parseFlagMap,
+  readPositiveInteger,
+  readString,
+} from './_args.js';
+
+const flags = parseFlagMap(process.argv.slice(2));
+const format = readString(flags, 'format', process.env.FPF_PRODUCTION_SMOKE_FORMAT ?? 'json');
+const failOnBreach = flags.has('fail-on-breach');
+const local = flags.has('local');
+const timeoutMs = readPositiveInteger(
+  flags,
+  'timeout-ms',
+  process.env.FPF_PRODUCTION_SMOKE_TIMEOUT_MS,
+  30_000,
+);
+
+const report = local
+  ? await runAgainstLocalServers()
+  : await runProductionSmoke({
+    websiteBaseUrl: readString(
+      flags,
+      'website-base-url',
+      process.env.FPF_PRODUCTION_SMOKE_WEBSITE_BASE_URL
+        ?? DEFAULT_PRODUCTION_SMOKE_WEBSITE_BASE_URL,
+    ),
+    mcpBaseUrl: readString(
+      flags,
+      'mcp-base-url',
+      process.env.FPF_PRODUCTION_SMOKE_MCP_BASE_URL
+        ?? DEFAULT_PRODUCTION_SMOKE_MCP_BASE_URL,
+    ),
+    timeoutMs,
+  });
+
+const markdown = formatProductionSmokeMarkdown(report);
+
+if (process.env.GITHUB_OUTPUT) {
+  await appendFile(process.env.GITHUB_OUTPUT, renderGithubOutput(report), 'utf8');
+}
+if (process.env.GITHUB_STEP_SUMMARY) {
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, markdown, 'utf8');
+}
+
+if (format === 'markdown') {
+  process.stdout.write(markdown);
+} else if (format === 'json') {
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+} else {
+  throw new Error('--format must be json or markdown.');
+}
+
+if (failOnBreach && report.breached) {
+  process.exitCode = 1;
+}
+
+async function runAgainstLocalServers(): Promise<ProductionSmokeReport> {
+  const docsOutDir = resolve(
+    readString(flags, 'docs-out-dir', process.env.FPF_DOCS_OUT_DIR ?? 'doc_build'),
+  );
+  const website = await listen(createStaticWebsiteServer(docsOutDir));
+  const mcp = await listen(createMcpServer());
+  try {
+    return await runProductionSmoke({
+      websiteBaseUrl: website.baseUrl,
+      mcpBaseUrl: mcp.baseUrl,
+      timeoutMs,
+    });
+  } finally {
+    await Promise.all([
+      closeServer(website.server),
+      closeServer(mcp.server),
+    ]);
+  }
+}
+
+function createStaticWebsiteServer(rootDir: string): Server {
+  return createServer((request, response) => {
+    serveStaticWebsite(rootDir, request, response).catch((error: unknown) => {
+      response.statusCode = 500;
+      response.setHeader('content-type', 'text/plain; charset=utf-8');
+      response.end(error instanceof Error ? error.message : String(error));
+    });
+  });
+}
+
+function createMcpServer(): Server {
+  return createServer((request, response) => {
+    vercelHandler(request, response).catch((error: unknown) => {
+      response.statusCode = 500;
+      response.setHeader('content-type', 'text/plain; charset=utf-8');
+      response.end(error instanceof Error ? error.message : String(error));
+    });
+  });
+}
+
+async function serveStaticWebsite(
+  rootDir: string,
+  request: IncomingMessage,
+  response: ServerResponse,
+): Promise<void> {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    response.statusCode = 405;
+    response.setHeader('allow', 'GET, HEAD');
+    response.end();
+    return;
+  }
+
+  const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+  const filePath = resolveStaticPath(rootDir, url.pathname);
+  const bytes = await readFile(filePath);
+  response.statusCode = 200;
+  response.setHeader('content-type', contentType(filePath));
+  response.setHeader('cache-control', 'no-store');
+  if (request.method === 'HEAD') {
+    response.end();
+    return;
+  }
+  response.end(bytes);
+}
+
+function resolveStaticPath(rootDir: string, pathname: string): string {
+  const decoded = decodeURIComponent(pathname);
+  const normalized = normalize(decoded).replace(/^(\.\.(\/|\\|$))+/u, '');
+  const relative =
+    normalized === sep || normalized === '/'
+      ? 'index.html'
+      : normalized.replace(/^[/\\]+/u, '').replace(/\/$/u, '/index.html');
+  const withHtml = extname(relative) ? relative : `${relative}.html`;
+  const filePath = resolve(rootDir, withHtml);
+  const rootWithSep = rootDir.endsWith(sep) ? rootDir : `${rootDir}${sep}`;
+  if (!filePath.startsWith(rootWithSep)) {
+    throw new Error(`Static path escapes docs output: ${pathname}`);
+  }
+  return filePath;
+}
+
+function contentType(filePath: string): string {
+  switch (extname(filePath)) {
+    case '.html':
+      return 'text/html; charset=utf-8';
+    case '.json':
+      return 'application/json; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.js':
+      return 'text/javascript; charset=utf-8';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+async function listen(server: Server): Promise<{ server: Server; baseUrl: string }> {
+  await new Promise<void>((resolveListen) => {
+    server.listen(0, '127.0.0.1', resolveListen);
+  });
+  const address = server.address();
+  if (typeof address !== 'object' || address === null) {
+    throw new Error('Local smoke server did not expose a TCP port.');
+  }
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => {
+      if (error) {
+        rejectClose(error);
+        return;
+      }
+      resolveClose();
+    });
+  });
+}
+
+function renderGithubOutput(report: ProductionSmokeReport): string {
+  return [
+    ['state', report.state],
+    ['ok', String(report.ok)],
+    ['breached', String(report.breached)],
+    ['website_base_url', report.websiteBaseUrl],
+    ['mcp_base_url', report.mcpBaseUrl],
+    ['expected_upstream_ref', report.expected.upstreamRef],
+    ['expected_source_hash', report.expected.sourceHash],
+    ['summary', report.summary],
+  ].map(([key, value]) => `${key}=${sanitizeOutputValue(value)}\n`).join('');
+}
+
+function sanitizeOutputValue(value: string): string {
+  return value.replace(/\r?\n/gu, ' ').trim();
+}

--- a/src/adapters/hosted/home-page.ts
+++ b/src/adapters/hosted/home-page.ts
@@ -436,6 +436,7 @@ export function renderHostedHomePage(): string {
           <span>Streamable HTTP endpoint</span>
           <code>${HOSTED_MCP_ENDPOINT}</code>
           <small>Legacy <code>${LEGACY_HOSTED_MCP_ENDPOINT}</code> is blocked during the May 2026 mitigation; use the endpoint above.</small>
+          <small>Browser GET returns <strong>405 Method Not Allowed</strong>; MCP clients should use POST Streamable HTTP JSON-RPC requests.</small>
         </div>
       </section>
 

--- a/src/build/production-smoke.ts
+++ b/src/build/production-smoke.ts
@@ -1,0 +1,619 @@
+import { validatePublishedSurface } from './published-surface.js';
+import {
+  HOSTED_FPF_STATUS_ROUTE,
+  HOSTED_MCP_ROUTE,
+} from '../composition/hosted.js';
+
+export const DEFAULT_PRODUCTION_SMOKE_WEBSITE_BASE_URL = 'https://fpf.sh';
+export const DEFAULT_PRODUCTION_SMOKE_MCP_BASE_URL = 'https://mcp.fpf.sh';
+export const PRODUCTION_SMOKE_CANONICAL_MCP_ENDPOINT =
+  `${DEFAULT_PRODUCTION_SMOKE_MCP_BASE_URL}${HOSTED_MCP_ROUTE}`;
+export const PRODUCTION_SMOKE_TIMEOUT_MS = 30_000;
+
+export const PRODUCTION_SMOKE_PUBLIC_TOOLS = [
+  'browse_fpf_catalog',
+  'search_fpf',
+  'ask_fpf',
+  'query_fpf_spec',
+  'read_fpf_doc',
+  'get_fpf_index_status',
+] as const;
+
+export interface ProductionSmokeConfig {
+  websiteBaseUrl?: string;
+  mcpBaseUrl?: string;
+  cwd?: string;
+  now?: Date;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  expectedPublication?: ExpectedPublication;
+}
+
+export interface ExpectedPublication {
+  upstreamRef: string;
+  sourceHash: string;
+  publishedAt?: string;
+}
+
+export type ProductionSmokeState = 'ok' | 'breach';
+export type ProductionSmokeStatus = 'pass' | 'fail';
+
+export interface ProductionSmokeCheck {
+  characteristic: string;
+  status: ProductionSmokeStatus;
+  evidence: string;
+  url?: string;
+}
+
+export interface ProductionSmokeReport {
+  state: ProductionSmokeState;
+  ok: boolean;
+  breached: boolean;
+  generatedAt: string;
+  websiteBaseUrl: string;
+  mcpBaseUrl: string;
+  expected: ExpectedPublication;
+  observed: {
+    statusEndpoint?: ObservedStatusEndpoint;
+    canonicalMcp?: ObservedMcpEndpoint;
+    standaloneMcpGet?: ObservedStandaloneGet;
+  };
+  checks: ProductionSmokeCheck[];
+  summary: string;
+}
+
+export interface ObservedStatusEndpoint {
+  servedAt?: string;
+  status: string;
+  publicationUpstreamRef?: string;
+  publicationSourceHash?: string;
+  publicationPublishedAt?: string;
+  runtimeBuiltAt?: string;
+  runtimeFresh?: boolean;
+  runtimeSourceHash?: string;
+  runtimeCurrentSourceHash?: string;
+  runtimeSnapshotSourceHash?: string;
+}
+
+export interface ObservedMcpEndpoint {
+  serverName?: string;
+  toolNames: string[];
+  statusToolSourceHash?: string;
+  statusToolFresh?: boolean;
+}
+
+export interface ObservedStandaloneGet {
+  status: number;
+  allow: string;
+  message?: string;
+}
+
+interface PageEvidence {
+  url: string;
+  status: number;
+  text: string;
+}
+
+interface JsonRpcResponse {
+  jsonrpc?: string;
+  id?: number | string | null;
+  result?: unknown;
+  error?: {
+    code?: number;
+    message?: string;
+  };
+}
+
+export async function runProductionSmoke(
+  config: ProductionSmokeConfig = {},
+): Promise<ProductionSmokeReport> {
+  const fetchImpl = config.fetchImpl ?? fetch;
+  const timeoutMs = config.timeoutMs ?? PRODUCTION_SMOKE_TIMEOUT_MS;
+  const websiteBaseUrl = normalizeBaseUrl(
+    config.websiteBaseUrl ?? DEFAULT_PRODUCTION_SMOKE_WEBSITE_BASE_URL,
+  );
+  const mcpBaseUrl = normalizeBaseUrl(
+    config.mcpBaseUrl ?? DEFAULT_PRODUCTION_SMOKE_MCP_BASE_URL,
+  );
+  const expected = config.expectedPublication ?? await readExpectedPublication(config.cwd);
+  const urls = buildSmokeUrls(websiteBaseUrl, mcpBaseUrl);
+
+  const checks: ProductionSmokeCheck[] = [];
+  const [websiteRoot, websiteConnect, mcpRoot, mcpConnect] = await Promise.all([
+    fetchPage(fetchImpl, urls.websiteRoot, timeoutMs),
+    fetchPage(fetchImpl, urls.websiteConnect, timeoutMs),
+    fetchPage(fetchImpl, urls.mcpRoot, timeoutMs),
+    fetchPage(fetchImpl, urls.mcpConnect, timeoutMs),
+  ]);
+
+  checks.push(
+    ...checkCanonicalOnboardingPage('fpf.sh root', websiteRoot),
+    ...checkCanonicalOnboardingPage('fpf.sh connect-mcp', websiteConnect),
+    ...checkCanonicalOnboardingPage('mcp.fpf.sh root', mcpRoot),
+    ...checkCanonicalOnboardingPage('mcp.fpf.sh connect-mcp', mcpConnect),
+    ...checkGetDocs(websiteConnect),
+    ...checkGetDocs(mcpConnect),
+  );
+
+  const statusEndpoint = await fetchStatusEndpoint(fetchImpl, urls.mcpStatus, timeoutMs);
+  checks.push(...checkStatusEndpoint(statusEndpoint, expected, urls.mcpStatus));
+
+  const canonicalMcp = await checkCanonicalMcpEndpoint(
+    fetchImpl,
+    urls.canonicalMcp,
+    expected,
+    timeoutMs,
+  );
+  checks.push(...canonicalMcp.checks);
+
+  const standaloneMcpGet = await fetchStandaloneMcpGet(fetchImpl, urls.canonicalMcp, timeoutMs);
+  checks.push(...checkStandaloneMcpGet(standaloneMcpGet, urls.canonicalMcp));
+
+  const breached = checks.some((check) => check.status === 'fail');
+  const state: ProductionSmokeState = breached ? 'breach' : 'ok';
+
+  return {
+    state,
+    ok: !breached,
+    breached,
+    generatedAt: (config.now ?? new Date()).toISOString(),
+    websiteBaseUrl,
+    mcpBaseUrl,
+    expected,
+    observed: {
+      statusEndpoint,
+      canonicalMcp: canonicalMcp.observed,
+      standaloneMcpGet,
+    },
+    checks,
+    summary: summarizeSmoke(state, checks),
+  };
+}
+
+export function formatProductionSmokeMarkdown(report: ProductionSmokeReport): string {
+  const rows = report.checks
+    .map((check) =>
+      `| ${check.characteristic} | ${check.status} | ${escapeTableCell(check.evidence)} | ${check.url ?? ''} |`,
+    )
+    .join('\n');
+
+  return `# Semantic Production Smoke
+
+State: **${report.state}**
+
+${report.summary}
+
+- Website base URL: ${report.websiteBaseUrl}
+- MCP base URL: ${report.mcpBaseUrl}
+- Expected upstream ref: ${report.expected.upstreamRef}
+- Expected source hash: ${report.expected.sourceHash}
+
+| Characteristic | Status | Evidence | URL |
+| --- | --- | --- | --- |
+${rows}
+`;
+}
+
+function buildSmokeUrls(websiteBaseUrl: string, mcpBaseUrl: string) {
+  return {
+    websiteRoot: buildUrl(websiteBaseUrl, '/'),
+    websiteConnect: buildUrl(websiteBaseUrl, '/connect-mcp'),
+    mcpRoot: buildUrl(mcpBaseUrl, '/'),
+    mcpConnect: buildUrl(mcpBaseUrl, '/connect-mcp'),
+    mcpStatus: buildUrl(mcpBaseUrl, HOSTED_FPF_STATUS_ROUTE),
+    canonicalMcp: buildUrl(mcpBaseUrl, HOSTED_MCP_ROUTE),
+  };
+}
+
+async function readExpectedPublication(cwd?: string): Promise<ExpectedPublication> {
+  const surface = await validatePublishedSurface({ cwd });
+  return {
+    upstreamRef: surface.manifest.upstreamRef,
+    sourceHash: surface.manifest.sourceHash,
+    publishedAt: surface.manifest.publishedAt,
+  };
+}
+
+async function fetchPage(
+  fetchImpl: typeof fetch,
+  url: string,
+  timeoutMs: number,
+): Promise<PageEvidence> {
+  const response = await fetchImpl(url, {
+    method: 'GET',
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  return {
+    url,
+    status: response.status,
+    text: await response.text(),
+  };
+}
+
+function checkCanonicalOnboardingPage(
+  label: string,
+  page: PageEvidence,
+): ProductionSmokeCheck[] {
+  const lower = page.text.toLowerCase();
+  const hasLegacyName = page.text.includes('fpf_memory');
+  const canonicalIndex = page.text.indexOf('fpf_reference');
+  const legacyIndex = page.text.indexOf('fpf_memory');
+  const legacyLabeled =
+    !hasLegacyName || /\b(legacy|compatibility|blocked|mitigation|old clients?)\b/iu.test(page.text);
+  const legacyNotPrimary =
+    legacyIndex < 0 || (canonicalIndex >= 0 && canonicalIndex < legacyIndex);
+  const oldProductPrimary =
+    /hosted\s+fpf-memory\s+mcp|fpf-memory\s+mcp\s+server/iu.test(page.text);
+
+  return [
+    {
+      characteristic: `${label} HTTP availability`,
+      status: page.status === 200 ? 'pass' : 'fail',
+      evidence: `HTTP ${page.status}`,
+      url: page.url,
+    },
+    {
+      characteristic: `${label} public product name`,
+      status: page.text.includes('FPF Reference') && !oldProductPrimary ? 'pass' : 'fail',
+      evidence: page.text.includes('FPF Reference')
+        ? 'names FPF Reference without old hosted fpf-memory primary copy'
+        : 'missing FPF Reference',
+      url: page.url,
+    },
+    {
+      characteristic: `${label} canonical MCP route`,
+      status:
+        page.text.includes('fpf_reference')
+        && page.text.includes('/api/mcp/fpf_reference/mcp')
+        && page.text.includes(PRODUCTION_SMOKE_CANONICAL_MCP_ENDPOINT)
+          ? 'pass'
+          : 'fail',
+      evidence: 'canonical server name and hosted endpoint are present',
+      url: page.url,
+    },
+    {
+      characteristic: `${label} legacy route boundary`,
+      status: legacyLabeled && legacyNotPrimary && !lower.includes('use fpf_memory') ? 'pass' : 'fail',
+      evidence: hasLegacyName
+        ? 'legacy fpf_memory mention is labeled and follows fpf_reference'
+        : 'no legacy fpf_memory onboarding path presented',
+      url: page.url,
+    },
+  ];
+}
+
+function checkGetDocs(page: PageEvidence): ProductionSmokeCheck[] {
+  const mentions405 = /405|Method Not Allowed/iu.test(page.text);
+  const mentions406 = /406|Not Acceptable/iu.test(page.text);
+
+  return [
+    {
+      characteristic: `${shortUrlLabel(page.url)} standalone MCP GET documentation`,
+      status: mentions405 && !mentions406 ? 'pass' : 'fail',
+      evidence: mentions405
+        ? 'documents standalone MCP GET as 405 Method Not Allowed'
+        : 'does not document standalone MCP GET as 405 Method Not Allowed',
+      url: page.url,
+    },
+  ];
+}
+
+async function fetchStatusEndpoint(
+  fetchImpl: typeof fetch,
+  url: string,
+  timeoutMs: number,
+): Promise<ObservedStatusEndpoint> {
+  const response = await fetchImpl(url, {
+    method: 'GET',
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const body = asRecord(await response.json(), 'status endpoint response');
+  const publication = asRecord(body.publication, 'status publication');
+  const runtime = asRecord(body.runtime, 'status runtime');
+
+  return {
+    servedAt: stringField(body.servedAt),
+    status: String(body.status ?? `http_${response.status}`),
+    publicationUpstreamRef: stringField(publication.upstreamRef),
+    publicationSourceHash: stringField(publication.sourceHash),
+    publicationPublishedAt: stringField(publication.publishedAt),
+    runtimeBuiltAt: stringField(runtime.builtAt),
+    runtimeFresh: booleanField(runtime.fresh),
+    runtimeSourceHash: stringField(runtime.sourceHash),
+    runtimeCurrentSourceHash: stringField(runtime.currentSourceHash),
+    runtimeSnapshotSourceHash: stringField(runtime.snapshotSourceHash),
+  };
+}
+
+function checkStatusEndpoint(
+  status: ObservedStatusEndpoint,
+  expected: ExpectedPublication,
+  url: string,
+): ProductionSmokeCheck[] {
+  const publicationMatches =
+    status.publicationUpstreamRef === expected.upstreamRef
+    && status.publicationSourceHash === expected.sourceHash;
+  const runtimeInternallyConsistent =
+    status.runtimeSourceHash === status.runtimeCurrentSourceHash
+    && status.runtimeSnapshotSourceHash === status.runtimeCurrentSourceHash
+    && status.runtimeFresh === true;
+  const runtimeMatchesExpected = status.runtimeCurrentSourceHash === expected.sourceHash;
+
+  return [
+    {
+      characteristic: 'status endpoint publication artifact',
+      status: publicationMatches ? 'pass' : 'fail',
+      evidence:
+        `published upstreamRef=${status.publicationUpstreamRef ?? 'unknown'}, sourceHash=${status.publicationSourceHash ?? 'unknown'}`,
+      url,
+    },
+    {
+      characteristic: 'status endpoint runtime source',
+      status: runtimeInternallyConsistent && runtimeMatchesExpected ? 'pass' : 'fail',
+      evidence:
+        `runtime internalFresh=${String(status.runtimeFresh)}, runtimeSourceHash=${status.runtimeCurrentSourceHash ?? 'unknown'}`,
+      url,
+    },
+    {
+      characteristic: 'status freshness basis',
+      status: publicationMatches && runtimeInternallyConsistent && runtimeMatchesExpected ? 'pass' : 'fail',
+      evidence:
+        'freshness requires both internal snapshot consistency and match to the expected published/current artifact',
+      url,
+    },
+  ];
+}
+
+async function checkCanonicalMcpEndpoint(
+  fetchImpl: typeof fetch,
+  endpoint: string,
+  expected: ExpectedPublication,
+  timeoutMs: number,
+): Promise<{
+  observed: ObservedMcpEndpoint;
+  checks: ProductionSmokeCheck[];
+}> {
+  const client = new JsonRpcMcpSmokeClient(fetchImpl, endpoint, timeoutMs);
+  const initialize = asRecord(
+    await client.rpc('initialize', {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: {
+        name: 'fpf-reference-production-smoke',
+        version: '1.0.0',
+      },
+    }),
+    'initialize result',
+  );
+  const serverInfo = asRecord(initialize.serverInfo, 'initialize serverInfo');
+  await client.notify('notifications/initialized');
+
+  const toolsResult = asRecord(await client.rpc('tools/list'), 'tools/list result');
+  const tools = asArray(toolsResult.tools, 'tools/list tools');
+  const toolNames = tools.map((tool, index) => {
+    const record = asRecord(tool, `tool ${index}`);
+    return String(record.name ?? '');
+  });
+
+  const statusResult = asRecord(
+    await client.rpc('tools/call', {
+      name: 'get_fpf_index_status',
+      arguments: {},
+    }),
+    'get_fpf_index_status result',
+  );
+  const structuredContent = asRecord(
+    statusResult.structuredContent,
+    'get_fpf_index_status structuredContent',
+  );
+  const observed: ObservedMcpEndpoint = {
+    serverName: stringField(serverInfo.name),
+    toolNames,
+    statusToolSourceHash: stringField(structuredContent.currentSourceHash)
+      ?? stringField(structuredContent.sourceHash),
+    statusToolFresh: booleanField(structuredContent.fresh),
+  };
+  const toolSurfaceMatches =
+    toolNames.length === PRODUCTION_SMOKE_PUBLIC_TOOLS.length
+    && PRODUCTION_SMOKE_PUBLIC_TOOLS.every((tool) => toolNames.includes(tool));
+  const statusToolMatches =
+    observed.statusToolFresh === true
+    && observed.statusToolSourceHash === expected.sourceHash;
+
+  return {
+    observed,
+    checks: [
+      {
+        characteristic: 'canonical MCP POST server identity',
+        status: observed.serverName === 'fpf_reference' ? 'pass' : 'fail',
+        evidence: `serverInfo.name=${observed.serverName ?? 'unknown'}`,
+        url: endpoint,
+      },
+      {
+        characteristic: 'canonical MCP public tool surface',
+        status: toolSurfaceMatches ? 'pass' : 'fail',
+        evidence: `${toolNames.length} public tools advertised`,
+        url: endpoint,
+      },
+      {
+        characteristic: 'canonical MCP status tool artifact',
+        status: statusToolMatches ? 'pass' : 'fail',
+        evidence:
+          `get_fpf_index_status fresh=${String(observed.statusToolFresh)}, sourceHash=${observed.statusToolSourceHash ?? 'unknown'}`,
+        url: endpoint,
+      },
+    ],
+  };
+}
+
+async function fetchStandaloneMcpGet(
+  fetchImpl: typeof fetch,
+  url: string,
+  timeoutMs: number,
+): Promise<ObservedStandaloneGet> {
+  const response = await fetchImpl(url, {
+    method: 'GET',
+    headers: {
+      Accept: 'text/event-stream',
+      'MCP-Protocol-Version': '2025-06-18',
+    },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const contentType = response.headers.get('content-type') ?? '';
+  const text = await response.text();
+  let message: string | undefined;
+  if (contentType.includes('json')) {
+    try {
+      const body = asRecord(JSON.parse(text), 'standalone GET response');
+      const error = asRecord(body.error, 'standalone GET error');
+      message = stringField(error.message);
+    } catch {
+      message = undefined;
+    }
+  }
+  return {
+    status: response.status,
+    allow: response.headers.get('allow') ?? '',
+    message,
+  };
+}
+
+function checkStandaloneMcpGet(
+  observed: ObservedStandaloneGet,
+  url: string,
+): ProductionSmokeCheck[] {
+  return [
+    {
+      characteristic: 'standalone MCP GET runtime behavior',
+      status:
+        observed.status === 405
+        && observed.allow.includes('POST')
+        && observed.message?.includes('Standalone MCP SSE GET is disabled') === true
+          ? 'pass'
+          : 'fail',
+      evidence:
+        `GET status=${observed.status}, allow=${observed.allow || 'unknown'}, disabledPayload=${String(Boolean(observed.message))}`,
+      url,
+    },
+  ];
+}
+
+class JsonRpcMcpSmokeClient {
+  private nextId = 1;
+  private sessionId: string | undefined;
+
+  constructor(
+    private readonly fetchImpl: typeof fetch,
+    private readonly endpoint: string,
+    private readonly timeoutMs: number,
+  ) {}
+
+  async rpc(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    const id = this.nextId++;
+    const response = await this.fetchImpl(this.endpoint, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method,
+        ...(params ? { params } : {}),
+      }),
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+    this.captureSessionId(response);
+
+    const body = await readJson(response, `${method} response`);
+    if (!response.ok || body.error) {
+      throw new Error(`${method} returned HTTP ${response.status}: ${body.error?.message ?? 'unknown JSON-RPC error'}`);
+    }
+    return body.result;
+  }
+
+  async notify(method: string, params?: Record<string, unknown>): Promise<void> {
+    const response = await this.fetchImpl(this.endpoint, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method,
+        ...(params ? { params } : {}),
+      }),
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+    this.captureSessionId(response);
+    await response.body?.cancel().catch(() => undefined);
+  }
+
+  private headers(): HeadersInit {
+    return {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      'MCP-Protocol-Version': '2025-06-18',
+      ...(this.sessionId ? { 'MCP-Session-Id': this.sessionId } : {}),
+    };
+  }
+
+  private captureSessionId(response: Response): void {
+    this.sessionId = response.headers.get('mcp-session-id') ?? this.sessionId;
+  }
+}
+
+async function readJson(response: Response, label: string): Promise<JsonRpcResponse> {
+  const text = await response.text();
+  try {
+    return JSON.parse(text) as JsonRpcResponse;
+  } catch {
+    throw new Error(`${label} was not JSON.`);
+  }
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.replace(/\/+$/u, '');
+}
+
+function buildUrl(baseUrl: string, path: string): string {
+  return new URL(path, `${baseUrl}/`).toString();
+}
+
+function shortUrlLabel(url: string): string {
+  const parsed = new URL(url);
+  return `${parsed.hostname}${parsed.pathname}`;
+}
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} was not an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function asArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} was not an array.`);
+  }
+  return value;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function booleanField(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function summarizeSmoke(
+  state: ProductionSmokeState,
+  checks: ProductionSmokeCheck[],
+): string {
+  if (state === 'ok') {
+    return `${checks.length} semantic production checks passed.`;
+  }
+  const failed = checks.filter((check) => check.status === 'fail');
+  return `${failed.length}/${checks.length} semantic production checks failed: ${failed.map((check) => check.characteristic).join('; ')}`;
+}
+
+function escapeTableCell(value: string): string {
+  return value.replace(/\|/gu, '\\|').replace(/\r?\n/gu, ' ');
+}

--- a/tests/content-quality-workflow.test.ts
+++ b/tests/content-quality-workflow.test.ts
@@ -11,6 +11,10 @@ describe('FPF content quality workflow', () => {
     expect(workflow).toContain(
       'bun run monitor:content -- --mode local --format markdown --fail-on-breach',
     );
+    expect(workflow).toContain('Run semantic production smoke against local build');
+    expect(workflow).toContain(
+      'bun run smoke:production -- --local --format markdown --fail-on-breach',
+    );
   });
 
   it('monitors production route and curated page drift on a schedule', async () => {
@@ -22,6 +26,9 @@ describe('FPF content quality workflow', () => {
     expect(workflow).toContain("- cron: '37 * * * *'");
     expect(workflow).toContain(
       'bun run monitor:content -- --mode live --format markdown --fail-on-breach',
+    );
+    expect(workflow).toContain(
+      'bun run smoke:production -- --format markdown --fail-on-breach',
     );
     expect(workflow).toContain('FPF_CONTENT_QUALITY_BASE_URL: https://fpf.sh');
     expect(workflow).toContain(

--- a/tests/deploy-production-surfaces-workflow.test.ts
+++ b/tests/deploy-production-surfaces-workflow.test.ts
@@ -47,6 +47,9 @@ describe('production deployment workflow', () => {
     expect(commands).toContain(
       'bun run monitor:content -- --mode live --format markdown --fail-on-breach --base-url https://fpf.sh --status-url https://mcp.fpf.sh/api/fpf/status',
     );
+    expect(commands).toContain(
+      'bun run smoke:production -- --format markdown --fail-on-breach',
+    );
     expect(
       commands.some((command) =>
         command.includes(`alias set ${oldMcpDeployment} mcp.fpf.sh`),
@@ -92,7 +95,7 @@ set -eu
 printf 'bun %s\\n' "$*" >> "$FPF_DEPLOY_COMMAND_LOG"
 if [ "$1" = "run" ]; then
   case "$2" in
-    deploy:validate|monitor:sync|monitor:content)
+    deploy:validate|monitor:sync|monitor:content|smoke:production)
       exit 0
       ;;
     vercel:website:build)

--- a/tests/hosted-home-page.test.ts
+++ b/tests/hosted-home-page.test.ts
@@ -32,6 +32,8 @@ describe('hosted home page', () => {
     expect(html).toContain('get_fpf_index_status');
     expect(html).toContain('query_fpf_spec');
     expect(html).toContain('read_fpf_doc');
+    expect(html).toContain('405 Method Not Allowed');
+    expect(html).not.toContain('406');
   });
 
   it('serves the connection page from the hosted root', async () => {

--- a/tests/production-smoke.test.ts
+++ b/tests/production-smoke.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from '@rstest/core';
+
+import {
+  formatProductionSmokeMarkdown,
+  runProductionSmoke,
+  type ExpectedPublication,
+} from '../src/build/production-smoke.js';
+
+const EXPECTED: ExpectedPublication = {
+  upstreamRef: '1234567890abcdef1234567890abcdef12345678',
+  sourceHash: 'sha256:expected',
+  publishedAt: '2026-05-31T09:25:05.436Z',
+};
+
+describe('semantic production smoke', () => {
+  it('passes only when naming, route, freshness, MCP POST, and GET semantics agree', async () => {
+    const report = await runProductionSmoke({
+      websiteBaseUrl: 'https://docs.example.test',
+      mcpBaseUrl: 'https://mcp.example.test',
+      expectedPublication: EXPECTED,
+      fetchImpl: createSmokeFetch(),
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.state).toBe('ok');
+    expect(report.observed.statusEndpoint?.publicationUpstreamRef).toBe(EXPECTED.upstreamRef);
+    expect(report.observed.canonicalMcp?.serverName).toBe('fpf_reference');
+    expect(report.observed.standaloneMcpGet?.status).toBe(405);
+    expect(JSON.stringify(report)).not.toContain('session');
+  });
+
+  it('breaches when status is internally fresh but not current against the expected artifact', async () => {
+    const report = await runProductionSmoke({
+      websiteBaseUrl: 'https://docs.example.test',
+      mcpBaseUrl: 'https://mcp.example.test',
+      expectedPublication: EXPECTED,
+      fetchImpl: createSmokeFetch({
+        statusSourceHash: 'sha256:old',
+        statusUpstreamRef: 'fedcba0987654321fedcba0987654321fedcba09',
+        statusRuntimeFresh: true,
+      }),
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.summary).toContain('status endpoint publication artifact');
+    expect(report.summary).toContain('status endpoint runtime source');
+    expect(formatProductionSmokeMarkdown(report)).toContain(
+      'freshness requires both internal snapshot consistency and match to the expected published/current artifact',
+    );
+  });
+
+  it('breaches when old fpf_memory onboarding is primary or unlabeled', async () => {
+    const report = await runProductionSmoke({
+      websiteBaseUrl: 'https://docs.example.test',
+      mcpBaseUrl: 'https://mcp.example.test',
+      expectedPublication: EXPECTED,
+      fetchImpl: createSmokeFetch({
+        mcpRootText:
+          'Hosted fpf-memory MCP server. Use fpf_memory at https://mcp.example.test/api/mcp/fpf_memory/mcp before fpf_reference.',
+      }),
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.summary).toContain('mcp.fpf.sh root public product name');
+    expect(report.summary).toContain('mcp.fpf.sh root legacy route boundary');
+  });
+
+  it('breaches when docs say 406 while runtime returns the expected 405 payload', async () => {
+    const report = await runProductionSmoke({
+      websiteBaseUrl: 'https://docs.example.test',
+      mcpBaseUrl: 'https://mcp.example.test',
+      expectedPublication: EXPECTED,
+      fetchImpl: createSmokeFetch({
+        websiteConnectText: pageText('406 Not Acceptable'),
+        mcpConnectText: pageText('406 Not Acceptable'),
+      }),
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.summary).toContain('standalone MCP GET documentation');
+    expect(report.observed.standaloneMcpGet?.status).toBe(405);
+  });
+});
+
+function createSmokeFetch(overrides: {
+  websiteRootText?: string;
+  websiteConnectText?: string;
+  mcpRootText?: string;
+  mcpConnectText?: string;
+  statusSourceHash?: string;
+  statusUpstreamRef?: string;
+  statusRuntimeFresh?: boolean;
+} = {}): typeof fetch {
+  const statusSourceHash = overrides.statusSourceHash ?? EXPECTED.sourceHash;
+  const statusUpstreamRef = overrides.statusUpstreamRef ?? EXPECTED.upstreamRef;
+
+  const fakeFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = new URL(typeof input === 'string' || input instanceof URL ? input : input.url);
+    const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+
+    if (url.pathname === '/api/fpf/status') {
+      return jsonResponse({
+        status: 'ok',
+        servedAt: '2026-05-31T10:00:00.000Z',
+        publication: {
+          upstreamRef: statusUpstreamRef,
+          sourceHash: statusSourceHash,
+          publishedAt: EXPECTED.publishedAt,
+        },
+        runtime: {
+          sourceHash: statusSourceHash,
+          snapshotSourceHash: statusSourceHash,
+          currentSourceHash: statusSourceHash,
+          builtAt: '2026-05-31T09:25:00.097Z',
+          snapshotExists: true,
+          fresh: overrides.statusRuntimeFresh ?? true,
+        },
+      });
+    }
+
+    if (url.pathname === '/api/mcp/fpf_reference/mcp' && method === 'GET') {
+      return jsonResponse(
+        {
+          jsonrpc: '2.0',
+          error: {
+            code: -32000,
+            message:
+              'Standalone MCP SSE GET is disabled on this endpoint; use POST Streamable HTTP JSON-RPC requests.',
+          },
+          id: null,
+        },
+        {
+          status: 405,
+          headers: { Allow: 'POST, DELETE' },
+        },
+      );
+    }
+
+    if (url.pathname === '/api/mcp/fpf_reference/mcp' && method === 'POST') {
+      return handleMcpPost(init);
+    }
+
+    if (url.hostname === 'docs.example.test' && url.pathname === '/') {
+      return htmlResponse(overrides.websiteRootText ?? pageText());
+    }
+    if (url.hostname === 'docs.example.test' && url.pathname === '/connect-mcp') {
+      return htmlResponse(overrides.websiteConnectText ?? pageText('405 Method Not Allowed'));
+    }
+    if (url.hostname === 'mcp.example.test' && url.pathname === '/') {
+      return htmlResponse(overrides.mcpRootText ?? pageText('405 Method Not Allowed'));
+    }
+    if (url.hostname === 'mcp.example.test' && url.pathname === '/connect-mcp') {
+      return htmlResponse(overrides.mcpConnectText ?? pageText('405 Method Not Allowed'));
+    }
+
+    return new Response('not found', { status: 404 });
+  };
+  return fakeFetch as unknown as typeof fetch;
+}
+
+function handleMcpPost(init: RequestInit | undefined): Response {
+  const payload = JSON.parse(String(init?.body ?? '{}')) as { method?: string; id?: number };
+  if (payload.method === 'notifications/initialized') {
+    return new Response('', {
+      status: 202,
+      headers: { 'mcp-session-id': 'private-session-id' },
+    });
+  }
+  if (payload.method === 'initialize') {
+    return jsonResponse(
+      {
+        jsonrpc: '2.0',
+        id: payload.id,
+        result: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          serverInfo: { name: 'fpf_reference', version: '1.0.0' },
+        },
+      },
+      { headers: { 'mcp-session-id': 'private-session-id' } },
+    );
+  }
+  if (payload.method === 'tools/list') {
+    return jsonResponse({
+      jsonrpc: '2.0',
+      id: payload.id,
+      result: {
+        tools: [
+          'browse_fpf_catalog',
+          'search_fpf',
+          'ask_fpf',
+          'query_fpf_spec',
+          'read_fpf_doc',
+          'get_fpf_index_status',
+        ].map((name) => ({ name })),
+      },
+    });
+  }
+  if (payload.method === 'tools/call') {
+    return jsonResponse({
+      jsonrpc: '2.0',
+      id: payload.id,
+      result: {
+        structuredContent: {
+          fresh: true,
+          currentSourceHash: EXPECTED.sourceHash,
+        },
+      },
+    });
+  }
+
+  return jsonResponse({
+    jsonrpc: '2.0',
+    id: payload.id,
+    error: { code: -32601, message: 'method not found' },
+  }, { status: 400 });
+}
+
+function pageText(extra = ''): string {
+  return [
+    '<title>FPF Reference MCP</title>',
+    'FPF Reference',
+    'https://mcp.fpf.sh/api/mcp/fpf_reference/mcp',
+    'fpf_reference',
+    'Legacy https://mcp.fpf.sh/api/mcp/fpf_memory/mcp is blocked during mitigation.',
+    extra,
+  ].join(' ');
+}
+
+function htmlResponse(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+  });
+}
+
+function jsonResponse(
+  body: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      ...init.headers,
+    },
+  });
+}


### PR DESCRIPTION
## Problem statement

Production checks could pass on HTTP 200, page title, or `status: ok` while the Run layer served stale artifacts, wrong route naming, or old `fpf_memory` onboarding. This PR adds a semantic smoke surface that keeps the intended FPF Reference promise, runtime ability, observed performance, and evidence separate.

## Files changed

- `src/build/production-smoke.ts`: reusable semantic smoke evaluator for website pages, MCP onboarding pages, status metadata, canonical MCP POST, and standalone MCP GET.
- `scripts/smoke-production.ts`: `bun run smoke:production` CLI with live defaults plus `--local` production-equivalent mode.
- `.github/workflows/ci.yml`: runs the smoke command against local docs + hosted MCP surfaces after build.
- `.github/workflows/fpf-content-quality.yml`: runs live production semantic smoke on the scheduled production monitor.
- `scripts/deploy-production-surfaces.ts`: runs semantic smoke after production alias verification and existing sync/content monitors.
- `src/adapters/hosted/home-page.ts`: documents hosted MCP browser GET as `405 Method Not Allowed`.
- Tests updated/added for smoke behavior and workflow/deploy wiring.

## Validation commands

- `bunx rstest run tests/production-smoke.test.ts`
- `bunx rstest run tests/hosted-home-page.test.ts tests/content-quality-workflow.test.ts tests/deploy-production-surfaces-workflow.test.ts`
- `bun run check`
- `bun run lint`
- `bun run docs:build`
- `bun run vercel:mcp:build`
- `bun run smoke:production -- --local --format markdown --fail-on-breach`
- `bun run smoke:production -- --format markdown`
- `git diff --check`
- `bun run evaluate:work`

## Test output

- Focused smoke tests: 4 tests passed.
- Focused hosted/workflow/deploy tests: 10 tests passed.
- Typecheck: passed.
- Lint: 0 errors, 0 warnings.
- Docs build: generated 982 files; Rspress build completed.
- MCP Vercel build: bundle 99.92 MB, 140.08 MB fail-threshold headroom, PASS.
- Local semantic smoke: 25/25 checks passed.
- FPF work evaluation: overall `aligned`.

## Live production evidence

`bun run smoke:production -- --format markdown` on 2026-05-31 reported:

- State: `breach`
- 24/25 semantic checks passed.
- Expected upstream ref: `2e112078bb209e5e3a511c3bd1aa6b1b2e299efe`
- Expected source hash: `sha256:73c08fb554cc5920f4bf5497e0d356ab6d3bcd5bdb605f8dcc2f82587565005e`
- `fpf.sh/`, `fpf.sh/connect-mcp`, `mcp.fpf.sh/`, status metadata, canonical MCP POST, and standalone MCP GET runtime behavior passed semantic checks.
- The single failing live check is `mcp.fpf.sh/connect-mcp standalone MCP GET documentation`, because production has not yet deployed the new hosted-page copy that states the documented `405 Method Not Allowed` behavior.

Baseline curl checks also showed current production status metadata matching the committed artifact:

- `publication.publishedAt`: `2026-05-31T09:25:05.436Z`
- `publication.upstreamRef`: `2e112078bb209e5e3a511c3bd1aa6b1b2e299efe`
- `runtime.builtAt`: `2026-05-31T09:25:00.097Z`
- `runtime.fresh`: `true`

## Privacy

The smoke command does not call prompt-bearing tools, does not print raw prompts, questions, answers, selectors, markdown bodies, session IDs, IP addresses, or user identifiers. It checks onboarding text, route names, artifact hashes/refs, tool names, status fields, and method behavior only.

## Caveats / residual risk

- This PR adds the guard and fixes the hosted MCP onboarding copy. The live production breach remains expected until this branch is merged and deployed.
- `runtime.fresh` is treated only as internal snapshot/source consistency. Passing currentness also requires matching the expected committed `published/current` upstream ref and source hash.
- The local CI mode exercises local docs + hosted MCP behavior. It does not replace the live scheduled/deploy smoke that checks canonical domains.

## What would falsify this success claim?

- `bun run smoke:production -- --format markdown --fail-on-breach` still fails after this branch is deployed to production.
- A production page presents `fpf_memory` as the primary setup path or omits `FPF Reference` / `fpf_reference`.
- `/api/fpf/status` is internally fresh but its upstream ref or source hash differs from committed `published/current`.
- Canonical MCP POST does not initialize as `fpf_reference`, omits the public tool surface, or serves a different source hash.
- Standalone MCP GET stops returning the documented `405` disabled JSON-RPC payload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production deploy gates and public MCP/website contract checks; misconfigured smoke could block merges or deploys, but changes are additive monitors with rollback on deploy failure.
> 
> **Overview**
> Adds **semantic production smoke** so CI, scheduled monitors, and deploys can fail when public surfaces look healthy on HTTP 200 but violate FPF Reference contracts (naming, routes, publication freshness, MCP tool surface, standalone GET behavior).
> 
> A reusable evaluator in `src/build/production-smoke.ts` and `bun run smoke:production` (live or `--local` against built docs + the Vercel MCP handler) assert onboarding copy, `/api/fpf/status` vs committed `published/current`, canonical MCP POST (`fpf_reference`, public tools, index hash), and that browser GET on the MCP route returns **405** with the disabled-SSE payload—not **406**.
> 
> **Wiring:** CI runs local smoke after Vercel dry-runs; `fpf-content-quality` runs live smoke hourly; `deploy-production-surfaces` runs live smoke after alias verification (rollback on breach). The hosted home page now documents browser GET as **405 Method Not Allowed**. Tests cover smoke logic and workflow/deploy wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83babb3abd6494161695947e8067b3e76021f328. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->