### PR TITLE
[codex] Improve MCP connector troubleshooting

### DIFF
--- a/docs/connect-mcp.md
+++ b/docs/connect-mcp.md
@@ -6,7 +6,7 @@ outline: deep
 
 # Connect FPF Reference MCP
 
-Use this page when you want ChatGPT, Claude, an editor, or a coding CLI to retrieve bounded FPF context through the hosted MCP server.
+Use this page to connect ChatGPT, Claude, editors, or coding CLIs to the hosted FPF Reference MCP server so they can retrieve bounded public FPF context by stable IDs, routes, and generated docs.
 
 ## Hosted endpoint
 
@@ -16,6 +16,30 @@ https://mcp.fpf.sh/api/mcp/fpf_reference/mcp
 
 This endpoint is the direct Vercel-hosted MCP origin over streamable HTTP. It exposes the public FPF Reference tools for catalog browsing, search, compact answers, exact generated doc reads, and index health.
 
+Use this URL only in an MCP client configuration. Do not open it in a browser tab.
+
+## Expected success
+
+A working client should show:
+
+- tools named `browse_fpf_catalog`, `search_fpf`, `ask_fpf`, `query_fpf_spec`, `read_fpf_doc`, and `get_fpf_index_status`;
+- `get_fpf_index_status` returning index, build, and source freshness data;
+- the first route prompt returning `route:project-alignment` with compact bounded next steps.
+
+## First successful call
+
+After adding the server, make the first success concrete:
+
+1. Call `get_fpf_index_status`.
+2. Confirm the response reports a loadable index and the expected upstream source details.
+3. Run a compact route query:
+
+```txt
+Use only fpf_reference. Call query_fpf_spec with question: "Project kickoff: align a project information system with roles and adoption next steps" and mode "compact". Return the route ID, ordered IDs, acceptance check, and next move.
+```
+
+A good response should include `route:project-alignment` in `ids`, then bounded next steps rather than a full FPF paste.
+
 The legacy endpoint is blocked during the May 2026 cost incident mitigation:
 
 ```txt
@@ -23,6 +47,8 @@ https://mcp.fpf.sh/api/mcp/fpf_memory/mcp
 ```
 
 Keep the route entry until the scheduled compatibility review on 2026-06-30 so old clients fail cheaply with a migration signal instead of falling through to an expensive timeout. Existing users with the old URL or `fpf_memory` client name should move to the canonical endpoint above.
+
+After 2026-06-30, record the review outcome on this page and either remove the legacy route note or replace it with the current migration policy.
 
 It is a JSON-RPC endpoint, not a web page. A bare browser GET returns **405 Method Not Allowed** because standalone MCP SSE streams are disabled on the hosted endpoint. Paste the canonical URL into your client's MCP config; do not open it in a tab.
 
@@ -43,15 +69,30 @@ Public tools:
 - `read_fpf_doc`
 - `get_fpf_index_status`
 
-## Test first
+## Connector metadata
 
-After adding the server, ask your client to call `get_fpf_index_status`. Then run a compact route query:
+Suggested connector name:
 
 ```txt
-Use only fpf_reference. Call query_fpf_spec with question: "Project kickoff: align a project information system with roles and adoption next steps" and mode "compact". Return the route ID, ordered IDs, acceptance check, and next move.
+FPF Reference
 ```
 
-A good response should include `route:project-alignment` in `ids`, then bounded next steps rather than a full FPF paste.
+Suggested description:
+
+```txt
+Retrieve bounded public First Principles Framework reference context by stable FPF IDs, routes, patterns, and generated docs. Use for FPF lookup, route selection, compact answers, and exact citation-backed reads.
+```
+
+## Troubleshooting
+
+| Symptom | Meaning | Fix |
+| --- | --- | --- |
+| Browser shows `405 Method Not Allowed` | Expected. This is not a web page. | Use the URL inside an MCP client configuration. |
+| Client shows no tools | URL is wrong, the client did not initialize the server, or the connector is not enabled in the chat. | Recheck the canonical URL, refresh or restart the client, then call `get_fpf_index_status`. |
+| Old `fpf_memory` endpoint fails | Expected during migration mitigation. | Use `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`. |
+| Client asks for auth or OAuth | Unexpected for the public reference tools unless the client requires connector auth metadata. | Check client settings. No bearer token should be needed for public tools. |
+| Test prompt does not return `route:project-alignment` | The tool connected, but routing or index behavior may be off. | Run `get_fpf_index_status`, then retry `query_fpf_spec` with `mode: compact`. |
+| Timeout | Hosted endpoint, index, or client transport issue. | Check `https://mcp.fpf.sh/api/fpf/status` first, then retry from the MCP client. |
 
 ## ChatGPT
 
@@ -61,8 +102,9 @@ Use this path for ChatGPT custom apps/connectors.
 2. Go to Apps & Connectors.
 3. Enable developer mode under Advanced settings if your plan or workspace requires it.
 4. Create a new custom app or connector.
-5. Set the connector URL to the hosted endpoint above.
-6. Create the connector, confirm the advertised tools, then open a new chat and add the connector from the composer tools menu.
+5. Use the suggested connector name and description above.
+6. Set the connector URL to the hosted endpoint above.
+7. Create the connector, confirm the advertised tools, then open a new chat and add the connector from the composer tools menu.
 
 Reference: [OpenAI Apps SDK - connect from ChatGPT](https://developers.openai.com/apps-sdk/deploy/connect-chatgpt).
 


### PR DESCRIPTION
## Summary
- Clarify the hosted FPF Reference MCP setup page for first-time connector users.
- Add explicit expected-success states, connector metadata, troubleshooting, and a post-2026-06-30 legacy-route cleanup reminder.

## Validation
- `bun run docs:build`
  - generated 989 docs
  - Rspress rendered pages and completed web/node build in 32.7 s

## Scope
- Docs-only change to `docs/connect-mcp.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or API behavior impact.
> 
> **Overview**
> **Docs-only** refresh of `docs/connect-mcp.md` to make first-time FPF Reference MCP setup easier to verify and debug.
> 
> The intro now states the page goal more clearly and warns not to open the MCP URL in a browser. New **Expected success** and **First successful call** sections define what a healthy client looks like (tool list, `get_fpf_index_status`, and a compact `query_fpf_spec` smoke test expecting `route:project-alignment`). **Connector metadata** adds copy-paste name/description for custom connectors. A **Troubleshooting** table covers common failures (405 in browser, missing tools, legacy `fpf_memory`, auth prompts, bad routing, timeouts). Legacy-route guidance adds a reminder to update this page after **2026-06-30**. ChatGPT steps now reference the suggested metadata before setting the URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fe51045b17c006791fe5df591d84818ac09047d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->