### PR TITLE
chore(deploy): pin Vercel CLI to 54.7.1 (was @latest)

### DIFF
--- a/scripts/deploy-production-surfaces.ts
+++ b/scripts/deploy-production-surfaces.ts
@@ -309,11 +309,11 @@ function requiredUrl(state: PreparedSurface): string {
 }
 
 function runVercel(args: string[]): void {
-  run('npx', ['--yes', 'vercel@latest', ...args]);
+  run('npx', ['--yes', 'vercel@54.7.1', ...args]);
 }
 
 function runVercelCapture(args: string[]): string {
-  return run('npx', ['--yes', 'vercel@latest', ...args], { capture: true });
+  return run('npx', ['--yes', 'vercel@54.7.1', ...args], { capture: true });
 }
 
 function vercelScopeArgs(): string[] {

--- a/scripts/deploy-vercel-prebuilt.ts
+++ b/scripts/deploy-vercel-prebuilt.ts
@@ -49,7 +49,7 @@ try {
 }
 
 function runVercel(args: string[]): void {
-  run('npx', ['--yes', 'vercel@latest', ...args]);
+  run('npx', ['--yes', 'vercel@54.7.1', ...args]);
 }
 
 function parseArgs(rawArgs: string[], env: NodeJS.ProcessEnv): DeployArgs {

--- a/scripts/monitor-vercel-spend.ts
+++ b/scripts/monitor-vercel-spend.ts
@@ -182,7 +182,7 @@ function createReport(): VercelSpendMonitorReport {
 }
 
 function runVercelMetrics(args: string[]): unknown {
-  const commandArgs = ['--yes', 'vercel@latest', 'metrics', ...args, '--non-interactive'];
+  const commandArgs = ['--yes', 'vercel@54.7.1', 'metrics', ...args, '--non-interactive'];
   const result = spawnSync('npx', commandArgs, {
     encoding: 'utf8',
     env: process.env,

--- a/scripts/usage-report.ts
+++ b/scripts/usage-report.ts
@@ -135,7 +135,7 @@ function runVercelLogs(input: {
 }): string[] {
   const args = [
     '--yes',
-    'vercel@latest',
+    'vercel@54.7.1',
     'logs',
     '--project',
     input.project,

--- a/tests/deploy-production-surfaces-workflow.test.ts
+++ b/tests/deploy-production-surfaces-workflow.test.ts
@@ -124,7 +124,7 @@ exit 64
     `#!/bin/sh
 set -eu
 printf 'npx %s\\n' "$*" >> "$FPF_DEPLOY_COMMAND_LOG"
-if [ "$1" = "--yes" ] && [ "$2" = "vercel@latest" ]; then
+if [ "$1" = "--yes" ] && [ "$2" = "vercel@54.7.1" ]; then
   shift 2
 fi
 command="$1"


### PR DESCRIPTION
## What

Pin the Vercel CLI used by the deploy and monitor scripts from `vercel@latest` to **`vercel@54.7.1`**.

## Why

Every production deploy and every scheduled spend/usage monitor run invoked `npx --yes vercel@latest`, pulling an unpinned CLI. A surprise major-version release could change flags/behavior and break the deploy or metrics path with no warning. `54.7.1` is the version just validated end-to-end this session — it ran both the production MCP deploy and `vercel metrics` successfully — so it's a known-good pin.

## Type

- `chore` — deploy/CI toolchain hardening

## Changes

- `scripts/deploy-production-surfaces.ts` (×2), `scripts/deploy-vercel-prebuilt.ts` — deploy/link/promote/alias calls
- `scripts/monitor-vercel-spend.ts` — `vercel metrics`
- `scripts/usage-report.ts` — `vercel logs`
- `tests/deploy-production-surfaces-workflow.test.ts` — updated the `npx` stub matcher in lockstep so the executed-script test still asserts the real invocation

Bump deliberately later by grepping `vercel@54.7.1`. (The bare `vercel link` helper scripts in `package.json` use a globally-installed CLI and are out of scope here.)

## Validation

- `bun run lint` passes locally — 0 errors, 0 warnings (149 files)
- `bun run check` passes locally — `tsc --noEmit` exit 0
- `bun run test` — ran the affected `deploy-production-surfaces-workflow.test.ts` → **2/2 pass** (it executes the deploy script against a fake `npx` and asserts the `vercel` invocation)
- No new warnings introduced
- `bun run build` — n/a (no runtime/server code changed)
- `bun run docs:build` — n/a
- Relevant docs updated: n/a (internal toolchain)
- End-to-end verification command + output excerpt: `grep -rn vercel@latest --include='*.ts' --include='*.yml' .` → none remain
- Caveats or blocker: none. Pure version pin; no endpoint/behavior change.

## Production evidence packet

### Promise checked
Deploy and metrics toolchain is deterministic (pinned), not floating on `@latest`.

### URLs checked
n/a — no deployment performed by this PR; no endpoint behavior change.

### Commands run
`bun run check`, `bun run lint`, `bunx rstest run tests/deploy-production-surfaces-workflow.test.ts`, `grep vercel@latest`.

### Expected semantic invariants
- HTTP availability: unaffected
- semantic correctness: deploy/monitor scripts invoke `vercel@54.7.1`; workflow test confirms the invocation
- freshness/currentness: unaffected
- route naming: unaffected
- live behavior: unaffected (no deploy in this PR)
- cost/risk guardrails: reduces supply-chain/breakage risk from floating `@latest`

### Actual output excerpt
`deploy-production-surfaces-workflow.test.ts` → `"passedTests": 2, "failedTests": 0`; `grep vercel@latest` → none.

### Upstream ref / source hash
Unchanged; `published/current/**` untouched.

### Deployment URL / alias checked
n/a (no deploy in this PR). `54.7.1` was validated by the separate `mcp.fpf.sh` production deploy earlier this session.

### Rollback target
Revert commit `098d5b7d` (restores `@latest`).

### Known caveats
`54.7.1` is exact; bump deliberately for CLI security/feature updates.

### What would falsify this success claim?
A pinned `54.7.1` lacking a flag the scripts use (none observed — it ran deploy + metrics this session).

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts remain in `src/mcp/tool-contracts.ts`

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Claude Code (Opus 4.8) |
| Task source | User-requested audit follow-up (Track A: CLI pin) |
| Privacy check | No raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers included. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only toolchain pin with no application runtime or API behavior changes; reduces risk of surprise CLI breakage from floating @latest.
> 
> **Overview**
> Replaces **`vercel@latest`** with a pinned **`vercel@54.7.1`** everywhere deploy and ops scripts invoke the CLI via `npx`, so production deploys, spend monitoring, and usage reporting no longer float on an unpinned major release.
> 
> **Deploy paths:** `runVercel` / `runVercelCapture` in `deploy-production-surfaces.ts` and `deploy-vercel-prebuilt.ts` now pass `vercel@54.7.1` instead of `@latest`.
> 
> **Ops paths:** `monitor-vercel-spend.ts` (`vercel metrics`) and `usage-report.ts` (`vercel logs`) use the same pin.
> 
> **Tests:** The fake `npx` stub in `deploy-production-surfaces-workflow.test.ts` strips `vercel@54.7.1` the way it previously stripped `@latest`, keeping the workflow test aligned with the real invocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 098d5b7d806c67c9866ee6bd8f0c6cefd906b763. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->