### PR TITLE
docs: add production evidence packet template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,6 +30,55 @@
 - End-to-end verification command + output excerpt:
 - Caveats or blocker:
 
+## Production evidence packet
+
+Required when the PR changes production-facing behavior, deployment, automation, monitoring, public docs, MCP routes, or published artifacts. Do not paste raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers.
+
+### Promise checked
+
+
+
+### URLs checked
+
+
+
+### Commands run
+
+
+
+### Expected semantic invariants
+
+- HTTP availability:
+- semantic correctness:
+- freshness/currentness:
+- route naming:
+- live behavior:
+- cost/risk guardrails:
+
+### Actual output excerpt
+
+
+
+### Upstream ref / source hash
+
+
+
+### Deployment URL / alias checked
+
+
+
+### Rollback target
+
+
+
+### Known caveats
+
+
+
+### What would falsify this success claim?
+
+
+
 ## Boundary check
 
 - Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
@@ -47,5 +96,5 @@
 | Field   | Value |
 | ------- | ----- |
 | Agent   |       |
-| Session |       |
-| Prompt  |       |
+| Task source |       |
+| Privacy check | No raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers included. |

--- a/docs/automation-playbook.md
+++ b/docs/automation-playbook.md
@@ -141,6 +141,43 @@ Done means each claim has current evidence. Do not treat a green local build, a 
    - Separate ability from performance: what the system can do, what was actually observed, and what remains unproven.
    - State residual uncertainty explicitly, especially when relying on cached responses, local DNS, or pending external checks.
 
+### Production evidence packet template
+
+Use this packet for production-affecting PRs, deploys, incident fixes, and manager briefs. It is intentionally stricter than "HTTP 200" or "status: ok" evidence: it separates availability, semantic correctness, freshness/currentness, route naming, live behavior, and cost/risk guardrails.
+
+Do not include raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers.
+
+```md
+## Production evidence packet
+
+### Promise checked
+
+### URLs checked
+
+### Commands run
+
+### Expected semantic invariants
+
+- HTTP availability:
+- semantic correctness:
+- freshness/currentness:
+- route naming:
+- live behavior:
+- cost/risk guardrails:
+
+### Actual output excerpt
+
+### Upstream ref / source hash
+
+### Deployment URL / alias checked
+
+### Rollback target
+
+### Known caveats
+
+### What would falsify this success claim?
+```
+
 ## fpf.sh Sync QA and Monitoring
 
 The production sync loop uses FPF as a quality model:

--- a/tests/production-evidence-template.test.ts
+++ b/tests/production-evidence-template.test.ts
@@ -1,0 +1,62 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from '@rstest/core';
+
+const REQUIRED_PACKET_FIELDS = [
+  '## Production evidence packet',
+  '### Promise checked',
+  '### URLs checked',
+  '### Commands run',
+  '### Expected semantic invariants',
+  'HTTP availability:',
+  'semantic correctness:',
+  'freshness/currentness:',
+  'route naming:',
+  'live behavior:',
+  'cost/risk guardrails:',
+  '### Actual output excerpt',
+  '### Upstream ref / source hash',
+  '### Deployment URL / alias checked',
+  '### Rollback target',
+  '### Known caveats',
+  '### What would falsify this success claim?',
+];
+
+const PRIVATE_ARTIFACT_BOUNDARY =
+  'No raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers included.';
+
+async function readRepoFile(path: string): Promise<string> {
+  return readFile(resolve(process.cwd(), path), 'utf8');
+}
+
+describe('production evidence packet template', () => {
+  it('requires semantic production evidence in PRs', async () => {
+    const template = await readRepoFile('.github/pull_request_template.md');
+
+    for (const field of REQUIRED_PACKET_FIELDS) {
+      expect(template).toContain(field);
+    }
+
+    expect(template).toContain('production-facing behavior');
+    expect(template).toContain(PRIVATE_ARTIFACT_BOUNDARY);
+    expect(template).not.toContain('| Session |');
+    expect(template).not.toContain('| Prompt  |');
+  });
+
+  it('documents the same packet in the automation playbook', async () => {
+    const playbook = await readRepoFile('docs/automation-playbook.md');
+
+    for (const field of REQUIRED_PACKET_FIELDS) {
+      expect(playbook).toContain(field);
+    }
+
+    expect(playbook).toContain('production-affecting PRs');
+    expect(playbook).toContain('semantic correctness');
+    expect(playbook).toContain('freshness/currentness');
+    expect(playbook).toContain('cost/risk guardrails');
+    expect(playbook).toContain(
+      'Do not include raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers.',
+    );
+  });
+});


### PR DESCRIPTION
## Problem statement
Production-facing PRs already include evidence comments, but the reusable process shape was not strict enough to prevent false-green checks based only on HTTP status, page title, or `status: ok`. The existing PR template also exposed raw `Session` and `Prompt` fields, which conflicts with the privacy boundary in the task brief.

## Files changed
- `.github/pull_request_template.md`: add a required production evidence packet for production-affecting PRs and replace raw `Session` / `Prompt` metadata with safer task-source and privacy-check fields.
- `docs/automation-playbook.md`: publish the same production evidence packet template under the Executive Production Checklist.
- `tests/production-evidence-template.test.ts`: regression coverage for packet fields and the privacy boundary.

## Validation commands
- `bunx rstest run tests/production-evidence-template.test.ts`
- `bun run check`
- `bun run docs:build`
- `bun run lint`
- `bun run check:boundaries`
- `rg -n "Production evidence packet|Executive Production Checklist|fpf_reference|405|evidence packet|semantic correctness|freshness/currentness|cost/risk guardrails" docs/automation-playbook.md doc_build/automation-playbook.html .github/pull_request_template.md`
- `git diff --check`

## Test output
- Focused Rstest: 1 file, 2 tests, 0 failures.
- Typecheck: `tsc --noEmit` completed successfully.
- Docs build: generated 989 docs files; Rspress web/node builds completed successfully.
- Lint: 0 lint errors, 0 type errors, 0 warnings.
- Boundary check: passed.
- Diff whitespace check: passed.

## Live production evidence when applicable
Not live yet. This PR changes a public docs page and PR template; after merge, `fpf.sh` must be redeployed and `https://fpf.sh/automation-playbook` must be checked for the Executive Production Checklist, `fpf_reference`, `405`, `evidence packet`, and the production evidence packet template.

## Caveats / residual risk
This is a process/docs change. It cannot force authors to fill the packet completely without a future CI or PR-body policy check.

## What would falsify the success claim?
- A new production-affecting PR can be opened without seeing the evidence packet in the template.
- The automation playbook source or built page lacks the packet.
- The template encourages raw prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers.
- The live automation playbook page remains stale after production deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and PR-process changes only; no runtime, auth, or deployment logic is modified.
> 
> **Overview**
> Introduces a **required production evidence packet** for PRs that touch production-facing behavior, deployment, automation, monitoring, public docs, MCP routes, or published artifacts. The packet goes beyond HTTP/status checks by asking authors to document promises, URLs, commands, semantic invariants (availability, correctness, freshness, routes, live behavior, cost guardrails), deployment/rollback context, and what would falsify the claim.
> 
> The same template is added to `docs/automation-playbook.md` under the Executive Production Checklist. **Agent metadata** in the PR template drops raw `Session` / `Prompt` fields in favor of **Task source** and a **Privacy check** line that forbids pasting user questions, prompts, answer text, selectors, bodies, session IDs, IPs, or identifiers.
> 
> **`tests/production-evidence-template.test.ts`** locks in required packet headings/invariants in both the PR template and playbook and asserts the privacy boundary and removal of session/prompt columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0480712605f316d0f4b7eaa4eb2640ecea5645df. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->