### PR TITLE
Clarify hosted status freshness semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Public hosted status endpoint:
 /api/fpf/status
 ```
 
-This returns the published `upstreamRef`, `sourceHash`, `publishedAt`, `specBytes`, and runtime freshness evidence for the same bundled FPF source and snapshot used by the hosted MCP endpoint.
+This returns the published `upstreamRef`, `sourceHash`, `publishedAt`, `specBytes`, and split runtime evidence for the same bundled FPF source and snapshot used by the hosted MCP endpoint. `runtime.snapshotConsistent` means the deployed source, manifest, and snapshot agree internally. `freshness.upstreamCurrentness` is `unknown` on this endpoint by design; production currentness is proven only by monitors that compare `publication.upstreamRef` and `publication.sourceHash` against the intended upstream/current artifact.
 
 ## FPF work evaluation
 

--- a/docs/automation-playbook.md
+++ b/docs/automation-playbook.md
@@ -111,7 +111,8 @@ Done means each claim has current evidence. Do not treat a green local build, a 
 
 3. **Publication freshness**
    - Hosted status `publication.sourceHash`, `runtime.sourceHash`, and `runtime.currentSourceHash` match.
-   - Hosted status reports `fresh: true`.
+   - Hosted status reports `runtime.snapshotConsistent: true` and `freshness.freshnessBasis: source_hash_match`.
+   - Treat `freshness.upstreamCurrentness: unknown` as expected until an external monitor compares the hosted publication to the intended upstream/current artifact.
    - The upstream ref in hosted status matches the committed `published/current/manifest.json` for the release being claimed.
 
 4. **Deployment ownership**

--- a/docs/connect-mcp.md
+++ b/docs/connect-mcp.md
@@ -32,7 +32,7 @@ For a browser-readable health check, use the freshness page instead:
 https://mcp.fpf.sh/api/fpf/status
 ```
 
-It returns JSON the browser will render — source hash, snapshot age, and the upstream ref the index was built from.
+It returns JSON the browser will render — source hash, snapshot age, and the upstream ref the index was built from. `runtime.snapshotConsistent` is an internal deployed-artifact check; upstream/currentness stays `unknown` there unless a monitor compares the status payload to the intended upstream ref and source hash.
 
 Public tools:
 

--- a/scripts/monitor-fpf-sync.ts
+++ b/scripts/monitor-fpf-sync.ts
@@ -70,7 +70,7 @@ function renderGithubOutput(report: SyncMonitorReport): string {
     ['published_short_ref', report.hosted.publication.upstreamRef.slice(0, 8)],
     ['drift_hours', String(report.driftHours)],
     ['max_drift_hours', String(report.maxDriftHours)],
-    ['runtime_fresh', String(report.runtimeFresh)],
+    ['runtime_snapshot_consistent', String(report.runtimeFresh)],
     ['source_coherent', String(report.sourceCoherent)],
     ['summary', report.summary],
   ].map(([key, value]) => `${key}=${sanitizeOutputValue(value)}\n`).join('');

--- a/src/adapters/hosted/status-page.ts
+++ b/src/adapters/hosted/status-page.ts
@@ -26,9 +26,11 @@ export interface HostedFpfStatusOptions {
 export interface HostedFpfStatus {
   status: 'ok' | 'stale';
   servedAt: string;
+  statusMeaning: string;
   publication: {
     channel: string;
     upstreamRef: string;
+    upstreamDate: string;
     publishedAt: string;
     sourceHash: string;
     compilerFingerprint: string;
@@ -44,9 +46,23 @@ export interface HostedFpfStatus {
     snapshotSourceHash: string;
     currentSourceHash: string;
     builtAt: string;
+    artifactBuiltAt: string;
+    artifactSourceHash: string;
     snapshotExists: boolean;
-    fresh: boolean;
+    snapshotConsistent: boolean;
+    artifactSourceMatchesConfiguredSource: boolean;
     compilerMode: 'local_vectorless';
+  };
+  freshness: {
+    snapshotConsistent: boolean;
+    artifactBuiltAt: string;
+    artifactSourceHash: string;
+    publicationUpstreamRef: string;
+    publicationUpstreamDate: string;
+    publicationCurrentAgainstConfiguredSource: boolean;
+    deployedAt: string | null;
+    freshnessBasis: 'source_hash_match' | 'unknown';
+    upstreamCurrentness: 'unknown';
   };
 }
 
@@ -88,18 +104,23 @@ export async function readHostedFpfStatus(
   );
   const snapshot = publicationSnapshotSchema.parse(JSON.parse(snapshotBytes.toString('utf8')));
   const currentSourceHash = `sha256:${createHash('sha256').update(sourceBytes).digest('hex')}`;
-  const fresh =
+  const snapshotConsistent =
     manifest.sourceHash === currentSourceHash
     && snapshot.sourceHash === currentSourceHash
     && manifest.compilerFingerprint === snapshot.compilerFingerprint
     && manifest.specBytes === sourceBytes.byteLength;
+  const artifactSourceMatchesConfiguredSource = snapshot.sourceHash === currentSourceHash;
+  const deployedAt = process.env.FPF_DEPLOYED_AT?.trim() || null;
 
   return {
-    status: fresh ? 'ok' : 'stale',
+    status: snapshotConsistent ? 'ok' : 'stale',
     servedAt: new Date().toISOString(),
+    statusMeaning:
+      'ok means the deployed source, manifest, and snapshot are internally consistent; upstream currentness is checked by monitors that compare publication.upstreamRef externally.',
     publication: {
       channel: manifest.channel,
       upstreamRef: manifest.upstreamRef,
+      upstreamDate: manifest.upstreamCommittedAt,
       publishedAt: manifest.publishedAt,
       sourceHash: manifest.sourceHash,
       compilerFingerprint: manifest.compilerFingerprint,
@@ -115,9 +136,23 @@ export async function readHostedFpfStatus(
       snapshotSourceHash: snapshot.sourceHash,
       currentSourceHash,
       builtAt: snapshot.builtAt,
+      artifactBuiltAt: snapshot.builtAt,
+      artifactSourceHash: snapshot.sourceHash,
       snapshotExists: true,
-      fresh,
+      snapshotConsistent,
+      artifactSourceMatchesConfiguredSource,
       compilerMode: 'local_vectorless',
+    },
+    freshness: {
+      snapshotConsistent,
+      artifactBuiltAt: snapshot.builtAt,
+      artifactSourceHash: snapshot.sourceHash,
+      publicationUpstreamRef: manifest.upstreamRef,
+      publicationUpstreamDate: manifest.upstreamCommittedAt,
+      publicationCurrentAgainstConfiguredSource: snapshotConsistent,
+      deployedAt,
+      freshnessBasis: snapshotConsistent ? 'source_hash_match' : 'unknown',
+      upstreamCurrentness: 'unknown',
     },
   };
 }

--- a/src/build/content-quality-monitor.ts
+++ b/src/build/content-quality-monitor.ts
@@ -117,7 +117,14 @@ export interface HostedContentStatus {
     currentSourceHash: string;
     builtAt?: string;
     snapshotExists: boolean;
-    fresh: boolean;
+    fresh?: boolean;
+    snapshotConsistent?: boolean;
+    artifactSourceMatchesConfiguredSource?: boolean;
+  };
+  freshness?: {
+    publicationCurrentAgainstConfiguredSource: boolean;
+    freshnessBasis: string;
+    upstreamCurrentness: 'unknown';
   };
 }
 
@@ -335,7 +342,7 @@ export function evaluateContentQuality(
       characteristic: 'published source coherence',
       status: livePass ? 'pass' : 'fail',
       evidence: live
-        ? `mcp source coherent=${String(live.statusSourceCoherent)}, website manifest matches=${String(live.websiteSourceMatchesPublished)}, raw upstream matches=${String(live.upstreamSourceMatchesPublished)}, runtime fresh=${String(live.runtimeFresh)}`
+        ? `mcp source coherent=${String(live.statusSourceCoherent)}, website manifest matches=${String(live.websiteSourceMatchesPublished)}, raw upstream matches=${String(live.upstreamSourceMatchesPublished)}, runtime snapshot consistent=${String(live.runtimeFresh)}`
         : `local published source hash ${input.sourceHash}`,
       fpf: ['B.3', 'G.6'],
     },
@@ -569,7 +576,9 @@ function evaluateLiveEvidence(
     statusSourceCoherent,
     websiteSourceMatchesPublished: live.websiteManifest.sourceHash === sourceHash,
     upstreamSourceMatchesPublished: live.upstreamSourceHash === sourceHash,
-    runtimeFresh: hosted.runtime.snapshotExists && hosted.runtime.fresh,
+    runtimeFresh:
+      hosted.runtime.snapshotExists
+      && (hosted.runtime.snapshotConsistent ?? hosted.runtime.fresh ?? false),
     publishedRefMatchesManifest: manifest?.upstreamRef
       ? hosted.publication.upstreamRef === manifest.upstreamRef
       : true,

--- a/src/build/production-smoke.ts
+++ b/src/build/production-smoke.ts
@@ -69,10 +69,13 @@ export interface ObservedStatusEndpoint {
   publicationSourceHash?: string;
   publicationPublishedAt?: string;
   runtimeBuiltAt?: string;
-  runtimeFresh?: boolean;
+  runtimeSnapshotConsistent?: boolean;
   runtimeSourceHash?: string;
   runtimeCurrentSourceHash?: string;
   runtimeSnapshotSourceHash?: string;
+  freshnessPublicationCurrent?: boolean;
+  freshnessBasis?: string;
+  freshnessUpstreamCurrentness?: string;
 }
 
 export interface ObservedMcpEndpoint {
@@ -310,6 +313,11 @@ async function fetchStatusEndpoint(
   const body = asRecord(await response.json(), 'status endpoint response');
   const publication = asRecord(body.publication, 'status publication');
   const runtime = asRecord(body.runtime, 'status runtime');
+  const freshness = typeof body.freshness === 'object' && body.freshness !== null
+    ? asRecord(body.freshness, 'status freshness')
+    : undefined;
+  const runtimeSnapshotConsistent =
+    booleanField(runtime.snapshotConsistent) ?? booleanField(runtime.fresh);
 
   return {
     servedAt: stringField(body.servedAt),
@@ -318,10 +326,17 @@ async function fetchStatusEndpoint(
     publicationSourceHash: stringField(publication.sourceHash),
     publicationPublishedAt: stringField(publication.publishedAt),
     runtimeBuiltAt: stringField(runtime.builtAt),
-    runtimeFresh: booleanField(runtime.fresh),
+    runtimeSnapshotConsistent,
     runtimeSourceHash: stringField(runtime.sourceHash),
     runtimeCurrentSourceHash: stringField(runtime.currentSourceHash),
     runtimeSnapshotSourceHash: stringField(runtime.snapshotSourceHash),
+    freshnessPublicationCurrent: freshness
+      ? booleanField(freshness.publicationCurrentAgainstConfiguredSource)
+      : runtimeSnapshotConsistent,
+    freshnessBasis: freshness ? stringField(freshness.freshnessBasis) : undefined,
+    freshnessUpstreamCurrentness: freshness
+      ? stringField(freshness.upstreamCurrentness)
+      : undefined,
   };
 }
 
@@ -336,8 +351,17 @@ function checkStatusEndpoint(
   const runtimeInternallyConsistent =
     status.runtimeSourceHash === status.runtimeCurrentSourceHash
     && status.runtimeSnapshotSourceHash === status.runtimeCurrentSourceHash
-    && status.runtimeFresh === true;
+    && status.runtimeSnapshotConsistent === true;
   const runtimeMatchesExpected = status.runtimeCurrentSourceHash === expected.sourceHash;
+  const freshnessBasisValid =
+    status.freshnessBasis === undefined || status.freshnessBasis === 'source_hash_match';
+  const upstreamCurrentnessDelimited =
+    status.freshnessUpstreamCurrentness === undefined
+    || status.freshnessUpstreamCurrentness === 'unknown';
+  const freshnessEnvelopeValid =
+    (status.freshnessPublicationCurrent ?? runtimeInternallyConsistent) === true
+    && freshnessBasisValid
+    && upstreamCurrentnessDelimited;
 
   return [
     {
@@ -351,14 +375,20 @@ function checkStatusEndpoint(
       characteristic: 'status endpoint runtime source',
       status: runtimeInternallyConsistent && runtimeMatchesExpected ? 'pass' : 'fail',
       evidence:
-        `runtime internalFresh=${String(status.runtimeFresh)}, runtimeSourceHash=${status.runtimeCurrentSourceHash ?? 'unknown'}`,
+        `runtime snapshotConsistent=${String(status.runtimeSnapshotConsistent)}, runtimeSourceHash=${status.runtimeCurrentSourceHash ?? 'unknown'}`,
       url,
     },
     {
       characteristic: 'status freshness basis',
-      status: publicationMatches && runtimeInternallyConsistent && runtimeMatchesExpected ? 'pass' : 'fail',
+      status:
+        publicationMatches
+        && runtimeInternallyConsistent
+        && runtimeMatchesExpected
+        && freshnessEnvelopeValid
+          ? 'pass'
+          : 'fail',
       evidence:
-        'freshness requires both internal snapshot consistency and match to the expected published/current artifact',
+        `freshnessBasis=${status.freshnessBasis ?? 'legacy_runtime_fresh'}, upstreamCurrentness=${status.freshnessUpstreamCurrentness ?? 'legacy_unspecified'}`,
       url,
     },
   ];

--- a/src/build/sync-monitor.ts
+++ b/src/build/sync-monitor.ts
@@ -79,7 +79,13 @@ export interface HostedSyncStatus {
     currentSourceHash: string;
     builtAt: string;
     snapshotExists: boolean;
-    fresh: boolean;
+    snapshotConsistent: boolean;
+    artifactSourceMatchesConfiguredSource: boolean;
+  };
+  freshness?: {
+    publicationCurrentAgainstConfiguredSource: boolean;
+    freshnessBasis: string;
+    upstreamCurrentness: 'unknown';
   };
 }
 
@@ -149,7 +155,7 @@ export function evaluateFpfSyncMonitor(input: {
   const runtimeFresh =
     input.hosted.status === 'ok'
     && input.hosted.runtime.snapshotExists
-    && input.hosted.runtime.fresh
+    && input.hosted.runtime.snapshotConsistent
     && sourceCoherent;
   const upstreamAhead = input.hosted.publication.upstreamRef !== input.upstream.sha;
   const driftHours = upstreamAhead
@@ -172,8 +178,8 @@ export function evaluateFpfSyncMonitor(input: {
       characteristic: 'coherence',
       status: runtimeFresh ? 'pass' : 'fail',
       evidence: runtimeFresh
-        ? `hosted runtime is fresh at ${input.hosted.runtime.currentSourceHash}`
-        : `hosted status=${input.hosted.status}, fresh=${String(input.hosted.runtime.fresh)}, sourceCoherent=${String(sourceCoherent)}`,
+        ? `hosted runtime snapshot is internally consistent at ${input.hosted.runtime.currentSourceHash}`
+        : `hosted status=${input.hosted.status}, snapshotConsistent=${String(input.hosted.runtime.snapshotConsistent)}, sourceCoherent=${String(sourceCoherent)}`,
       fpf: ['B.3', 'A.10'],
     },
     {
@@ -305,6 +311,14 @@ function parseHostedStatus(value: unknown): HostedSyncStatus {
     })
     .parse(record.publication);
   const runtime = requireRecord(record.runtime, 'hosted runtime');
+  const legacyFresh = typeof runtime.fresh === 'boolean' ? runtime.fresh : undefined;
+  const snapshotConsistent =
+    typeof runtime.snapshotConsistent === 'boolean'
+      ? runtime.snapshotConsistent
+      : legacyFresh;
+  if (snapshotConsistent === undefined) {
+    throw new Error('hosted runtime missing runtime.snapshotConsistent.');
+  }
   return {
     status: requireString(record.status, 'status'),
     servedAt: requireString(record.servedAt, 'servedAt'),
@@ -315,8 +329,25 @@ function parseHostedStatus(value: unknown): HostedSyncStatus {
       currentSourceHash: requireString(runtime.currentSourceHash, 'runtime.currentSourceHash'),
       builtAt: requireString(runtime.builtAt, 'runtime.builtAt'),
       snapshotExists: requireBoolean(runtime.snapshotExists, 'runtime.snapshotExists'),
-      fresh: requireBoolean(runtime.fresh, 'runtime.fresh'),
+      snapshotConsistent,
+      artifactSourceMatchesConfiguredSource:
+        typeof runtime.artifactSourceMatchesConfiguredSource === 'boolean'
+          ? runtime.artifactSourceMatchesConfiguredSource
+          : snapshotConsistent,
     },
+    freshness: typeof record.freshness === 'object' && record.freshness !== null
+      ? {
+        publicationCurrentAgainstConfiguredSource: requireBoolean(
+          (record.freshness as Record<string, unknown>).publicationCurrentAgainstConfiguredSource,
+          'freshness.publicationCurrentAgainstConfiguredSource',
+        ),
+        freshnessBasis: requireString(
+          (record.freshness as Record<string, unknown>).freshnessBasis,
+          'freshness.freshnessBasis',
+        ),
+        upstreamCurrentness: 'unknown',
+      }
+      : undefined,
   };
 }
 

--- a/tests/content-quality-monitor.test.ts
+++ b/tests/content-quality-monitor.test.ts
@@ -395,7 +395,13 @@ function makeHostedStatus(overrides: { sourceHash?: string } = {}): HostedConten
       snapshotSourceHash: sourceHash,
       currentSourceHash: sourceHash,
       snapshotExists: true,
-      fresh: true,
+      snapshotConsistent: true,
+      artifactSourceMatchesConfiguredSource: true,
+    },
+    freshness: {
+      publicationCurrentAgainstConfiguredSource: true,
+      freshnessBasis: 'source_hash_match',
+      upstreamCurrentness: 'unknown',
     },
   };
 }

--- a/tests/hosted-status.test.ts
+++ b/tests/hosted-status.test.ts
@@ -37,19 +37,47 @@ describe('hosted FPF status endpoint', () => {
     const response = await app.request(HOSTED_FPF_STATUS_ROUTE);
     const body = await response.json() as {
       status: string;
-      publication: { upstreamRef: string; sourceHash: string; publishedAt: string };
-      runtime: { fresh: boolean; currentSourceHash: string; compilerMode: string };
+      statusMeaning: string;
+      publication: {
+        upstreamRef: string;
+        upstreamDate: string;
+        sourceHash: string;
+        publishedAt: string;
+      };
+      runtime: {
+        snapshotConsistent: boolean;
+        artifactBuiltAt: string;
+        artifactSourceHash: string;
+        currentSourceHash: string;
+        compilerMode: string;
+        fresh?: boolean;
+      };
+      freshness: {
+        snapshotConsistent: boolean;
+        publicationCurrentAgainstConfiguredSource: boolean;
+        freshnessBasis: string;
+        upstreamCurrentness: string;
+      };
     };
 
     expect(response.status).toBe(200);
     expect(response.headers.get('Cache-Control')).toBe('no-store');
     expect(body.status).toBe('ok');
+    expect(body.statusMeaning).toContain('internally consistent');
     expect(body.publication.upstreamRef).toMatch(/^[0-9a-f]{40}$/);
+    expect(body.publication.upstreamDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(body.publication.sourceHash).toMatch(/^sha256:/);
     expect(body.publication.publishedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-    expect(body.runtime.fresh).toBe(true);
+    expect(body.runtime.fresh).toBeUndefined();
+    expect(body.runtime.snapshotConsistent).toBe(true);
+    expect(body.runtime.artifactBuiltAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(body.runtime.artifactSourceHash).toBe(body.publication.sourceHash);
     expect(body.runtime.currentSourceHash).toBe(body.publication.sourceHash);
     expect(body.runtime.compilerMode).toBe('local_vectorless');
+    expect(body.freshness.snapshotConsistent).toBe(true);
+    expect(body.freshness.publicationCurrentAgainstConfiguredSource).toBe(true);
+    expect(body.freshness.freshnessBasis).toBe('source_hash_match');
+    expect(body.freshness.upstreamCurrentness).toBe('unknown');
   }, 20_000);
 
   it('reads hosted staged manifest, source, and snapshot when present', async () => {
@@ -67,13 +95,19 @@ describe('hosted FPF status endpoint', () => {
 
     expect(status.status).toBe('ok');
     expect(status.publication.upstreamRef).toBe('1234567890abcdef1234567890abcdef12345678');
+    expect(status.publication.upstreamDate).toBe('2026-05-08T17:00:40Z');
     expect(status.publication.specBytes).toBe(Buffer.byteLength(specText));
-    expect(status.runtime.fresh).toBe(true);
+    expect(status.runtime.snapshotConsistent).toBe(true);
+    expect(status.runtime.artifactSourceMatchesConfiguredSource).toBe(true);
+    expect(status.runtime.artifactBuiltAt).toBe('2026-05-09T00:00:00.000Z');
     expect(status.runtime.sourcePath).toBe(HOSTED_STAGED_SOURCE_PATH);
     expect(status.runtime.manifestPath).toBe(HOSTED_STAGED_MANIFEST_PATH);
+    expect(status.freshness.publicationCurrentAgainstConfiguredSource).toBe(true);
+    expect(status.freshness.freshnessBasis).toBe('source_hash_match');
+    expect(status.freshness.upstreamCurrentness).toBe('unknown');
   });
 
-  it('reports stale when the staged snapshot does not match the staged source', async () => {
+  it('reports stale internal consistency without implying upstream currentness', async () => {
     const specText = '# Fake FPF\n\nHosted status fixture.\n';
     const sourceHash = `sha256:${createHash('sha256').update(specText).digest('hex')}`;
     await writeHostedStage({
@@ -87,9 +121,14 @@ describe('hosted FPF status endpoint', () => {
     const status = await readHostedFpfStatus({ cwd: tempRoot });
 
     expect(status.status).toBe('stale');
-    expect(status.runtime.fresh).toBe(false);
+    expect(status.runtime.snapshotConsistent).toBe(false);
+    expect(status.runtime.artifactSourceMatchesConfiguredSource).toBe(false);
     expect(status.runtime.currentSourceHash).toBe(sourceHash);
     expect(status.runtime.snapshotSourceHash).toBe('sha256:stale');
+    expect(status.freshness.snapshotConsistent).toBe(false);
+    expect(status.freshness.publicationCurrentAgainstConfiguredSource).toBe(false);
+    expect(status.freshness.freshnessBasis).toBe('unknown');
+    expect(status.freshness.upstreamCurrentness).toBe('unknown');
   });
 });
 

--- a/tests/production-smoke.test.ts
+++ b/tests/production-smoke.test.ts
@@ -37,7 +37,7 @@ describe('semantic production smoke', () => {
       fetchImpl: createSmokeFetch({
         statusSourceHash: 'sha256:old',
         statusUpstreamRef: 'fedcba0987654321fedcba0987654321fedcba09',
-        statusRuntimeFresh: true,
+        statusSnapshotConsistent: true,
       }),
     });
 
@@ -45,8 +45,20 @@ describe('semantic production smoke', () => {
     expect(report.summary).toContain('status endpoint publication artifact');
     expect(report.summary).toContain('status endpoint runtime source');
     expect(formatProductionSmokeMarkdown(report)).toContain(
-      'freshness requires both internal snapshot consistency and match to the expected published/current artifact',
+      'freshnessBasis=source_hash_match, upstreamCurrentness=unknown',
     );
+  });
+
+  it('accepts transitional legacy runtime.fresh status payloads', async () => {
+    const report = await runProductionSmoke({
+      websiteBaseUrl: 'https://docs.example.test',
+      mcpBaseUrl: 'https://mcp.example.test',
+      expectedPublication: EXPECTED,
+      fetchImpl: createSmokeFetch({ legacyStatusFresh: true }),
+    });
+
+    expect(report.ok).toBe(true);
+    expect(formatProductionSmokeMarkdown(report)).toContain('legacy_runtime_fresh');
   });
 
   it('breaches when old fpf_memory onboarding is primary or unlabeled', async () => {
@@ -89,10 +101,12 @@ function createSmokeFetch(overrides: {
   mcpConnectText?: string;
   statusSourceHash?: string;
   statusUpstreamRef?: string;
-  statusRuntimeFresh?: boolean;
+  statusSnapshotConsistent?: boolean;
+  legacyStatusFresh?: boolean;
 } = {}): typeof fetch {
   const statusSourceHash = overrides.statusSourceHash ?? EXPECTED.sourceHash;
   const statusUpstreamRef = overrides.statusUpstreamRef ?? EXPECTED.upstreamRef;
+  const statusSnapshotConsistent = overrides.statusSnapshotConsistent ?? true;
 
   const fakeFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const url = new URL(typeof input === 'string' || input instanceof URL ? input : input.url);
@@ -113,8 +127,20 @@ function createSmokeFetch(overrides: {
           currentSourceHash: statusSourceHash,
           builtAt: '2026-05-31T09:25:00.097Z',
           snapshotExists: true,
-          fresh: overrides.statusRuntimeFresh ?? true,
+          ...(overrides.legacyStatusFresh
+            ? { fresh: statusSnapshotConsistent }
+            : { snapshotConsistent: statusSnapshotConsistent }),
         },
+        ...(overrides.legacyStatusFresh
+          ? {}
+          : {
+            freshness: {
+              snapshotConsistent: statusSnapshotConsistent,
+              publicationCurrentAgainstConfiguredSource: statusSnapshotConsistent,
+              freshnessBasis: statusSnapshotConsistent ? 'source_hash_match' : 'unknown',
+              upstreamCurrentness: 'unknown',
+            },
+          }),
       });
     }
 

--- a/tests/sync-monitor.test.ts
+++ b/tests/sync-monitor.test.ts
@@ -60,6 +60,65 @@ describe('FPF sync monitor', () => {
     expect(report.summary).toContain('exceeding the 10h sync SLO');
   });
 
+  it('does not treat internal snapshot consistency as upstream currentness', () => {
+    const report = evaluateFpfSyncMonitor({
+      upstream: makeUpstream({
+        sha: SHA_CURRENT,
+        committedAt: '2026-05-29T20:00:00Z',
+      }),
+      hosted: makeHosted({
+        upstreamRef: SHA_PUBLISHED,
+        runtimeFresh: true,
+      }),
+      now: new Date('2026-05-30T12:00:00Z'),
+      maxDriftHours: 10,
+    });
+
+    expect(report.runtimeFresh).toBe(true);
+    expect(report.sourceCoherent).toBe(true);
+    expect(report.upstreamAhead).toBe(true);
+    expect(report.state).toBe('breach');
+    expect(report.summary).toContain('exceeding the 10h sync SLO');
+  });
+
+  it('accepts the transitional legacy runtime.fresh field while parsing hosted status', async () => {
+    const fetchImpl = Object.assign(
+      async (url: Parameters<typeof fetch>[0]) => {
+        if (String(url).includes('api.github.com')) {
+          return jsonResponse({
+            sha: SHA_CURRENT,
+            html_url: `https://github.com/ailev/FPF/commit/${SHA_CURRENT}`,
+            commit: {
+              message: 'quality improvement campaign results',
+              author: { date: '2026-05-30T08:00:00Z' },
+            },
+          });
+        }
+
+        const status = makeHosted({ upstreamRef: SHA_CURRENT });
+        return jsonResponse({
+          ...status,
+          runtime: {
+            ...status.runtime,
+            snapshotConsistent: undefined,
+            artifactSourceMatchesConfiguredSource: undefined,
+            fresh: true,
+          },
+        });
+      },
+      { preconnect: fetch.preconnect },
+    ) satisfies typeof fetch;
+
+    const report = await runFpfSyncMonitor({
+      fetchImpl,
+      now: new Date('2026-05-30T12:00:00Z'),
+      maxDriftHours: 10,
+    });
+
+    expect(report.runtimeFresh).toBe(true);
+    expect(report.state).toBe('ok');
+  });
+
   it('breaches when the hosted runtime is internally stale', () => {
     const report = evaluateFpfSyncMonitor({
       upstream: makeUpstream({ sha: SHA_CURRENT }),
@@ -173,7 +232,13 @@ function makeHosted(
       currentSourceHash: sourceHash,
       builtAt: '2026-05-30T10:00:00Z',
       snapshotExists: true,
-      fresh: overrides.runtimeFresh ?? true,
+      snapshotConsistent: overrides.runtimeFresh ?? true,
+      artifactSourceMatchesConfiguredSource: overrides.runtimeFresh ?? true,
+    },
+    freshness: {
+      publicationCurrentAgainstConfiguredSource: overrides.runtimeFresh ?? true,
+      freshnessBasis: overrides.runtimeFresh ?? true ? 'source_hash_match' : 'unknown',
+      upstreamCurrentness: 'unknown',
     },
   };
 }


### PR DESCRIPTION
## Problem statement

`/api/fpf/status` used `status: ok` and `runtime.fresh` in a way that could be read as a proof that production was current against upstream. The endpoint can only prove deployed artifact consistency by itself; upstream currentness requires external comparison against the intended upstream ref/source hash.

## Files changed

- `src/adapters/hosted/status-page.ts` splits internal consistency from upstream currentness and adds `statusMeaning`, `publication.upstreamDate`, `runtime.snapshotConsistent`, artifact fields, and a `freshness` envelope.
- `src/build/sync-monitor.ts`, `src/build/content-quality-monitor.ts`, and `scripts/monitor-fpf-sync.ts` consume `runtime.snapshotConsistent` while accepting legacy `runtime.fresh` during rollout.
- `src/build/production-smoke.ts` validates the clarified status shape and remains compatible with current production until this PR is deployed.
- `README.md`, `docs/connect-mcp.md`, and `docs/automation-playbook.md` document that `status: ok` is internal artifact consistency, not upstream-current proof.
- Tests cover hosted status semantics, sync/content monitor compatibility, and production smoke behavior.

## Validation commands

- `bunx rstest run tests/production-smoke.test.ts tests/hosted-status.test.ts tests/sync-monitor.test.ts tests/content-quality-monitor.test.ts`
- `bun run check`
- `bun run lint`
- `bun run docs:build`
- `bun run vercel:mcp:build`
- `env FPF_RUNTIME_ARTIFACT_DIR=$(mktemp -d /tmp/fpf-status-smoke-artifacts.XXXXXX) bun run smoke:production -- --local --format markdown --fail-on-breach`
- `bun run smoke:production -- --format markdown --fail-on-breach`
- `bun run monitor:sync -- --format markdown --fail-on-breach`
- `bun run monitor:content -- --mode live --format markdown --fail-on-breach`
- `bun run check:boundaries`
- `bun run evaluate:work`
- `git diff --check HEAD~1..HEAD`

## Test output

- Rstest: 23/23 passed across production smoke, hosted status, sync monitor, and content quality monitor tests.
- Typecheck: passed.
- Lint: 0 errors, 0 type errors, 0 warnings.
- Docs build: passed; generated 989 docs files and built Rspress web/node output.
- MCP build: passed; Vercel function bundle 101.33 MB with 138.67 MB fail-threshold headroom.
- Local semantic smoke: 25/25 checks passed with `runtime snapshotConsistent=true` and `freshnessBasis=source_hash_match, upstreamCurrentness=unknown`.
- Live semantic smoke against current production: 25/25 checks passed; compatibility path reports `freshnessBasis=legacy_runtime_fresh`.
- Live sync monitor: State `ok`; published upstreamRef matches `16cd3138`; coherence evidence now says hosted runtime snapshot is internally consistent.
- Live content monitor: State `ok`; route coverage 23/23, route pages 23/23, content refs 172/172, pattern links 119/119, raw upstream/source hashes match.
- FPF work evaluation: Overall `aligned`.

## Live production evidence

Current production is still on the legacy status schema, so this PR was verified in two layers: local hosted smoke for the new schema and live smoke/monitors for backward compatibility against current production. Live production currently reports upstreamRef `16cd31387cff04ab6b0feef22717f82ac54efa8f` and sourceHash `sha256:f86b7e00c39bb0e9b817917f807b5514048d763988c682b81a61b8190cba7158`.

## Caveats / residual risk

- The new status fields are not live until this PR is merged and deployed.
- `status: ok` remains intentionally scoped to internal deployed-artifact consistency; external monitors remain the authority for upstream currentness.
- The smoke checker keeps transitional legacy support so rollout does not fail while current production still emits `runtime.fresh`.

## What would falsify the success claim

- `/api/fpf/status` still emits `runtime.fresh` after this PR is deployed.
- The endpoint claims upstream currentness without an external monitor comparison.
- Live semantic smoke fails the status freshness-basis check after deployment.
- Sync/content monitors fail to parse either the new status payload or the transitional legacy payload.

Privacy: this PR and validation packet do not log or report raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production observability contracts and monitor/smoke parsing; rollout relies on transitional legacy runtime.fresh support until deploy completes.
> 
> **Overview**
> **`/api/fpf/status`** no longer implies production is current against upstream. **`runtime.fresh`** is replaced by **`runtime.snapshotConsistent`** (deployed source, manifest, and snapshot agree), plus a **`freshness`** block with **`freshnessBasis`** and **`upstreamCurrentness: unknown`** by design.
> 
> **Sync monitor**, **content-quality monitor**, **production smoke**, and **`monitor-fpf-sync`** read the new fields and still accept legacy **`runtime.fresh`** during rollout. Docs (**README**, **connect-mcp**, **automation-playbook**) state that **`status: ok`** is internal artifact consistency only; upstream currentness stays with external monitors comparing **`publication.upstreamRef`** / **`sourceHash`** to the intended artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da518438cf2e9f6edc583d92976eb33d7314a85f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->