### PR TITLE
fix(sync): replace 2h runner sleep with a monitor-driven review window

### DIFF
--- a/.github/workflows/sync-fpf.yml
+++ b/.github/workflows/sync-fpf.yml
@@ -279,10 +279,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          echo "Opened sync PR #$PR_NUMBER; waiting two hours before merge eligibility check."
-          sleep 7200
+          # Review window without parking a runner for two hours: exit early when the
+          # PR is younger than the window. fpf-sync-monitor runs hourly and re-dispatches
+          # this worker while production is still behind upstream (its "worker retry can
+          # recheck merge eligibility" path), so eligibility is rechecked each hour until
+          # the window elapses — then this step proceeds to the same merge + deploy below.
+          REVIEW_WINDOW_SECONDS=7200
+          PR_INFO=$(gh pr view "$PR_NUMBER" --json state,createdAt)
+          PR_STATE=$(jq -r .state <<<"$PR_INFO")
+          PR_CREATED_AT=$(jq -r .createdAt <<<"$PR_INFO")
+          PR_AGE_SECONDS=$(( $(date -u +%s) - $(date -u -d "$PR_CREATED_AT" +%s) ))
+          if [ "$PR_AGE_SECONDS" -lt "$REVIEW_WINDOW_SECONDS" ]; then
+            echo "Sync PR #$PR_NUMBER is ${PR_AGE_SECONDS}s old (< ${REVIEW_WINDOW_SECONDS}s review window); leaving it open. The hourly fpf-sync-monitor will re-dispatch this worker to recheck merge eligibility."
+            exit 0
+          fi
 
-          PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq .state)
           if [ "$PR_STATE" != "OPEN" ]; then
             echo "Sync PR #$PR_NUMBER is $PR_STATE; nothing to merge."
             exit 0


### PR DESCRIPTION
## What

Replace the 2-hour `sleep 7200` in `sync-fpf.yml`'s "Merge sync PR" step with an **age-gate** that exits early when the PR is younger than the review window, letting the existing hourly `fpf-sync-monitor` re-dispatch the worker to recheck eligibility.

> ⚠️ **Not runtime-verified — needs a CI test-merge before trusting.** GitHub Actions can't run in the authoring environment. YAML is validated and the gating/merge/deploy logic is preserved verbatim, but please exercise the test plan below on a real or dispatched sync before relying on it.

## Why

The merge step parked a GitHub-hosted runner on `sleep 7200` (2h) for every upstream sync, and a runner restart/cancel during the sleep **lost the merge entirely**. That's wasteful and fragile for a review window.

`fpf-sync-monitor.yml` already runs hourly and, while production is behind upstream and no worker is active, **re-dispatches `sync-fpf.yml`** — its own steps document this as the path where "a worker retry can recheck merge eligibility" (`fpf-sync-monitor.yml:78-80,124-129`). This PR leans on that existing loop instead of a blocking sleep.

## Changes

`sync-fpf.yml` — the "Merge sync PR after two-hour review window" step:
- **Removed** `sleep 7200`.
- **Added** an age-gate: read `createdAt`, compute age, and `exit 0` (leave PR open) if `age < REVIEW_WINDOW_SECONDS (7200)`.
- **Unchanged:** everything after — the PR-open check, manual-CI-success check, `REQUIRED_CHECK_NAMES` gate, `NOT_READY` gate, `VERCEL_TOKEN` gate, `gh pr merge --squash --delete-branch`, and the `deploy:prod` + monitor steps are all verbatim. `PR_STATE` is still derived (now from the same `gh pr view`).

Net: ~2h of billed runner freed per sync; the lost-merge-on-restart fragility is gone; the failure mode stays graceful (an ineligible/young PR is just left open for the next hourly retry or manual merge).

## Behavior walk-through
1. Sync worker opens the PR, sees `age < 2h` → exits immediately (runner released).
2. Hourly `fpf-sync-monitor`: production still behind upstream, no active worker → re-dispatches `sync-fpf.yml`.
3. Re-dispatched worker: `publish:current` is idempotent on unchanged content (no new commit), finds the existing PR, reaches the merge step, rechecks age.
4. Once `age ≥ 2h` **and** all gates pass → merge + deploy (verbatim).

## Validation
- YAML validated (`ruby -ryaml`): **VALID**
- Indentation confirmed inside the `run: |` block (10-space bash); `PR_STATE` preserved for the existing `OPEN` check
- Gating/merge/deploy logic unchanged (diff is +14/−3, isolated to the sleep→age-gate swap)
- `bun run lint` / `bun run check` — n/a (workflow YAML only; no TS changed)
- End-to-end verification command + output excerpt: **deferred to CI** — see test plan
- Caveats or blocker: **cannot run GitHub Actions locally.** This is the one change in the audit follow-up I could not runtime-verify; it must be test-merged in CI.

### Test plan (before relying on auto-merge)
1. `gh workflow run sync-fpf.yml --ref <this-branch> -f upstream_ref=<current ailev/FPF HEAD>` (or wait for a real upstream change) and confirm the worker **opens the PR and exits in seconds** (no 2h hang).
2. Confirm `fpf-sync-monitor` (hourly) re-dispatches `sync-fpf.yml` while the PR is open and production is behind.
3. After ≥2h, confirm a re-dispatched run **merges + deploys** when gates pass, and **leaves the PR open** when they don't.
4. Negative: force a failing check and confirm the PR is left open (no merge).

## Production evidence packet
### Promise checked
Review window + gated merge/deploy preserved; only the *wait mechanism* changes (blocking sleep → monitor-driven retry).
### URLs checked
n/a — no deployment performed by this PR.
### Commands run
`ruby -ryaml` (YAML validity); `git diff` (scope).
### Expected semantic invariants
- HTTP availability / route naming / live behavior: unaffected
- semantic correctness: merge eligibility gates identical (manual CI success, `REQUIRED_CHECK_NAMES`, `VERCEL_TOKEN`)
- freshness/currentness: improved operationally (no lost-merge-on-restart)
- cost/risk guardrails: ~2h billed runner saved per sync
### Actual output excerpt
`sync-fpf.yml: VALID YAML`; diff isolated to the merge step (+14/−3).
### Upstream ref / source hash
Unchanged; `published/current/**` untouched.
### Deployment URL / alias checked
n/a (no deploy in this PR).
### Rollback target
Revert commit `12a5b802` (restores `sleep 7200`).
### Known caveats
Not CI-verified by the author; relies on `fpf-sync-monitor`'s hourly re-dispatch (confirmed present in that workflow) to drive retries. `date -u -d` assumes the GNU `date` on `ubuntu-latest` (it is).
### What would falsify this success claim?
Sync PRs never auto-merging (re-dispatch not re-entering the merge step), or merging before the window / with failing gates.

## Boundary check
- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts remain in `src/mcp/tool-contracts.ts`

## Agent metadata
| Field   | Value |
| ------- | ----- |
| Agent   | Claude Code (Opus 4.8) |
| Task source | User-requested audit follow-up (Track A: sleep 7200) |
| Privacy check | No raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers included. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when auto-merge runs (timing/retry via monitor) for production sync PRs, though merge eligibility checks are unchanged; operational risk if hourly re-dispatch fails.
> 
> **Overview**
> The **Merge sync PR after two-hour review window** step in `sync-fpf.yml` no longer blocks the runner with **`sleep 7200`**. It now reads the sync PR’s **`createdAt`**, compares age to **`REVIEW_WINDOW_SECONDS` (7200)**, and **exits successfully** while the PR is still inside the window so the job finishes immediately instead of holding a runner for two hours.
> 
> After the window, behavior is unchanged: the same **OPEN** check, manual **CI** success, required check names, **`VERCEL_TOKEN`**, squash merge, and **`deploy:prod`** / monitor steps still run. Retries are expected from the hourly **`fpf-sync-monitor`** workflow, which already re-dispatches **`sync-fpf.yml`** when a target sync PR exists and production is behind upstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a5b80271dc1042b9f8ef3b9c46bea46128d444. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->