### PR TITLE
fix(runtime): fingerprint the real tokenizer in the snapshot input set

### DIFF
--- a/published/current/manifest.json
+++ b/published/current/manifest.json
@@ -1,12 +1,12 @@
 {
   "channel": "latest-published",
   "sourceHash": "sha256:f86b7e00c39bb0e9b817917f807b5514048d763988c682b81a61b8190cba7158",
-  "compilerFingerprint": "sha256:fb4598cc919f65dca49d0ae696174c75c1ddd6524c541ec2942d25c1088f3dd3",
+  "compilerFingerprint": "sha256:c78f228313fd0d71aa6abdc572032afd931ccb8de7bca456aa215875076abafe",
   "upstreamRef": "16cd31387cff04ab6b0feef22717f82ac54efa8f",
   "upstreamRepoUrl": "https://github.com/ailev/FPF",
   "upstreamCommittedAt": "2026-05-31T07:57:58Z",
   "specPath": "published/current/FPF-Spec.md",
   "snapshotPath": "published/current/fpf-index/snapshot.json",
   "specBytes": 8105549,
-  "publishedAt": "2026-05-31T19:47:12.869Z"
+  "publishedAt": "2026-06-01T23:01:58.714Z"
 }

--- a/src/build/compiler-fingerprint.ts
+++ b/src/build/compiler-fingerprint.ts
@@ -15,7 +15,8 @@ export const SNAPSHOT_COMPILER_FINGERPRINT_INPUTS = [
   'src/runtime/graph-compiler.ts',
   'src/runtime/index-projector.ts',
   'src/runtime/validation-runner.ts',
-  'src/runtime/text.ts',
+  'src/runtime/route-intent-signals.ts',
+  'src/core/text.ts',
   'src/runtime/text-scan.ts',
 ] as const;
 


### PR DESCRIPTION
## What

Fix a stale-index correctness gap: `computeCompilerFingerprint` was hashing `src/runtime/text.ts` — a one-line barrel that just re-exports `src/core/text.ts` — so the actual tokenizer and the `route-intent-signals` constants that feed `snapshot.heuristicSeedRules` were never part of the fingerprint.

## Why

The compiler fingerprint exists to force `published/current/**` to be republished whenever snapshot-determining code changes. Because the real tokenizer (`cleanMarkdown` / `stripMarkdownToText` / `tokenize` / `scoreOverlap` / stop-words in `src/core/text.ts`) and `src/runtime/route-intent-signals.ts` were not hashed, editing either would **not** invalidate the published snapshot — so `/api/fpf/status` could report `fresh` / `snapshotConsistent` against an index built by older tokenizer logic. This closes that gap.

## Type

- `fix` — correctness (snapshot freshness/consistency)

## Changes

- `src/build/compiler-fingerprint.ts`: replace the `src/runtime/text.ts` barrel with `src/core/text.ts` and add `src/runtime/route-intent-signals.ts` to `SNAPSHOT_COMPILER_FINGERPRINT_INPUTS`.
- Republish `published/current/**` at the **same** upstream ref (`16cd3138`, unchanged) so only the `compilerFingerprint` changes (`fb4598cc…` → `c78f2283…`). `sourceHash` and the spec are byte-identical; the 89 MB snapshot diff is 6/5 lines (fingerprint + build timestamp only).

## Validation

- `bun run lint` passes locally — 0 errors, 0 warnings (164 files)
- `bun run check` passes locally — `tsc --noEmit` exit 0
- `bun run test` passes locally — **371 passed, 0 failed**
- No new warnings introduced
- `bun run build` — not re-run (no runtime/server entrypoint changed; only the fingerprint input list)
- `bun run docs:build` — not applicable (no docs changed)
- Relevant docs updated: n/a (internal build detail)
- End-to-end verification command + output excerpt: `bun run validate:published` → `sourceHash sha256:f86b7e00…`, `upstreamRef 16cd3138…` (consistent)
- Caveats or blocker: none. The next deploy will carry the new fingerprint to `mcp.fpf.sh`; until then production reports the old fingerprint, which is expected.

## Production evidence packet

### Promise checked

Snapshot freshness/consistency is determined by *all* snapshot-affecting compiler inputs. `sourceHash` and spec content are unchanged; only the fingerprint coverage is corrected.

### URLs checked

`https://mcp.fpf.sh/api/fpf/status` (pre-change baseline).

### Commands run

`FPF_UPSTREAM_REF=16cd3138… bun run spec:download`; `… bun run publish:current`; `bun run validate:published`; `bun run check`; `bun run lint`; `bun run test`.

### Expected semantic invariants

- HTTP availability: unaffected (no runtime route change)
- semantic correctness: full unit suite green (371); retrieval output unchanged (same snapshot content)
- freshness/currentness: **improved** — fingerprint now covers the tokenizer + route-intent-signals
- route naming: unchanged
- live behavior: unchanged until next deploy
- cost/risk guardrails: none affected

### Actual output excerpt

- `publish:current` → `"compilerFingerprint":"sha256:c78f228313fd0d71aa6abdc572032afd931ccb8de7bca456aa215875076abafe"`, `"sourceHash":"sha256:f86b7e00…"` (unchanged)
- `git diff --stat` → `published/current/fpf-index/snapshot.json`, `published/current/manifest.json`, `src/build/compiler-fingerprint.ts`; **FPF-Spec.md not modified**

### Upstream ref / source hash

`upstreamRef 16cd31387cff04ab6b0feef22717f82ac54efa8f`; `sourceHash sha256:f86b7e00c39bb0e9b817917f807b5514048d763988c682b81a61b8190cba7158` (both unchanged — republished at the same ref).

### Deployment URL / alias checked

`mcp.fpf.sh` (baseline). This PR does not deploy; the new fingerprint reaches production on the next deploy.

### Rollback target

Revert commit `2d5ebd21`. Restores the prior fingerprint input list and the prior `published/current` (sourceHash identical, so no content rollback needed).

### Known caveats

After merge, deploy `mcp.fpf.sh` so its `/api/fpf/status` `compilerFingerprint` matches the committed `c78f2283…`; otherwise the sync monitor's currentness comparison sees the old fingerprint.

### What would falsify this success claim?

`validate:published` failing; the spec `sourceHash` changing; or retrieval output differing from the prior snapshot.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts remain in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Claude Code (Opus 4.8) |
| Task source | User-requested audit follow-up (Track D) |
| Privacy check | No raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers included. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/publish metadata and fingerprint input list only; spec content and runtime routes are unchanged.
> 
> **Overview**
> Fixes **snapshot freshness** by correcting which files feed `computeCompilerFingerprint`. The fingerprint input list now hashes **`src/core/text.ts`** (the real tokenizer) instead of the **`src/runtime/text.ts`** re-export barrel, and adds **`src/runtime/route-intent-signals.ts`** so heuristic seed rules are covered. Without this, edits to those files would not bump `compilerFingerprint`, so `/api/fpf/status` could still report a consistent snapshot built with older logic.
> 
> **`published/current`** is republished at the **same** upstream ref and **`sourceHash`**; only **`compilerFingerprint`**, **`builtAt`**, and **`publishedAt`** change in `manifest.json` and `fpf-index/snapshot.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d5ebd21b98f5f6d4df007086cc7abdd5ff4d8f8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->