### PR TITLE
[codex] Fix no-tools troubleshooting guidance

### DIFF
--- a/docs/connect-mcp.md
+++ b/docs/connect-mcp.md
@@ -88,7 +88,7 @@ Retrieve bounded public First Principles Framework reference context by stable F
 | Symptom | Meaning | Fix |
 | --- | --- | --- |
 | Browser shows `405 Method Not Allowed` | Expected. This is not a web page. | Use the URL inside an MCP client configuration. |
-| Client shows no tools | URL is wrong, the client did not initialize the server, or the connector is not enabled in the chat. | Recheck the canonical URL, refresh or restart the client, then call `get_fpf_index_status`. |
+| Client shows no tools | URL is wrong, the client did not initialize the server, or the connector is not enabled in the chat. | Recheck the canonical URL, refresh or restart the client, and verify the connection logs. |
 | Old `fpf_memory` endpoint fails | Expected during migration mitigation. | Use `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`. |
 | Client asks for auth or OAuth | Unexpected for the public reference tools unless the client requires connector auth metadata. | Check client settings. No bearer token should be needed for public tools. |
 | Test prompt does not return `route:project-alignment` | The tool connected, but routing or index behavior may be off. | Run `get_fpf_index_status`, then retry `query_fpf_spec` with `mode: compact`. |


### PR DESCRIPTION
## Summary
- Address Gemini review feedback from PR #189.
- Update the `Client shows no tools` troubleshooting fix so it does not suggest calling a missing tool.

## Validation
- `bun run docs:build`
  - generated 995 docs
  - Rspress built web/node successfully

## Review feedback addressed
- https://github.com/venikman/fpf-memory/pull/189#discussion_r3373336190

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to MCP connection troubleshooting; no runtime or API behavior affected.
> 
> **Overview**
> Updates the **Client shows no tools** row in `docs/connect-mcp.md` so the fix no longer tells users to call `get_fpf_index_status`—that step is impossible when the client has not loaded any tools.
> 
> The replacement guidance is to recheck the canonical URL, refresh or restart the client, and **verify the connection logs**, aligning troubleshooting with the Gemini review on PR #189.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98ddc42874bf41594fd4f4c4812560f7a803ade6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->