### PR TITLE
fix(runtime): route API/contract-review queries to boundary unpacking

### DIFF
--- a/published/current/manifest.json
+++ b/published/current/manifest.json
@@ -1,12 +1,12 @@
 {
   "channel": "latest-published",
   "sourceHash": "sha256:f86b7e00c39bb0e9b817917f807b5514048d763988c682b81a61b8190cba7158",
-  "compilerFingerprint": "sha256:87f34a6f5a7c707b6cc626aa42ca237ddf58350285d61454a4cb56c60184542d",
+  "compilerFingerprint": "sha256:9469e5a3d94c2ff05414e2948e7ca0dedf1efa2230cfa5c632cb19222e2bc83b",
   "upstreamRef": "16cd31387cff04ab6b0feef22717f82ac54efa8f",
   "upstreamRepoUrl": "https://github.com/ailev/FPF",
   "upstreamCommittedAt": "2026-05-31T07:57:58Z",
   "specPath": "published/current/FPF-Spec.md",
   "snapshotPath": "published/current/fpf-index/snapshot.json",
   "specBytes": 8105549,
-  "publishedAt": "2026-06-02T01:39:49.953Z"
+  "publishedAt": "2026-06-02T02:43:50.683Z"
 }

--- a/src/runtime/answer-projector.ts
+++ b/src/runtime/answer-projector.ts
@@ -92,9 +92,9 @@ export function buildRouteAnswer(
 ): QueryResult {
   const route = snapshot.routeGraph.nodes[routeNodeId]!;
   // Include routeSurfaces alongside the ordered/optional/landing lists.
-  // Some routes (e.g. boundary-unpacking-claim-routing) only declare
-  // surfaces; without this fallback the structured `ids` response would
-  // be just the route ID, hiding the patterns the answer prose names.
+  // Some routes only declare surfaces; without this fallback the structured
+  // `ids` response would be just the route ID, hiding the patterns the
+  // answer prose names.
   const ids = unique([
     routeNodeId,
     ...route.orderedIds,
@@ -180,8 +180,6 @@ function routeAcceptanceCheck(
   switch (routeNodeId) {
     case 'route:project-alignment':
       return 'a shared kickoff packet names the bounded context, actor roles, role/method/work split, first work-plan item, evidence to collect, and UTS-ready terms';
-    case 'route:boundary-unpacking-claim-routing':
-      return 'the boundary text is decomposed into layer-correct claims with named API/contract/protocol obligations, acceptance evidence, and owner handoff';
     case 'route:boundary-unpacking':
       return 'mixed boundary statements have stable claim IDs in a claim register and each atomic claim routes to one owner layer';
     default:
@@ -198,8 +196,6 @@ function routeNextMove(
   switch (routeNodeId) {
     case 'route:project-alignment':
       return 'read A.1.1 and A.15 first, draft the kickoff worksheet, then add A.15.2/A.15.3 only when the plan/run split must be made explicit';
-    case 'route:boundary-unpacking-claim-routing':
-      return 'read A.6, A.6.B, and A.6.C against the concrete boundary sentence before deciding whether A.6.P/A.6.Q/A.6.A is needed';
     case 'route:boundary-unpacking':
       return 'create the claim register first, then open exact pattern pages only for claims whose owner layer remains unclear';
     default:

--- a/src/runtime/spec-heuristics.ts
+++ b/src/runtime/spec-heuristics.ts
@@ -45,8 +45,7 @@ export const SPEC_HEURISTICS_PROVENANCE = {
 // ---------------------------------------------------------------------------
 
 export const PROJECT_ALIGNMENT_ROUTE_NAME = 'project alignment';
-export const BOUNDARY_UNPACKING_CLAIM_ROUTING_ROUTE_NAME =
-  'boundary unpacking / claim routing';
+export const BOUNDARY_UNPACKING_ROUTE_NAME = 'boundary unpacking';
 
 // ---------------------------------------------------------------------------
 // Keyword / intent signal lists
@@ -202,10 +201,9 @@ export interface SeedRuleDef {
 
 /**
  * Ordered — the array order is the persisted `heuristicSeedRules` order, which
- * the seeder/ranker iterate. `boundary-review` is retained even though its
- * route name does not resolve in the current edition (so it is skipped at
- * build time): keeping it makes the binding explicit and lets it re-activate
- * automatically if the upstream route name returns.
+ * the seeder/ranker iterate. `boundary-review` binds the API/contract/boundary
+ * burden path to `route:boundary-unpacking` (name "boundary unpacking"), seeding
+ * the A.6 claim-unpacking family for reviewer and CI/deploy-gate questions.
  */
 export const SEED_RULE_DEFS: readonly SeedRuleDef[] = [
   {
@@ -260,11 +258,11 @@ export const SEED_RULE_DEFS: readonly SeedRuleDef[] = [
     name: 'boundary-review',
     allOf: [BOUNDARY_REVIEW_RULE_JOB_SIGNALS],
     anyOf: [[...BOUNDARY_BURDEN_SIGNALS, 'continuous integration']],
-    seedNodeIds: ['A.6', 'A.6.B', 'A.6.C', 'A.6.P', 'A.6.Q', 'A.6.A'],
+    seedNodeIds: ['A.6', 'A.6.B', 'A.6.C', 'A.6.P', 'C.16.Q', 'A.6.A'],
     initialNodeIds: [],
     seedScore: 24,
     seedOrigin: 'route_expansion',
-    route: { name: BOUNDARY_UNPACKING_CLAIM_ROUTING_ROUTE_NAME, score: 96 },
+    route: { name: BOUNDARY_UNPACKING_ROUTE_NAME, score: 96 },
   },
   {
     name: 'role-assignment-connection',
@@ -308,10 +306,10 @@ export const ROUTE_CONSTRAINT_DEFS: readonly RouteConstraintDef[] = [
     ],
   },
   {
-    routeName: BOUNDARY_UNPACKING_CLAIM_ROUTING_ROUTE_NAME,
+    routeName: BOUNDARY_UNPACKING_ROUTE_NAME,
     constraints: [
       'Start with A.6, A.6.B, and A.6.C for API, contract, protocol, CI/deploy gate, or acceptance-clause review.',
-      'Add A.6.P, A.6.Q, or A.6.A only when the review text hides overloaded relation, quality, or action-invitation language.',
+      'Add A.6.P, C.16.Q, or A.6.A only when the review text hides overloaded relation, quality, or action-invitation language.',
       'Do not open the whole FPF; read exact pattern pages only when a finding depends on wording.',
     ],
   },
@@ -365,18 +363,19 @@ export const ROUTE_INTENT_DEFS: Readonly<Record<string, RouteIntentDef>> = {
       },
     ],
   },
-  'route:boundary-unpacking-claim-routing': {
+  'route:boundary-unpacking': {
+    // Adoption-intent phrasing (unpack/decompose/claim register) and the
+    // API/contract/boundary burden path both land on this route. Negations
+    // suppress it when the asker says it is explicitly not a contract review.
     negations: BOUNDARY_REVIEW_NEGATIONS,
     tiers: [
+      { kind: 'signals', allGroups: [BOUNDARY_UNPACKING_INTENT_SIGNALS], score: 96 },
       {
         kind: 'signals',
         allGroups: [BOUNDARY_BURDEN_SIGNALS, BOUNDARY_BURDEN_JOB_SIGNALS],
         score: 92,
       },
     ],
-  },
-  'route:boundary-unpacking': {
-    tiers: [{ kind: 'signals', allGroups: [BOUNDARY_UNPACKING_INTENT_SIGNALS], score: 96 }],
   },
   'route:writing-or-reviewing-patterns': {
     tiers: [

--- a/tests/fpf-spec-runtime.test.ts
+++ b/tests/fpf-spec-runtime.test.ts
@@ -275,58 +275,40 @@ describe('FpfRuntime', () => {
     expect(trace.sufficient).toBe(true);
   });
 
-  it('returns the boundary unpacking / claim routing route for PR reviewer API contract prompts', async () => {
+  it('returns the boundary unpacking route for PR reviewer API contract prompts', async () => {
     await runtime.refresh();
-    const routes = await runtime.browse({ kind: 'route' });
-    const routeIds = new Set(routes.entries.map((entry) => entry.id));
-    if (!routeIds.has('route:boundary-unpacking-claim-routing')) {
-      const route = await runtime.query(
-        'For a PR/code reviewer checking an API contract change, return exact route or pattern IDs and acceptance checks without pasting the full FPF.',
-        'compact',
-      );
-      expect(['ok', 'ambiguous']).toContain(route.status);
-      expect(route.ids.length).toBeGreaterThan(0);
-      expect(route.ids.every((id) => !id.startsWith('route:'))).toBe(true);
-      if (route.status === 'ambiguous') {
-        expect(Array.isArray(route.candidateIds)).toBe(true);
-        expect((route.candidateIds ?? []).length).toBeGreaterThan(0);
-      }
-      return;
-    }
     const question =
       'For a PR/code reviewer checking an API contract change, return exact route or pattern IDs and acceptance checks without pasting the full FPF.';
     const route = await runtime.query(question, 'compact');
 
     expect(route.status).toBe('ok');
     expect(route.ids.slice(0, 4)).toEqual([
-      'route:boundary-unpacking-claim-routing',
+      'route:boundary-unpacking',
       'A.6',
       'A.6.B',
       'A.6.C',
     ]);
-    // The route names A.6.P/A.6.Q/A.6.A as conditional additions in
-    // answer prose ("…before deciding whether A.6.P/A.6.Q/A.6.A is
-    // needed") rather than structured IDs, so they appear in `answer`
-    // but not in `ids`.
-    expect(route.answer).toContain('A.6.P/A.6.Q/A.6.A');
-    expect(route.answer).toContain('route:boundary-unpacking-claim-routing');
+    // The boundary route lands the full A.6 claim-unpacking family as
+    // structured IDs, including the conditional adds A.6.P / C.16.Q / A.6.A.
+    expect(route.ids).toContain('C.16.Q');
+    expect(route.answer).toContain('route:boundary-unpacking');
     expect(route.constraints).toContain(
       'Do not open the whole FPF; read exact pattern pages only when a finding depends on wording.',
     );
 
     const ask = renderAskFpfResult(route);
     expect(ask.ids.slice(0, 4)).toEqual([
-      'route:boundary-unpacking-claim-routing',
+      'route:boundary-unpacking',
       'A.6',
       'A.6.B',
       'A.6.C',
     ]);
-    expect(ask.markdown).toContain('route:boundary-unpacking-claim-routing');
+    expect(ask.markdown).toContain('route:boundary-unpacking');
 
     const trace = await runtime.trace(question, 'compact');
     expect(trace.status).toBe('ok');
     expect(trace.routeWins).toBe(true);
-    expect(trace.selectedNodeIds).toContain('route:boundary-unpacking-claim-routing');
+    expect(trace.selectedNodeIds).toContain('route:boundary-unpacking');
   });
 
   // This test chains `refresh()` (full snapshot build, ~16–18s on GitHub

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -373,16 +373,16 @@ describe('direct MCP server', () => {
     const readBoundaryRouteDoc = await harness.request('tools/call', {
       name: 'read_fpf_doc',
       arguments: {
-        selector: 'route:boundary-unpacking-claim-routing',
+        selector: 'route:boundary-unpacking',
         kind: 'route',
       },
     });
     const readBoundaryRouteDocPayload = asToolPayload(readBoundaryRouteDoc);
-    if (routeIds.has('route:boundary-unpacking-claim-routing')) {
+    if (routeIds.has('route:boundary-unpacking')) {
       expect(readBoundaryRouteDocPayload.resolvedAs).toBe('route');
-      expect(readBoundaryRouteDocPayload.nodeId).toBe('route:boundary-unpacking-claim-routing');
+      expect(readBoundaryRouteDocPayload.nodeId).toBe('route:boundary-unpacking');
       expect(readBoundaryRouteDocPayload.markdown).toContain(
-        '# Boundary unpacking / claim routing',
+        'route:boundary-unpacking',
       );
     } else {
       expect(readBoundaryRouteDocPayload.status).toBe('not_found');
@@ -405,15 +405,15 @@ describe('direct MCP server', () => {
     expect((reviewerQueryPayload.ids as string[]).length).toBeGreaterThan(0);
     if (
       reviewerQueryPayload.status === 'ok' &&
-      routeIds.has('route:boundary-unpacking-claim-routing')
+      routeIds.has('route:boundary-unpacking')
     ) {
       expect((reviewerQueryPayload.ids as string[]).slice(0, 4)).toEqual([
-        'route:boundary-unpacking-claim-routing',
+        'route:boundary-unpacking',
         'A.6',
         'A.6.B',
         'A.6.C',
       ]);
-      expect(reviewerQueryPayload.answer).toContain('route:boundary-unpacking-claim-routing');
+      expect(reviewerQueryPayload.answer).toContain('route:boundary-unpacking');
     } else if (reviewerQueryPayload.status === 'ambiguous') {
       expect(Array.isArray(reviewerQueryPayload.candidateIds)).toBe(true);
       expect((reviewerQueryPayload.candidateIds as string[]).length).toBeGreaterThan(0);
@@ -448,14 +448,14 @@ describe('direct MCP server', () => {
       },
     });
     const reviewerAskPayload = asToolPayload(reviewerAsk);
-    if (routeIds.has('route:boundary-unpacking-claim-routing')) {
+    if (routeIds.has('route:boundary-unpacking')) {
       expect((reviewerAskPayload.ids as string[]).slice(0, 4)).toEqual([
-        'route:boundary-unpacking-claim-routing',
+        'route:boundary-unpacking',
         'A.6',
         'A.6.B',
         'A.6.C',
       ]);
-      expect(reviewerAskPayload.markdown).toContain('route:boundary-unpacking-claim-routing');
+      expect(reviewerAskPayload.markdown).toContain('route:boundary-unpacking');
     } else {
       expect((reviewerAskPayload.ids as string[]).every((id) => !id.startsWith('route:'))).toBe(
         true,

--- a/tests/query-contracts.test.ts
+++ b/tests/query-contracts.test.ts
@@ -138,14 +138,6 @@ function addRouteFixtures(baseSnapshot: Snapshot): Snapshot {
     ['F.17'],
   );
   addRoute(
-    'route:boundary-unpacking-claim-routing',
-    'boundary unpacking / claim routing',
-    'First route for API boundary, contract, protocol, and reviewer work.',
-    ['A.6', 'A.6.B', 'A.6.C'],
-    ['A.6.P', 'A.6.Q', 'A.6.A'],
-    ['A.6'],
-  );
-  addRoute(
     'route:writing-or-reviewing-patterns',
     'writing or reviewing patterns',
     'First route for spec writers adding or reviewing FPF patterns.',
@@ -153,24 +145,6 @@ function addRouteFixtures(baseSnapshot: Snapshot): Snapshot {
     [],
     ['E.8'],
   );
-
-  snapshot.heuristicSeedRules = [
-    ...(snapshot.heuristicSeedRules ?? []),
-    {
-      name: 'boundary-review',
-      allOf: [
-        ['api contract', 'contract change', 'api boundary'],
-        ['reviewer', 'code reviewer', 'pr'],
-      ],
-      anyOf: [['api', 'contract', 'boundary']],
-      seedNodeIds: ['A.6', 'A.6.B', 'A.6.C'],
-      seedScore: 20,
-      seedOrigin: 'lexical',
-      initialNodeIds: [],
-      routeId: 'route:boundary-unpacking-claim-routing',
-      routeScore: 95,
-    },
-  ];
 
   snapshot.validation.parsedRoutes = Object.keys(snapshot.routeGraph.nodes).length;
   return snapshot;
@@ -330,7 +304,7 @@ describe('Query / Seed coverage stage', () => {
     );
     const seeding = seedCandidates(normalized, snapshot);
 
-    const routeCandidate = seeding.candidateMap.get('route:boundary-unpacking-claim-routing');
+    const routeCandidate = seeding.candidateMap.get('route:boundary-unpacking');
     expect(routeCandidate).toBeDefined();
     expect(routeCandidate!.reasons).toContain('burden:boundary-review');
     expect(routeCandidate!.score).toBeGreaterThanOrEqual(90);
@@ -344,7 +318,7 @@ describe('Query / Seed coverage stage', () => {
     );
     const seeding = seedCandidates(normalized, snapshot);
 
-    const routeCandidate = seeding.candidateMap.get('route:boundary-unpacking-claim-routing');
+    const routeCandidate = seeding.candidateMap.get('route:boundary-unpacking');
     expect(routeCandidate?.reasons ?? []).not.toContain('burden:boundary-review');
   });
 
@@ -356,7 +330,7 @@ describe('Query / Seed coverage stage', () => {
     );
     const seeding = seedCandidates(normalized, snapshot);
 
-    const routeCandidate = seeding.candidateMap.get('route:boundary-unpacking-claim-routing');
+    const routeCandidate = seeding.candidateMap.get('route:boundary-unpacking');
     expect(routeCandidate?.reasons ?? []).not.toContain('burden:boundary-review');
   });
 
@@ -507,7 +481,7 @@ describe('Query / Ranker stage', () => {
     expect(ranking.initialNodeIds).toEqual(['route:writing-or-reviewing-patterns']);
   });
 
-  it('selects boundary unpacking / claim routing for API boundary kickoff questions', async () => {
+  it('selects boundary unpacking for API boundary kickoff questions', async () => {
     const snapshot = await getSnapshotWithRouteFixtures();
     const question =
       'As a project lead, what small FPF route should I use to run a 30-minute project kickoff about an API boundary decision?';
@@ -516,7 +490,7 @@ describe('Query / Ranker stage', () => {
     const ranking = rankCandidates(question, seeding.candidateMap, snapshot);
 
     expect(ranking.routeWins).toBe(true);
-    expect(ranking.initialNodeIds).toEqual(['route:boundary-unpacking-claim-routing']);
+    expect(ranking.initialNodeIds).toEqual(['route:boundary-unpacking']);
   });
 
   it('selects the boundary route for PR reviewer API contract prompts', async () => {
@@ -528,7 +502,7 @@ describe('Query / Ranker stage', () => {
     const ranking = rankCandidates(question, seeding.candidateMap, snapshot);
 
     expect(ranking.routeWins).toBe(true);
-    expect(ranking.initialNodeIds).toEqual(['route:boundary-unpacking-claim-routing']);
+    expect(ranking.initialNodeIds).toEqual(['route:boundary-unpacking']);
   });
 
   it('selects C.16 for measurement template characteristic scale evidence prompts', async () => {
@@ -785,7 +759,7 @@ describe('Query / Projection stability stage', () => {
     expect(trace.selectedNodeIds[0]).toBe('route:writing-or-reviewing-patterns');
   });
 
-  it('does not fast-route generic compliance review wording to boundary unpacking / claim routing', async () => {
+  it('does not fast-route generic compliance review wording to boundary unpacking', async () => {
     const snapshot = await getSnapshotWithRouteFixtures();
     const engine = new QueryEngine(snapshot, false);
     const questions = [
@@ -798,8 +772,8 @@ describe('Query / Projection stability stage', () => {
       const trace = engine.trace(question, 'compact');
 
       expect(trace.routeWins).toBe(false);
-      expect(trace.selectedNodeIds[0]).not.toBe('route:boundary-unpacking-claim-routing');
-      expect(trace.candidateScores[0]?.nodeId).not.toBe('route:boundary-unpacking-claim-routing');
+      expect(trace.selectedNodeIds[0]).not.toBe('route:boundary-unpacking');
+      expect(trace.candidateScores[0]?.nodeId).not.toBe('route:boundary-unpacking');
     }
   });
 


### PR DESCRIPTION
## What

Re-point the inert `boundary-review` heuristic from a route name upstream FPF no longer ships to the real successor route `route:boundary-unpacking`, so API/contract/boundary-review query intent reaches the A.6 claim-unpacking family instead of lexically-matched pattern-authoring nodes.

## Why

`boundary-review` bound to the route name `"boundary unpacking / claim routing"`, which the current upstream edition does not define. The compiler therefore skipped the seed rule and its route constraint, and the matching route-intent def keyed a route ID absent from the snapshot. Net effect: a PR/code-reviewer API-contract-review query class fell through to lexical token overlap and surfaced pattern-authoring/quality nodes (E.19/E.21) rather than the A.6 boundary nodes that actually answer it.

## Type

- `fix` — restores intended retrieval behavior for a query class

## Changes

- `src/runtime/spec-heuristics.ts`: rename `BOUNDARY_UNPACKING_CLAIM_ROUTING_ROUTE_NAME` → `BOUNDARY_UNPACKING_ROUTE_NAME` (`"boundary unpacking"`), re-activating the seed rule + route constraint against `route:boundary-unpacking`. Merge the dead route's burden intent tier (score 92) into the route's existing adoption-intent def (score 96, walked first); carry the `BOUNDARY_REVIEW_NEGATIONS` guard entry-wide. Fix the seed/constraint node list from the non-existent `A.6.Q` to the route's real `C.16.Q`.
- `src/runtime/answer-projector.ts`: remove the now-unreachable `route:boundary-unpacking-claim-routing` arms; the existing `route:boundary-unpacking` arms serve (no prose change for queries already reaching that route).
- `tests/{fpf-spec-runtime,mcp-server,query-contracts}.test.ts`: re-point assertions to `route:boundary-unpacking`; drop the obsolete synthetic boundary fixture (the real compiled snapshot now provides the route + rule), making these genuine production-wiring checks.
- `published/current/**`: republished from the pinned upstream source — only `heuristicSeedRules`, the route's `constraints`, and the compiler fingerprint change.

## Validation

- `bun run lint` passes locally (0 errors, 0 warnings)
- `bun run check` passes locally (tsc --noEmit clean)
- `bun run check:boundaries` passes locally
- `bun run test` passes locally — 359 passed; 1 unrelated failure (`docs-projection` shells out to `@rspress/core`, which is not installed in this worktree; environment-only, untouched by this change)
- End-to-end verification: started the hosted server locally against the republished snapshot and ran `bun run bench:mcp:qa` against it → **8 ok, 0 failed**, session check ok
- Caveats: `bench:mcp:qa` against live `mcp.fpf.sh` should be re-run post-deploy (this change is not deployed yet).

## Production evidence packet

### URLs checked

- Local hosted MCP `…/api/mcp/fpf_reference/mcp` (QA bench target) — pre-deploy validation
- Production `mcp.fpf.sh` unchanged until merge+deploy

### Commands run

- `FPF_PUBLISH_SOURCE_PATH=published/current/FPF-Spec.md FPF_UPSTREAM_REF=16cd3138… bun run publish:current`
- `bun run lint && bun run check && bun run check:boundaries && bun run test`
- `FPF_MCP_QA_BENCH_URL=http://localhost:<port>/api/mcp/fpf_reference/mcp bun run bench:mcp:qa`

### Expected semantic invariants

- HTTP availability: local server returns 200 on the status endpoint
- semantic correctness: the API-contract-review query class resolves to `route:boundary-unpacking` → `A.6` → `A.6.B` → `A.6.C` (previously E.19/E.21); generic compliance-review wording still does **not** route to the boundary route (negation guard intact)
- freshness/currentness: `sourceHash` unchanged; snapshot rebuilt from the pinned source; manifest fresh
- route naming: heuristics + projector now reference the real `route:boundary-unpacking`; the absent `route:boundary-unpacking-claim-routing` ID is fully removed from runtime code
- live behavior: local QA bench 8/8, session-prime check ok
- cost/risk guardrails: no new dependencies; published snapshot byte size unchanged; 6070 per-section blame stamps preserved

### Actual output excerpt

QA bench summary (local, against republished snapshot): `"ok": 8, "failed": 0`, `sessionCheck.ok: true`. (No prompts or answer bodies included.)

### Upstream ref / source hash

- upstreamRef `16cd31387cff04ab6b0feef22717f82ac54efa8f` (unchanged)
- sourceHash `sha256:f86b7e00c39bb0e9b817917f807b5514048d763988c682b81a61b8190cba7158` (unchanged)
- compilerFingerprint `sha256:87f34a6f…` → `sha256:9469e5a3…` (expected — spec-heuristics is a fingerprinted compiler input)

### Deployment URL / alias checked

N/A pre-merge. Production (`mcp.fpf.sh`) serves the committed snapshot; deploy occurs on merge.

### Rollback target

Revert this commit to restore the prior published snapshot (compilerFingerprint `sha256:87f34a6f…`); behavior reverts to the prior inert state.

### Known caveats

- Re-run `bun run smoke:production` + `bun run bench:mcp:qa` against `mcp.fpf.sh` after deploy to confirm in production.
- The boundary route's answer prose keeps the existing claim-register framing; the route's `constraints` carry the A.6-first actionable guidance.

### What would falsify this success claim?

- Post-deploy, the API-contract-review query class does not return `route:boundary-unpacking` as the leading ID, or
- Any canonical QA case regresses, or generic compliance-review wording starts routing to the boundary route.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts in `src/mcp/tool-contracts.ts` unchanged

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Claude Code (Opus 4.8) |
| Task source | P4 — re-activate inert boundary/API-contract route |
| Privacy check | No raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers included. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query routing and published snapshot semantics for a high-traffic MCP path; mis-binding would send reviewers to wrong patterns, but scope is localized to heuristics and tests with negation guards preserved.
> 
> **Overview**
> **Re-activates** the `boundary-review` heuristic so PR/API/contract/boundary questions route to **`route:boundary-unpacking`** and the **A.6** claim-unpacking family instead of falling through to unrelated lexical matches.
> 
> Runtime heuristics now bind that seed rule and route constraints to the upstream route name **"boundary unpacking"** (replacing the removed **"boundary unpacking / claim routing"**), fix conditional pattern references **`A.6.Q` → `C.16.Q`**, and **merge** API/contract burden scoring into a single **`route:boundary-unpacking`** intent definition (with existing negation guards). **`answer-projector`** drops dead special cases for the obsolete route ID.
> 
> **`published/current`** is republished so the compiled snapshot includes the live **`boundary-review`** seed rule, populated route **constraints**, and an updated **compiler fingerprint**; **tests** assert the corrected routing against the real snapshot (synthetic obsolete-route fixtures removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 721350c7babba295a5f5a028c13219baeed58dd8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->