### PR TITLE
[codex] Add hosted MCP quick connect page

### DIFF
--- a/docs/connect-local.md
+++ b/docs/connect-local.md
@@ -1,0 +1,45 @@
+---
+title: "What Do I Need To Run?"
+description: "Use the hosted FPF Reference MCP server from a local MCP client. No local server required."
+outline: false
+---
+
+# What do I need to run?
+
+You do not need to run an FPF server. You only need an MCP client that supports remote HTTP MCP servers.
+
+Paste these values into the client.
+
+| Field | Value |
+| --- | --- |
+| Name | `fpf_reference` |
+| Transport | `HTTP` or `Streamable HTTP` |
+| URL | `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp` |
+| Auth | None |
+
+If the client asks for a local command, choose its remote HTTP server option instead.
+
+After saving the server, confirm the client shows these tools:
+
+- `browse_fpf_catalog`
+- `search_fpf`
+- `ask_fpf`
+- `query_fpf_spec`
+- `read_fpf_doc`
+- `get_fpf_index_status`
+
+First check:
+
+```txt
+Call get_fpf_index_status.
+```
+
+Good first prompt:
+
+```txt
+Use only fpf_reference. First call get_fpf_index_status. If the index is available, find the smallest FPF route for this work: <describe work>. Return Context | Route ID | Ordered IDs | Acceptance check | Next move.
+```
+
+Opening the endpoint in a browser returns `405 Method Not Allowed`. That is expected; the URL is for MCP clients.
+
+For product-specific setup screens, use [Connect MCP](/connect-mcp).

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -308,6 +308,7 @@ document.addEventListener('keydown',function(e){
       {
         text: 'MCP',
         items: [
+          { text: 'Quick connect', link: '/connect-local' },
           { text: 'Recipes', link: '/mcp-recipes' },
           { text: 'Connect to clients', link: '/connect-mcp' },
           { text: 'Automation Playbook', link: '/automation-playbook' },

--- a/src/build/content-quality-monitor.ts
+++ b/src/build/content-quality-monitor.ts
@@ -28,6 +28,7 @@ export const CONTENT_QUALITY_CURATED_DOCS = [
   { label: 'home', path: '/', sourcePath: 'docs/index.md' },
   { label: 'start-here', path: '/start-here', sourcePath: 'docs/start-here.md' },
   { label: 'work-packets', path: '/work-packets', sourcePath: 'docs/work-packets.md' },
+  { label: 'connect-local', path: '/connect-local', sourcePath: 'docs/connect-local.md' },
   { label: 'connect-mcp', path: '/connect-mcp', sourcePath: 'docs/connect-mcp.md' },
   { label: 'mcp-recipes', path: '/mcp-recipes', sourcePath: 'docs/mcp-recipes.md' },
   {
@@ -315,6 +316,7 @@ export function evaluateContentQuality(
     : true;
   const monitoredMcpDocs = new Set(curatedDocs.map((doc) => doc.label));
   const mcpPagesPresent = [
+    'connect-local',
     'connect-mcp',
     'mcp-recipes',
     'automation-playbook',

--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -552,7 +552,7 @@ function renderHomeMarkdown(
     '- `read_fpf_doc` — exact canonical page for a selector (preview + full modes)',
     '- `get_fpf_index_status` — snapshot freshness, source hash, build time',
     '',
-    'Endpoint: `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp` · Legacy blocked during May 2026 mitigation: `https://mcp.fpf.sh/api/mcp/fpf_memory/mcp` · Status: [`mcp.fpf.sh/api/fpf/status`](https://mcp.fpf.sh/api/fpf/status) · [Connect setup →](/connect-mcp)',
+    'Endpoint: `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp` · Legacy blocked during May 2026 mitigation: `https://mcp.fpf.sh/api/mcp/fpf_memory/mcp` · Status: [`mcp.fpf.sh/api/fpf/status`](https://mcp.fpf.sh/api/fpf/status) · [Quick connect →](/connect-local) · [Full setup →](/connect-mcp)',
     '',
     '## FPF — the framework this server projects',
     '',
@@ -573,6 +573,7 @@ function renderHomeMarkdown(
 function renderHomeNavigateLine(snapshot: Snapshot): string {
   const links: DocsNavLink[] = [
     { text: 'Start here', link: '/start-here' },
+    { text: 'Quick connect', link: '/connect-local' },
     { text: 'Connect MCP', link: '/connect-mcp' },
     { text: 'Patterns', link: '/generated/patterns/index' },
     { text: 'Routes', link: '/generated/routes/index' },

--- a/tests/content-quality-monitor.test.ts
+++ b/tests/content-quality-monitor.test.ts
@@ -331,6 +331,12 @@ function makeCuratedDocs(overrides: Record<string, string> = {}): ContentQuality
       text: 'Use route:writing-or-reviewing-patterns and /generated/patterns/A.3.',
     },
     {
+      label: 'connect-local',
+      path: '/connect-local',
+      sourcePath: 'docs/connect-local.md',
+      text: 'Call get_fpf_index_status.',
+    },
+    {
       label: 'connect-mcp',
       path: '/connect-mcp',
       sourcePath: 'docs/connect-mcp.md',

--- a/tests/docs-projection.test.ts
+++ b/tests/docs-projection.test.ts
@@ -488,6 +488,7 @@ describe('docs projection', () => {
       expect(rootIndex).toContain('Cite this spec');
       expect(rootIndex).toContain('## Navigate');
       expect(rootIndex).toContain('[Start here](/start-here)');
+      expect(rootIndex).toContain('[Quick connect](/connect-local)');
       expect(rootIndex).toContain('[Connect MCP](/connect-mcp)');
       expect(rootIndex).toContain('[Patterns](/generated/patterns/index)');
       expect(rootIndex).toContain('[Routes](/generated/routes/index)');
@@ -553,6 +554,7 @@ describe('docs projection', () => {
       buildDocsProjection(alternateSnapshot).pagesByMarkdownPath['docs/index.md']?.markdown ?? '';
 
     expect(rootIndex).toContain('[Start here](/start-here)');
+    expect(rootIndex).toContain('[Quick connect](/connect-local)');
     expect(rootIndex).toContain('[Patterns](/generated/patterns/index)');
     expect(rootIndex).not.toContain('[Glossary](/generated/patterns/');
     expect(rootIndex).not.toContain('[Change log](/generated/patterns/');
@@ -678,6 +680,12 @@ describe('docs projection', () => {
       expect(await readFile(resolve(outDir, 'connect-mcp.html'), 'utf8')).toContain(
         'Pi MCP extension',
       );
+      const connectLocal = await readFile(resolve(outDir, 'connect-local.html'), 'utf8');
+      expect(connectLocal).toContain('What do I need to run?');
+      expect(connectLocal).toContain('You do not need to run an FPF server.');
+      expect(connectLocal).toContain('https://mcp.fpf.sh/api/mcp/fpf_reference/mcp');
+      expect(connectLocal).not.toContain('bun run start');
+      expect(connectLocal).not.toContain('git clone');
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }

--- a/tests/e2e/rendering.spec.ts
+++ b/tests/e2e/rendering.spec.ts
@@ -35,3 +35,18 @@ test('connect-mcp page mentions the canonical MCP endpoint', async ({
     page.getByText('https://mcp.fpf.sh/api/mcp/fpf_reference/mcp').first(),
   ).toBeVisible();
 });
+
+test('connect-local page stays focused on hosted server values', async ({
+  page,
+}) => {
+  await page.goto('/connect-local');
+  await expect(page).toHaveTitle(/What Do I Need To Run\?|FPF Reference/);
+  await expect(
+    page.getByRole('heading', { name: 'What do I need to run?', level: 1 }),
+  ).toBeVisible();
+  await expect(page.getByText('You do not need to run an FPF server.')).toBeVisible();
+  await expect(
+    page.getByText('https://mcp.fpf.sh/api/mcp/fpf_reference/mcp').first(),
+  ).toBeVisible();
+  await expect(page.getByText('bun run start')).toHaveCount(0);
+});

--- a/tests/e2e/routes.spec.ts
+++ b/tests/e2e/routes.spec.ts
@@ -5,6 +5,7 @@ import { expect, test } from '@playwright/test';
 const STATIC_PATHS = [
   '/',
   '/start-here',
+  '/connect-local',
   '/connect-mcp',
   '/patterns',
   '/automation-playbook',


### PR DESCRIPTION
## Summary
- Add `/connect-local` as a simple share page for people asking what they need to run.
- Keep the page scoped to hosted MCP connection values: no local server, no repo clone, no product-specific client matrix.
- Add the page to the MCP nav, generated home links, content monitor, docs projection tests, and browser route/render checks.

## Quick share text
Use this page when someone asks what they need to run: `/connect-local`.

The short answer on the page is: you do not run an FPF server; paste the hosted MCP URL into any client that supports remote HTTP MCP servers.

## Validation
- `bun install --frozen-lockfile`
- `git diff --check`
- `bun run test -- tests/docs-projection.test.ts tests/content-quality-monitor.test.ts` -> 30 passed
- `bun run docs:build` -> generated 995 docs, Rspress build/render passed
- `FPF_E2E_BASE_URL=http://127.0.0.1:4174 bun run test:e2e -- tests/e2e/routes.spec.ts tests/e2e/rendering.spec.ts` -> 16 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no runtime, auth, or MCP server behavior changes.
> 
> **Overview**
> Adds **`/connect-local`** (“What do I need to run?”) as a **shareable, hosted-only MCP setup page**: no local server, clone, or client matrix—just name, HTTP transport, `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`, tool checklist, and starter prompts, with a pointer to **`/connect-mcp`** for per-client steps.
> 
> **Discovery and guardrails:** **Quick connect** is first under the **MCP** nav; generated home **Navigate** and the MCP blurb link **Quick connect** before full setup. The page is registered in the **content quality monitor** curated MCP doc set, and **unit/build/e2e** tests assert the route, home projection links, HTML content (hosted URL present; no `git clone` / `bun run start`), and Playwright smoke on `/connect-local`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 506a559474b4d579226f12f2fc2e6a7fa9d27bf6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->