### PR TITLE
Fix Vercel usage report log scope

### DIFF
--- a/scripts/usage-report.ts
+++ b/scripts/usage-report.ts
@@ -24,6 +24,8 @@ import {
 const DEFAULT_USAGE_REPORT_WINDOW = '24h';
 const DEFAULT_USAGE_REPORT_PROJECT = 'fpf-reference-mcp';
 const DEFAULT_USAGE_REPORT_VERCEL_LIMIT = 1000;
+const DEFAULT_USAGE_REPORT_VERCEL_TIMEOUT_MS = 300_000;
+const VERCEL_LOGS_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 
 const flags = parseFlagMap(process.argv.slice(2));
 const windowLabel = readString(
@@ -151,6 +153,7 @@ function runVercelLogs(input: {
     input.project,
     '--environment',
     'production',
+    '--no-branch',
     '--source',
     'serverless',
     '--since',
@@ -168,22 +171,35 @@ function runVercelLogs(input: {
   const result = spawnSync('npx', args, {
     encoding: 'utf8',
     env: process.env,
-    timeout: 120_000,
+    maxBuffer: VERCEL_LOGS_MAX_BUFFER_BYTES,
+    timeout: readVercelLogsTimeoutMs(),
   });
 
   if (result.error) {
-    throw result.error;
+    throw new Error(formatVercelSpawnError(result.error));
   }
   if (result.status !== 0) {
     throw new Error(
       [
         `vercel logs failed with exit code ${result.status ?? 'unknown'}.`,
-        result.stdout.trim(),
-        result.stderr.trim(),
+        sanitizeVercelFailureOutput(result.stderr, input.token),
       ].filter(Boolean).join('\n'),
     );
   }
   return result.stdout.split(/\r?\n/u).filter((line) => line.trim().length > 0);
+}
+
+function formatVercelSpawnError(error: Error): string {
+  const maybeCode = (error as Error & { code?: unknown }).code;
+  const code = typeof maybeCode === 'string' ? ` (${maybeCode})` : '';
+  return `vercel logs failed to run${code}.`;
+}
+
+function sanitizeVercelFailureOutput(value: string, token: string): string {
+  const redacted = token
+    ? value.replaceAll(token, '[redacted-vercel-token]')
+    : value;
+  return redacted.trim().slice(0, 4000);
 }
 
 function vercelSource(
@@ -197,6 +213,7 @@ function vercelSource(
     '--project',
     project,
     '--environment production',
+    '--no-branch',
     '--source serverless',
     `--since ${window}`,
     '--query mcp_tool_usage',
@@ -223,6 +240,15 @@ function readReportLimit(): number {
     'limit',
     process.env.FPF_USAGE_REPORT_LIMIT,
     20,
+  );
+}
+
+function readVercelLogsTimeoutMs(): number {
+  return readPositiveInteger(
+    flags,
+    'vercel-timeout-ms',
+    process.env.FPF_USAGE_REPORT_VERCEL_TIMEOUT_MS,
+    DEFAULT_USAGE_REPORT_VERCEL_TIMEOUT_MS,
   );
 }
 

--- a/src/build/usage-report.ts
+++ b/src/build/usage-report.ts
@@ -929,8 +929,21 @@ function buildCaveats(totals: UsageReportTotals, source: UsageReportSource): str
   }
   if (source.kind === 'vercel') {
     caveats.push('Vercel log export availability and retention can limit historical windows.');
+    const queryLimit = readVercelQueryLimit(source);
+    if (queryLimit !== undefined && totals.rawLineCount >= queryLimit) {
+      caveats.push(`Vercel returned the configured ${queryLimit}-line limit; reported counts are lower bounds for this window.`);
+    }
   }
   return caveats;
+}
+
+function readVercelQueryLimit(source: UsageReportSource): number | undefined {
+  const match = /(?:^|\s)--limit\s+(\d+)(?:\s|$)/u.exec(source.vercelQuery ?? '');
+  if (!match?.[1]) {
+    return undefined;
+  }
+  const limit = Number.parseInt(match[1], 10);
+  return Number.isFinite(limit) && limit > 0 ? limit : undefined;
 }
 
 function rankTable(rows: UsageRank[]): string {

--- a/tests/usage-report.test.ts
+++ b/tests/usage-report.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 
 import { describe, expect, it } from '@rstest/core';
@@ -183,6 +184,54 @@ describe('usage report aggregation', () => {
       'Missing Vercel logs token. Set FPF_USAGE_REPORT_VERCEL_TOKEN or VERCEL_TOKEN.',
     ]);
     expect(report.caveats).toContain('No usage counts were produced.');
+  });
+
+  it('marks Vercel reports as capped when the query limit is reached', async () => {
+    const contents = await readFile(FIXTURE_PATH, 'utf8');
+    const report = await buildUsageReportFromLines({
+      lines: contents.split(/\r?\n/u).filter(Boolean),
+      windowLabel: '24h',
+      now: NOW,
+      source: {
+        kind: 'vercel',
+        description: 'Vercel production logs for project fpf-reference-mcp',
+        vercelQuery: 'vercel logs --project fpf-reference-mcp --no-branch --query mcp_tool_usage --json --limit 10',
+      },
+    });
+
+    expect(report.caveats).toContain(
+      'Vercel returned the configured 10-line limit; reported counts are lower bounds for this window.',
+    );
+  });
+
+  it('does not let Vercel CLI branch auto-detection hide production logs', () => {
+    const env = { ...process.env };
+    delete env.FPF_USAGE_REPORT_VERCEL_TOKEN;
+    delete env.VERCEL_USAGE_REPORT_TOKEN;
+    delete env.VERCEL_TOKEN;
+
+    const result = spawnSync(
+      'bun',
+      [
+        'scripts/usage-report.ts',
+        '--source',
+        'vercel',
+        '--window',
+        '7d',
+        '--format',
+        'json',
+        '--no-write',
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        env,
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const report = JSON.parse(result.stdout) as { source?: { vercelQuery?: string } };
+    expect(report.source?.vercelQuery).toContain('--no-branch');
   });
 });
 


### PR DESCRIPTION
## Summary
- query Vercel production logs with `--no-branch` so CLI branch auto-detection cannot hide production telemetry
- raise the Vercel log export timeout/buffer for high-volume 7-day reports
- avoid dumping raw Vercel stdout on command failure and add a capped-export caveat

## Validation
- `bun run test -- tests/mcp-usage-telemetry.test.ts tests/usage-report.test.ts`
- `bun run usage:report -- --source file --log-path tests/fixtures/usage/mcp_tool_usage.jsonl --window 14d --format markdown --no-write --limit 5`
- Corrected local Vercel export produced 1000 valid MCP telemetry events and marked the result as capped/lower-bound

## Notes
The local web report at `http://127.0.0.1:4173/` also includes a separate request-log cross-check for dashboard-visible HTTP status traffic (`405` reached the 1000-line cap). This runtime artifact is ignored and is not part of the PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operator-facing reporting and CLI invocation only; no runtime MCP or auth paths, with clearer failure output and explicit lower-bound caveats.
> 
> **Overview**
> **Vercel usage report export** now passes `--no-branch` on production log queries so CLI branch auto-detection cannot omit production MCP telemetry.
> 
> The `vercel logs` subprocess gets a **64MB stdout buffer**, a **5-minute default timeout** (overridable via `--vercel-timeout-ms` / `FPF_USAGE_REPORT_VERCEL_TIMEOUT_MS`), and **safer failures**: spawn errors are summarized, stderr is token-redacted and truncated, and stdout is no longer included on non-zero exit.
> 
> **Report caveats** for Vercel sources now warn when the returned line count hits the configured `--limit`, treating counts as **lower bounds**. Tests cover the cap caveat and that the CLI-built query includes `--no-branch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c05116cc196c58768b48e255acd75fad561f90dd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->