### PR TITLE
docs: wire Vercel MCP operator workflow

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -8,3 +8,7 @@ approval_mode = "approve"
 
 [mcp_servers.fpf_reference.tools.browse_fpf_catalog]
 approval_mode = "approve"
+
+[mcp_servers.vercel]
+url = "https://mcp.vercel.com"
+default_tools_approval_mode = "prompt"

--- a/docs/automation-playbook.md
+++ b/docs/automation-playbook.md
@@ -35,6 +35,7 @@ The main safety rule is simple: discovery roles stay read-only, implementation r
 | Implementation PR agent | Turn one ready item into a bounded PR. | Edit code/docs, validate, open or update one PR. | Self-merge or perform broad product scouting. | PR with source links, validation output, and residual risk. |
 | PR review and merge captain | Keep PRs moving with independent judgment. | Review PRs, check CI/reviews/mergeability, comment on blockers, merge when policy is met. | Implement fixes or silently wait on blocked PRs. | Merge/no-merge decision with evidence. |
 | FPF sync monitor | Keep fpf.sh self-sustaining against upstream FPF. | Compare upstream HEAD, hosted status, manifest provenance, runtime freshness, and drift SLO; trigger or retry guarded sync when upstream is ahead and no sync worker is active. | Bypass CI, merge a failed sync PR, or publish unproven source/ref pairs. | Monitor run summary and sync workflow trigger. |
+| Vercel MCP operator | Gather Vercel control-plane evidence for the split website and MCP deployments. | Use Vercel MCP to inspect projects, deployments, build logs, runtime logs, protected preview fetches, and Vercel docs. | Deploy, promote, alias, rollback, buy domains, change billing, or create durable access without explicit approval. | Deployment/log evidence packet with project, URL, status, and caveats. |
 | Vercel spend monitor | Detect hosted cost spikes before they repeat. | Poll Vercel metrics for Function Duration GB-hours, legacy MCP route function invocations, and function error-code rows; distinguish breach, config error, unavailable metrics, and expected blocked traffic; update one issue when operator action is required and close it after a clean run. | Change billing settings, buy services, or remove compatibility routes without explicit approval. | Monitor run summary and GitHub issue state. |
 | Manager brief | Compress automation state for the user. | Read automation memory, repo state, PRs, discussions, docs, and hosted MCP health. | Replace the specialist roles or make external commitments. | Product readiness, changed, validated, Top 3 next actions, decisions needed. |
 | Technical architect | Make periodic system-level judgment. | Review MCP server, index/runtime, docs/adoption UX, CLI, evaluator, packaging/deploy, CI, and automation health. | Create implementation work unless explicitly asked. | Architecture state, risks, recommendations, handoffs, and stop/replan triggers. |
@@ -73,10 +74,29 @@ Manager brief
 | Local repo and public product read access | All roles | Allowed for evidence gathering. |
 | GitHub read access | All roles that inspect discussions, issues, PRs, and CI | Allowed for evidence gathering. |
 | GitHub write access | Implementation PR agent and PR review/merge captain | Allowed only within their role boundaries. |
+| Vercel MCP access | Vercel MCP operator, PR review/merge captain, FPF sync monitor, Vercel spend monitor | Read-first evidence gathering; mutating tools require human confirmation and role-specific approval. |
 | External publishing accounts | Growth and publishing scout | Draft-only unless the user explicitly approves a specific publish/send action. |
 | Secrets, billing, deploy settings, destructive actions | User or explicitly delegated operator | Prepare instructions; do not perform final actions by default. |
 
 For purchases, subscriptions, billing changes, account changes, or external publishing, the automation may prepare the flow and draft the copy. The user performs or explicitly approves the final action.
+
+## Vercel MCP Evidence Loop
+
+Vercel MCP is the Vercel control-plane server at `https://mcp.vercel.com`; FPF Reference MCP is this product's public lookup server at `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`. Keep those roles separate in prompts and evidence packets.
+
+Use Vercel MCP when a run needs current Vercel project/deployment facts that are awkward to prove from local files alone:
+
+- `fpf-reference-mcp` deployment status, build logs, runtime logs, and protected preview access;
+- `fpf-sh` deployment status and preview rendering access;
+- Vercel documentation lookup for changed platform behavior.
+
+Default prompt boundary:
+
+```text
+Use the Vercel MCP server named vercel for read-only deployment evidence. Inspect the relevant project, deployment, build logs, runtime logs, and protected preview URL if needed. Do not deploy, promote, alias, rollback, buy domains, or change settings unless the user explicitly approves that action.
+```
+
+For project-scoped operations, prefer the project-specific URLs documented in [Vercel MCP Packaging](/vercel-mcp-packaging) so the team/project context is explicit.
 
 ## Merge policy
 

--- a/docs/vercel-mcp-packaging.md
+++ b/docs/vercel-mcp-packaging.md
@@ -18,6 +18,39 @@ The MCP Vercel project (`fpf-reference-mcp`) serves:
 
 The wiki (`fpf.sh`) is a **separate** Vercel project (`fpf-sh`) built from `vercel:website:build`.
 
+## Vercel MCP for operators
+
+Vercel MCP is a separate operator-side control-plane server from Vercel, not the hosted FPF Reference MCP server. Use it to inspect Vercel projects, deployments, build logs, runtime logs, protected preview URLs, and Vercel documentation while keeping `fpf_reference` as the public FPF lookup endpoint.
+
+General Codex setup:
+
+```bash
+codex mcp add vercel --url https://mcp.vercel.com
+```
+
+This repository also registers the same server in `.codex/config.toml` with tool approval prompts enabled by default. Codex will still require OAuth authorization before the Vercel tools can access the account.
+
+Project-specific Vercel MCP URLs can reduce missing team/project parameters during operations:
+
+```text
+https://mcp.vercel.com/venikmans-projects/fpf-reference-mcp
+https://mcp.vercel.com/venikmans-projects/fpf-sh
+```
+
+Use the project-specific `fpf-reference-mcp` URL for MCP/API deployment checks and the `fpf-sh` URL for website deployment checks. Use the general `https://mcp.vercel.com` endpoint when a run needs to compare both projects.
+
+Recommended operator prompts:
+
+```text
+Use the Vercel MCP server named vercel. Inspect the latest production deployment for project fpf-reference-mcp in team venikmans-projects, then get build logs and runtime logs for errors since the deploy. Do not deploy or change domains.
+```
+
+```text
+Use the Vercel MCP server named vercel. Fetch https://mcp.fpf.sh/api/fpf/status through Vercel access tooling if protection or preview auth blocks a normal fetch, then report status, deployment URL, and any runtime errors. Do not mutate the project.
+```
+
+Keep human confirmation enabled for Vercel MCP tools, especially actions that can mutate Vercel state, create access links, run CLI actions, deploy, promote, alias, rollback, buy domains, or change billing-related resources. Vercel MCP should supply evidence for the production packet; the merge/deploy scripts below remain the source of deployment work.
+
 ## Publication input
 
 Both surfaces consume the committed channel `published/current/**`, staged before MCP deploy via:

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -321,6 +321,7 @@ document.addEventListener('keydown',function(e){
           { text: 'Recipes', link: '/mcp-recipes' },
           { text: 'Connect to clients', link: '/connect-mcp' },
           { text: 'Automation Playbook', link: '/automation-playbook' },
+          { text: 'Vercel MCP Packaging', link: '/vercel-mcp-packaging' },
           { text: 'Rename compatibility plan', link: '/fpf-reference-mcp-rename' },
         ],
       },

--- a/src/build/content-quality-monitor.ts
+++ b/src/build/content-quality-monitor.ts
@@ -37,6 +37,11 @@ export const CONTENT_QUALITY_CURATED_DOCS = [
     sourcePath: 'docs/automation-playbook.md',
   },
   {
+    label: 'vercel-mcp-packaging',
+    path: '/vercel-mcp-packaging',
+    sourcePath: 'docs/vercel-mcp-packaging.md',
+  },
+  {
     label: 'fpf-reference-mcp-rename',
     path: '/fpf-reference-mcp-rename',
     sourcePath: 'docs/fpf-reference-mcp-rename.md',

--- a/tests/content-quality-monitor.test.ts
+++ b/tests/content-quality-monitor.test.ts
@@ -355,6 +355,12 @@ function makeCuratedDocs(overrides: Record<string, string> = {}): ContentQuality
       text: 'Keep publication evidence bounded.',
     },
     {
+      label: 'vercel-mcp-packaging',
+      path: '/vercel-mcp-packaging',
+      sourcePath: 'docs/vercel-mcp-packaging.md',
+      text: 'Use Vercel MCP for read-only deployment evidence.',
+    },
+    {
       label: 'fpf-reference-mcp-rename',
       path: '/fpf-reference-mcp-rename',
       sourcePath: 'docs/fpf-reference-mcp-rename.md',

--- a/tests/e2e/routes.spec.ts
+++ b/tests/e2e/routes.spec.ts
@@ -9,6 +9,7 @@ const STATIC_PATHS = [
   '/connect-mcp',
   '/patterns',
   '/automation-playbook',
+  '/vercel-mcp-packaging',
   '/mcp-recipes',
   '/work-packets',
   '/routes',


### PR DESCRIPTION
## What

Registers Vercel MCP as a Codex operator-side MCP server and documents how to use it for deployment evidence around the split `fpf-sh` website and `fpf-reference-mcp` API/MCP surfaces.

## Why

Vercel MCP is now the right control-plane interface for agents to inspect Vercel projects, deployments, build logs, runtime logs, and protected previews. This keeps that operator capability separate from the public FPF Reference MCP (`fpf_reference`) lookup endpoint.

Primary references:
- https://vercel.com/docs/agent-resources/vercel-mcp
- https://vercel.com/docs/agent-resources/vercel-mcp/tools
- https://developers.openai.com/codex/config-reference

## Type

- `docs` — documentation only
- `chore` — maintenance (project Codex MCP config)

## Changes

- Adds `mcp_servers.vercel` to `.codex/config.toml` using `https://mcp.vercel.com`.
- Sets `default_tools_approval_mode = "prompt"` for Vercel MCP so Vercel tools ask before execution.
- Adds a Vercel MCP operator section to `docs/vercel-mcp-packaging.md` with general and project-specific endpoint guidance.
- Adds a Vercel MCP evidence loop and role boundary to `docs/automation-playbook.md`.
- Adds `/vercel-mcp-packaging` to the MCP nav, route/content smoke coverage, and the production content-quality monitor.

## Validation

- `bun run check` passes locally.
- `bun run test -- tests/content-quality-monitor.test.ts tests/production-evidence-template.test.ts` passes locally: 2 files, 9 tests passed.
- `bun run docs:build` succeeds locally; generated 984 docs files and Rspress built web + node output.
- End-to-end verification command + output excerpt:
  - `FPF_E2E_BASE_URL=http://127.0.0.1:4173 bunx playwright test tests/e2e/routes.spec.ts`
  - `14 passed`, including `GET /vercel-mcp-packaging returns 200`.
- Vercel project-specific MCP URL shape probe:
  - `curl -D - https://mcp.vercel.com/venikmans-projects/fpf-reference-mcp`
  - returned `401` with `x-matched-path: /[teamId]/[projectId]`, so the path is recognized and gated by OAuth rather than missing.
- Caveats or blocker: Vercel MCP was not available as a callable tool in this Codex app session, so OAuth/live Vercel MCP inspection was not performed here.

## Production evidence packet

Required when the PR changes production-facing behavior, deployment, automation, monitoring, public docs, MCP routes, or published artifacts. Do not paste raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers.

### Promise checked

The docs and project Codex config define Vercel MCP as an operator-side control-plane server for deployment evidence, while preserving FPF Reference MCP (`fpf_reference`) as the public lookup endpoint.

### URLs checked

- Local Rspress preview: `http://127.0.0.1:4173/vercel-mcp-packaging`
- Local Rspress preview route set from `tests/e2e/routes.spec.ts`
- Vercel MCP project path probe: `https://mcp.vercel.com/venikmans-projects/fpf-reference-mcp`

### Commands run

```bash
bun run check
bun run test -- tests/content-quality-monitor.test.ts tests/production-evidence-template.test.ts
bun run docs:build
RSPRESS_PERSISTENT_CACHE=false bunx rspress preview --host 127.0.0.1 --port 4173
FPF_E2E_BASE_URL=http://127.0.0.1:4173 bunx playwright test tests/e2e/routes.spec.ts
curl -sS -D - -o /tmp/vercel-mcp-project.txt https://mcp.vercel.com/venikmans-projects/fpf-reference-mcp
git diff --check
```

### Expected semantic invariants

- HTTP availability: local preview serves `/vercel-mcp-packaging` and existing curated docs with `200`.
- semantic correctness: Vercel MCP is described as the Vercel control-plane MCP, not the FPF Reference MCP server.
- freshness/currentness: no `published/current/**` artifacts changed.
- route naming: canonical public endpoint remains `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`; legacy `fpf_memory` is not introduced in new setup copy.
- live behavior: no production deploy or Vercel control-plane mutation was performed by this PR.
- cost/risk guardrails: Vercel MCP defaults to `prompt` approval mode in project Codex config.

### Actual output excerpt

```text
Rstest: 2 files, 9 tests passed
TypeScript: tsc --noEmit passed
Rspress: generatedFiles: 984; ready built in 31.5 s (web), 31.6 s (node)
Playwright: 14 passed; GET /vercel-mcp-packaging returns 200
Vercel MCP project path: HTTP/2 401; x-matched-path: /[teamId]/[projectId]
```

### Upstream ref / source hash

No publication refresh. Current docs build used `published/current/FPF-Spec.md` with `sourceHash` `sha256:7b45ba487aa7b33aee51ad35462d0a700d05d351fef03dcb63998001af0a9afc`.

### Deployment URL / alias checked

No production deployment was created or aliased. Local preview was checked at `http://127.0.0.1:4173`.

### Rollback target

Revert this docs/config commit. No production alias rollback needed because no deploy ran.

### Known caveats

Vercel MCP OAuth/live tool execution could not be verified in this Codex app session because the Vercel MCP tool surface was not callable here. The setup and tool names were checked against current Vercel/OpenAI documentation.

### What would falsify this success claim?

- Codex cannot load `https://mcp.vercel.com` from the project config.
- Vercel changes the documented tool names or project-specific URL shape.
- `/vercel-mcp-packaging` is missing from the built docs, MCP nav, or content monitor.
- New docs collapse Vercel MCP control-plane evidence with the public `fpf_reference` lookup endpoint.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added.
- No vector database or remote indexing introduced.
- No Python code added.
- MCP tool contracts are in `src/mcp/tool-contracts.ts`; this PR does not change them.

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Codex |
| Task source | User-requested Vercel MCP operator integration |
| Privacy check | No raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers included. |
