### PR TITLE
[codex] fix MCP status placeholder argument

### DIFF
--- a/src/mcp/tool-contracts.ts
+++ b/src/mcp/tool-contracts.ts
@@ -458,7 +458,18 @@ export const askFpfInputSchema = z
   })
   .strict();
 
-export const getFpfIndexStatusInputSchema = z.object({}).strict();
+export const getFpfIndexStatusInputSchema = z
+  .object({
+    random_string: z
+      .string()
+      .min(1)
+      .max(MAX_FILTER_LENGTH)
+      .optional()
+      .describe(
+        'Ignored compatibility placeholder for MCP clients that cannot send an empty arguments object.',
+      ),
+  })
+  .strict();
 
 export const inspectFpfNodeInputSchema = z
   .object({

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -256,7 +256,11 @@ describe('direct MCP server', () => {
 
     const statusSchema = tools.find((tool) => tool.name === 'get_fpf_index_status')?.inputSchema;
     expect(statusSchema?.type).toBe('object');
-    expect(statusSchema?.properties).toEqual({});
+    expect(statusSchema?.properties).toMatchObject({
+      random_string: {
+        type: 'string',
+      },
+    });
     expect(statusSchema?.additionalProperties).toBe(false);
   });
 
@@ -275,6 +279,16 @@ describe('direct MCP server', () => {
     const statusPayload = asToolPayload(status);
     expect(typeof statusPayload.snapshotExists).toBe('boolean');
     expect(statusPayload.compilerMode).toBe('local_vectorless');
+
+    const notionStatus = await harness.request('tools/call', {
+      name: 'get_fpf_index_status',
+      arguments: {
+        random_string: 'notion-placeholder',
+      },
+    });
+    const notionStatusPayload = asToolPayload(notionStatus);
+    expect(typeof notionStatusPayload.snapshotExists).toBe('boolean');
+    expect(notionStatusPayload.compilerMode).toBe('local_vectorless');
 
     const query = await harness.request('tools/call', {
       name: 'query_fpf_spec',

--- a/tests/tool-input-caps.test.ts
+++ b/tests/tool-input-caps.test.ts
@@ -4,6 +4,7 @@ import {
   askFpfInputSchema,
   browseFpfCatalogInputSchema,
   expandFpfCitationsInputSchema,
+  getFpfIndexStatusInputSchema,
   inspectFpfAnchorInputSchema,
   inspectFpfNodeInputSchema,
   queryFpfSpecInputSchema,
@@ -71,5 +72,16 @@ describe('public MCP tool input caps', () => {
     expect(
       expandFpfCitationsInputSchema.safeParse({ citationIds: [big(257)] }).success,
     ).toBe(false);
+  });
+
+  it('getFpfIndexStatus accepts only an ignored compatibility placeholder', () => {
+    expect(getFpfIndexStatusInputSchema.safeParse({}).success).toBe(true);
+    expect(
+      getFpfIndexStatusInputSchema.safeParse({ random_string: 'notion-placeholder' }).success,
+    ).toBe(true);
+    expect(getFpfIndexStatusInputSchema.safeParse({ random_string: big(65) }).success).toBe(
+      false,
+    );
+    expect(getFpfIndexStatusInputSchema.safeParse({ _probe: true }).success).toBe(false);
   });
 });


### PR DESCRIPTION
## Source

Closes #180.

Issue evidence: Notion AI cannot call `get_fpf_index_status` because it drops empty argument objects before dispatch, while the FPF Reference server correctly rejects non-empty unknown keys.

## Change

- Add one optional ignored `random_string` input to `get_fpf_index_status`.
- Keep `additionalProperties: false` so only the compatibility placeholder is accepted.
- Add schema coverage for `{}`, `{ random_string: "..." }`, capped placeholder length, and continued rejection of unknown keys.
- Add stdio MCP regression coverage proving `tools/list` advertises the placeholder and `tools/call` still returns status metadata when the placeholder is supplied.

## Validation

- `bun run test -- tests/tool-input-caps.test.ts tests/mcp-server.test.ts`
  - Passed: 2 files, 18 tests, 0 failures.
  - Includes real stdio MCP calls for `get_fpf_index_status` with `{}` and `{ "random_string": "notion-placeholder" }`.
- `bun run check`
  - Passed: `tsc --noEmit`.
- `bun run build:mcp`
  - Passed: bundled `src/entrypoints/mcp-stdio.ts` to `dist/stdio.js`, 1.27 MB.
- `bun run evaluate:work`
  - Overall: `usable_with_followups`; 0 blocker/high findings.

## Residual Risk

This is a server-side compatibility shim for a Notion AI client bug, not the durable client-side fix. If Notion changes its placeholder behavior, callers may need to send the documented `random_string` field explicitly or return to `{}` after the client is fixed.

## Handoff

Ready for the Friday PR review and merge captain. Please verify whether the `random_string` field name is acceptable as the public compatibility contract before merging.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only compatibility shim with strict validation; no change to index or status logic.
> 
> **Overview**
> Adds an optional, **ignored** `random_string` argument to **`get_fpf_index_status`** so MCP clients that refuse to send `{}` (e.g. Notion AI) can call the tool with a placeholder while **`additionalProperties: false`** still blocks any other keys.
> 
> The handler behavior is unchanged—status still comes from `runtime.status()`—but **`tools/list`** now advertises the placeholder field, and tests cover schema acceptance (`{}` vs placeholder vs length cap vs unknown keys) plus a stdio **`tools/call`** with `random_string`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 208d4888b15ddcdcb48ed4e8dd53c41ade08819f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->