### PR TITLE
fix(publish): make published surface deterministic per upstream ref

### DIFF
--- a/src/build/publish-current.ts
+++ b/src/build/publish-current.ts
@@ -191,6 +191,7 @@ export async function publishCurrent(
     config.publishedSpecPath ?? PUBLISHED_SPEC_PATH,
     publishedSnapshotPath,
     compilerFingerprint,
+    upstreamCommit.committedAt,
   );
 
   const manifestWithoutTimestamp = {
@@ -223,7 +224,17 @@ export async function publishCurrent(
 
   const manifest: PublishCurrentManifest = {
     ...manifestWithoutTimestamp,
-    publishedAt: new Date().toISOString(),
+    // Anchor publishedAt to the upstream commit date rather than wall-clock.
+    // The CI sync worker (sync-fpf.yml) republishes from a clean `main`
+    // checkout every hour, so the idempotency guard above never matches
+    // (the committed manifest on main is the previously-merged ref) and a
+    // wall-clock value rewrote this field — and thus the sync branch's
+    // commit SHA — on every run. That moving SHA permanently wedged the
+    // auto-merge gate, which only merges when a completed CI run matches the
+    // current PR head SHA. Pinning to the (immutable) upstream revision time
+    // makes republishes of the same ref byte-identical. publishedAt is
+    // provenance/display only — no SLO drift math reads it.
+    publishedAt: upstreamCommit.committedAt,
   };
 
   await writeFile(publishedManifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
@@ -279,6 +290,7 @@ async function normalizeSnapshotForPublication(
   publishedSpecPath: string,
   publishedSnapshotPath: string,
   compilerFingerprint: string,
+  deterministicBuiltAt: string,
 ): Promise<Buffer> {
   const currentSnapshot = parsePublicationSnapshot(snapshotBytes);
   if (!currentSnapshot) {
@@ -300,7 +312,13 @@ async function normalizeSnapshotForPublication(
       === comparableSnapshotShape(normalizedCurrent, publishedSpecPath);
   const normalizedSnapshot = {
     ...normalizedCurrent,
-    builtAt: canPreserveBuiltAt ? existingSnapshot.builtAt : currentSnapshot.builtAt,
+    // builtAt is non-semantic for the published surface — comparableSnapshotShape()
+    // strips it before comparison — but the compiler stamps it with wall-clock, so a
+    // fresh CI rebuild churns the snapshot (and the sync branch SHA) on every run, the
+    // same way wall-clock publishedAt did. Preserve a matching prior value when present;
+    // otherwise pin to the upstream revision time so republishes of the same ref stay
+    // byte-identical instead of wedging the sync auto-merge gate.
+    builtAt: canPreserveBuiltAt ? existingSnapshot.builtAt : deterministicBuiltAt,
   };
 
   return Buffer.from(`${JSON.stringify(normalizedSnapshot, null, 2)}\n`);

--- a/tests/publish-current.test.ts
+++ b/tests/publish-current.test.ts
@@ -72,6 +72,47 @@ describe('publishCurrent', () => {
     expect(secondManifest).toBe(firstManifest);
   }, 30_000);
 
+  it('republishes the same ref byte-identically from a clean tree', async () => {
+    // Reproduces the CI sync worker: it republishes from a fresh `main`
+    // checkout every hour, so it never has this ref's prior published surface
+    // to fall back on. Before the determinism fix, wall-clock publishedAt
+    // (manifest) and builtAt (snapshot) made each run emit a new commit SHA,
+    // which permanently wedged the sync PR's auto-merge gate. Two clean-tree
+    // publishes of the same ref must now be byte-for-byte identical.
+    const config = {
+      publishSourcePath,
+      upstreamRef: 'test-ref',
+      resolveUpstreamCommit: STUB_UPSTREAM_RESOLVER,
+      channel: 'latest-published',
+      publishedSpecPath,
+      publishedArtifactDir,
+      publishedManifestPath,
+    };
+    const env = {
+      ...process.env,
+      FPF_RUNTIME_ARTIFACT_DIR: runtimeArtifactDir,
+    } as NodeJS.ProcessEnv;
+
+    await publishCurrent(config, env);
+    const firstManifest = await readFile(publishedManifestPath, 'utf8');
+    const firstSnapshot = await readFile(resolve(publishedArtifactDir, 'snapshot.json'), 'utf8');
+
+    // Wipe everything a fresh checkout would lack: the published surface (so
+    // the idempotency guard cannot short-circuit) and the runtime artifact dir
+    // (so the compiler genuinely rebuilds with a new wall-clock builtAt). The
+    // sleep guarantees a wall-clock value would differ on the unfixed path.
+    await rm(resolve(tempRoot, 'published'), { recursive: true, force: true });
+    await rm(runtimeArtifactDir, { recursive: true, force: true });
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
+
+    await publishCurrent(config, env);
+
+    expect(await readFile(publishedManifestPath, 'utf8')).toBe(firstManifest);
+    expect(await readFile(resolve(publishedArtifactDir, 'snapshot.json'), 'utf8')).toBe(
+      firstSnapshot,
+    );
+  }, 30_000);
+
   it('resolves the default runtime artifact dir relative to the publish source root', async () => {
     await publishCurrent(
       {


### PR DESCRIPTION
## Problem

The hourly FPF sync was silently stuck: upstream `ailev/FPF` advanced to `3d190101`, the worker opened sync PR #183, but it **never auto-merged** — it sat open for ~14h while `mcp.fpf.sh` stayed pinned to `16cd3138` and the `fpf-sync-monitor` SLO began failing (`behind upstream by 13.6h`).

## Root cause

`publishCurrent` stamps `manifest.publishedAt` and the published snapshot's `builtAt` with **wall-clock** time. The idempotency guards that should preserve those stamps compare the fresh build against the committed surface — but the CI worker (`sync-fpf.yml`) always checks out **`main`** (the previously-merged ref, `16cd3138`), so a `3d190101` publish never matches the guard. Every hourly run rewrote both fields, which made `peter-evans/create-pull-request` **force-push a new commit SHA** to the sync branch on every run.

That broke the auto-merge gate, which merges only when a *completed, successful* `ci.yml` run matches the **current** PR head SHA. Each worker run advanced the head and then immediately checked for a finished CI run on that brand-new SHA — which was still queued. 10 consecutive hourly runs produced 10 distinct head SHAs differing only in these two timestamps; the gate could never catch its own moving target.

## Fix

Anchor both stamps to the upstream commit date (`upstreamCommit.committedAt`) so republishing the same ref is **byte-identical**. The branch SHA then stabilizes, its CI run completes, and the existing merge gate converges on the next hourly re-dispatch.

Both fields are provenance/display only:
- `publishedAt` feeds **no** SLO drift math — drift is computed from the upstream commit date (`sync-monitor.ts`).
- `builtAt` is **non-semantic** for the published surface — `comparableSnapshotShape()` strips it before content comparison.
- The **runtime** compiler's `builtAt` (`runtime.ts`) is unchanged, so refresh-changes-builtAt invariants (e.g. `mcp-session-roundtrip`) still hold.

### Behavior change to note
`manifest.publishedAt` now equals the upstream revision time rather than the CI wall-clock. The docs "Published …" footer therefore shows the commit date, which is consistent with the per-section commit dates already rendered from line blame. If you'd prefer to keep `publishedAt` as a distinct publication timestamp, the alternative is a workflow-level fix (seed `published/current/` from the existing sync branch before publishing so the guards fire) — happy to switch.

## Verification
- `bun run test` → **361 passed, 0 failed**.
- New regression test `republishes the same ref byte-identically from a clean tree` reproduces the CI churn (wipes the published surface + runtime artifacts, re-publishes) and asserts a byte-identical manifest + snapshot. Confirmed it **fails** on the wall-clock path and **passes** with the fix.
- `tsc --noEmit` clean.

## Related
The two upstream commits (`a0c90e3b`, `3d190101`) were already landed manually via #183 to unblock immediately. After this merges, the automation will produce a stable, deterministic sync PR going forward (and will run `deploy:prod` when it converges).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only provenance timestamps on the published manifest/snapshot; no auth, runtime compiler `builtAt`, or SLO drift logic is affected.
> 
> **Overview**
> **Makes republishing the same upstream ref produce byte-identical published artifacts** so hourly CI sync PRs stop getting a new commit SHA every run and can pass the auto-merge gate.
> 
> `publishCurrent` now sets **`manifest.publishedAt`** to **`upstreamCommit.committedAt`** instead of wall-clock ISO time, and **`normalizeSnapshotForPublication`** pins **`snapshot.builtAt`** to that same upstream commit time when there is no prior published snapshot to preserve (still reuses existing `builtAt` when shape matches). **`publishedAt`** is display/provenance only; **`builtAt`** is already stripped for content comparison via **`comparableSnapshotShape()`**.
> 
> Adds regression test **`republishes the same ref byte-identically from a clean tree`**: wipe published output and runtime artifacts, wait, republish, assert manifest and snapshot match byte-for-byte.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af04502dac171d34d387bdf5a7604b34268724ae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->