### PR TITLE
[codex] Restore FPF Reference route overlay

### DIFF
--- a/published/current/manifest.json
+++ b/published/current/manifest.json
@@ -1,7 +1,7 @@
 {
   "channel": "latest-published",
   "sourceHash": "sha256:7b45ba487aa7b33aee51ad35462d0a700d05d351fef03dcb63998001af0a9afc",
-  "compilerFingerprint": "sha256:9469e5a3d94c2ff05414e2948e7ca0dedf1efa2230cfa5c632cb19222e2bc83b",
+  "compilerFingerprint": "sha256:0c8fc337946799add7f525e712ecc3a9149e7111de4b2c0cd765db761f945a29",
   "upstreamRef": "093d30e806a1466e24032733eb020bb5a5f585cc",
   "upstreamRepoUrl": "https://github.com/ailev/FPF",
   "upstreamCommittedAt": "2026-06-08T20:41:28Z",

--- a/src/docs/generated-search-id-registry.ts
+++ b/src/docs/generated-search-id-registry.ts
@@ -1382,5 +1382,21 @@ export const SEARCH_ID_REGISTRY: SearchIdRegistry = {
       "staticPath": "/generated/patterns/K.3"
     }
   ],
-  "routes": []
+  "routes": [
+    {
+      "slug": "boundary-unpacking",
+      "title": "boundary unpacking",
+      "staticPath": "/generated/routes/route_boundary-unpacking"
+    },
+    {
+      "slug": "project-alignment",
+      "title": "project alignment",
+      "staticPath": "/generated/routes/route_project-alignment"
+    },
+    {
+      "slug": "writing-or-reviewing-patterns",
+      "title": "writing or reviewing patterns",
+      "staticPath": "/generated/routes/route_writing-or-reviewing-patterns"
+    }
+  ]
 };

--- a/src/runtime/compiler.ts
+++ b/src/runtime/compiler.ts
@@ -76,7 +76,7 @@ export function compileFpfSource(params: {
 
   // Stage 2: GraphCompiler — SourceIR → pattern/route/relation graphs
   const patternGraph = buildPatternGraph(ir);
-  const routeGraph = buildRouteGraph(ir);
+  const routeGraph = buildRouteGraph(ir, patternGraph.nodes);
   const outlineRelations = buildOutlineRelations(patternGraph.nodes);
   const explicitReferenceRelations = buildExplicitReferenceRelations(
     ir.sections,

--- a/src/runtime/graph-compiler.ts
+++ b/src/runtime/graph-compiler.ts
@@ -22,6 +22,7 @@ import {
   splitMarkdownRow,
   unique,
 } from './text.js';
+import { REFERENCE_ROUTE_DEFS } from './spec-heuristics.js';
 import type {
   AnchorRef,
   LexiconEntry,
@@ -122,6 +123,7 @@ export function buildPatternGraph(
 
 export function buildRouteGraph(
   ir: SourceIR,
+  patternNodes: Record<string, PatternRecord>,
 ): Snapshot['routeGraph'] {
   const { lines, anchorMap } = ir;
   const routes = new Map<string, RouteRecord>();
@@ -148,6 +150,12 @@ export function buildRouteGraph(
       searchableText: unique([existing.searchableText, route.searchableText]).join(' '),
       constraints: unique([...existing.constraints, ...route.constraints]),
     });
+  }
+
+  for (const route of buildReferenceOverlayRoutes(patternNodes, anchorMap)) {
+    if (!routes.has(route.id)) {
+      routes.set(route.id, route);
+    }
   }
 
   return {
@@ -458,6 +466,75 @@ function parseJ4Routes(
     });
   }
   return routes;
+}
+
+function buildReferenceOverlayRoutes(
+  patternNodes: Record<string, PatternRecord>,
+  anchorMap: Record<string, AnchorRef>,
+): RouteRecord[] {
+  const filterPatternIds = (ids: readonly string[]): string[] =>
+    ids.filter((id) => Boolean(patternNodes[id]));
+
+  return REFERENCE_ROUTE_DEFS
+    .map((def): RouteRecord | undefined => {
+      const id = routeKey(def.name);
+      const orderedIds = filterPatternIds(def.orderedIds);
+      const optionalIds = filterPatternIds(def.optionalIds);
+      const landingIds = filterPatternIds(def.landingIds);
+      const routeSurfaces = filterPatternIds(def.routeSurfaces);
+      const nextOwners = filterPatternIds(def.nextOwners);
+      const reroutes = filterPatternIds(def.reroutes);
+
+      if (
+        orderedIds.length === 0 &&
+        optionalIds.length === 0 &&
+        landingIds.length === 0 &&
+        routeSurfaces.length === 0
+      ) {
+        return undefined;
+      }
+
+      const citation = `fpf-reference-adoption-overlay:${id.replace(/^route:/, '')}`;
+      anchorMap[citation] = {
+        id: citation,
+        nodeId: id,
+        heading: def.name,
+        lineStart: 0,
+        lineEnd: 1,
+        path: ['FPF Reference adoption overlay', def.name],
+        text: def.description,
+        plainText: `${def.description} ${def.firstHonestBurden}`,
+        role: 'route_surface',
+      };
+      return {
+        id,
+        name: def.name,
+        description: def.description,
+        firstHonestBurden: def.firstHonestBurden,
+        orderedIds,
+        optionalIds,
+        landingIds,
+        routeSurfaces,
+        nextOwners,
+        reroutes,
+        citations: [citation],
+        anchorIds: [citation],
+        searchableText: cleanMarkdown(unique([
+          id,
+          def.name,
+          def.description,
+          def.firstHonestBurden,
+          ...orderedIds,
+          ...optionalIds,
+          ...landingIds,
+          ...routeSurfaces,
+          ...nextOwners,
+          ...reroutes,
+        ]).join(' ')),
+        constraints: [],
+      };
+    })
+    .filter((route): route is RouteRecord => Boolean(route));
 }
 
 function buildRouteRelations(routeNodes: Record<string, RouteRecord>): RelationEdge[] {

--- a/src/runtime/spec-heuristics.ts
+++ b/src/runtime/spec-heuristics.ts
@@ -199,6 +199,69 @@ export interface SeedRuleDef {
   route?: { name: string; score: number };
 }
 
+export interface ReferenceRouteDef {
+  name: string;
+  description: string;
+  firstHonestBurden: string;
+  orderedIds: readonly string[];
+  optionalIds: readonly string[];
+  landingIds: readonly string[];
+  routeSurfaces: readonly string[];
+  nextOwners: readonly string[];
+  reroutes: readonly string[];
+}
+
+/**
+ * FPF Reference adoption overlay routes.
+ *
+ * Upstream FPF editions may omit the machine-readable route table while the
+ * public MCP surface still promises a task-first route layer. These records
+ * preserve that bounded adoption surface without pretending the route came
+ * from a source line in `FPF-Spec.md`; the compiler filters every referenced
+ * pattern ID against the actual compiled snapshot.
+ */
+export const REFERENCE_ROUTE_DEFS: readonly ReferenceRouteDef[] = [
+  {
+    name: PROJECT_ALIGNMENT_ROUTE_NAME,
+    description:
+      'First route for project kickoff, project information-system alignment, or agent work packets when roles, method, work, and adoption next steps must stay separate.',
+    firstHonestBurden:
+      'A shared project kickoff packet needs the bounded context, role/method/work split, first work item, and adoption evidence without loading the whole FPF',
+    orderedIds: ['A.1.1', 'A.15', 'B.5.1'],
+    optionalIds: ['A.15.2', 'A.15.3'],
+    landingIds: ['F.17'],
+    routeSurfaces: ['A.1.1'],
+    nextOwners: ['B.5.1'],
+    reroutes: [],
+  },
+  {
+    name: BOUNDARY_UNPACKING_ROUTE_NAME,
+    description:
+      'First route for API, contract, workflow, protocol, CI gate, deploy promise, or acceptance-clause boundary review.',
+    firstHonestBurden:
+      'Mixed boundary prose needs atomic claim IDs and a declared owner layer before implementation or review can proceed safely',
+    orderedIds: ['A.6', 'A.6.B', 'A.6.C'],
+    optionalIds: ['A.6.P', 'C.16.Q', 'A.6.A'],
+    landingIds: ['A.6'],
+    routeSurfaces: ['A.6'],
+    nextOwners: ['A.6.C'],
+    reroutes: [],
+  },
+  {
+    name: 'writing or reviewing patterns',
+    description:
+      'First route for spec writers adding, drafting, revising, or reviewing FPF patterns.',
+    firstHonestBurden:
+      'A pattern author or reviewer needs the minimum writing/review path before opening neighboring patterns',
+    orderedIds: ['E.8', 'E.19'],
+    optionalIds: [],
+    landingIds: ['E.8'],
+    routeSurfaces: ['E.8'],
+    nextOwners: ['E.19'],
+    reroutes: [],
+  },
+];
+
 /**
  * Ordered — the array order is the persisted `heuristicSeedRules` order, which
  * the seeder/ranker iterate. `boundary-review` binds the API/contract/boundary

--- a/tests/compiler-contracts.test.ts
+++ b/tests/compiler-contracts.test.ts
@@ -405,9 +405,44 @@ describe('Compiler / Spec-heuristic binding', () => {
   const EXPECTED_RULE_NAMES = [
     'creative-search-heuristic',
     'measurement-template-discipline',
+    'agent-workflow-adoption',
+    'vocabulary-alignment',
+    'boundary-review',
     'role-assignment-connection',
     'same-entity-comparative-reading',
   ];
+
+  const EXPECTED_REFERENCE_ROUTE_IDS = [
+    'route:boundary-unpacking',
+    'route:project-alignment',
+    'route:writing-or-reviewing-patterns',
+  ];
+
+  it('keeps the public FPF Reference adoption routes in the compiled graph', async () => {
+    const { snapshot } = await getCompilerOutput();
+    const routeIds = Object.keys(snapshot.routeGraph.nodes).sort();
+
+    expect(routeIds).toEqual(expect.arrayContaining(EXPECTED_REFERENCE_ROUTE_IDS));
+    for (const routeId of EXPECTED_REFERENCE_ROUTE_IDS) {
+      const route = snapshot.routeGraph.nodes[routeId];
+      expect(route, `expected ${routeId} to be available to MCP clients`).toBeDefined();
+      expect(route!.citations[0]).toMatch(/^fpf-reference-adoption-overlay:/);
+      expect(route!.orderedIds.length).toBeGreaterThan(0);
+      for (const nodeId of [
+        ...route!.orderedIds,
+        ...route!.optionalIds,
+        ...route!.landingIds,
+        ...route!.routeSurfaces,
+        ...route!.nextOwners,
+        ...route!.reroutes,
+      ]) {
+        expect(
+          snapshot.patternGraph.nodes[nodeId],
+          `${routeId} points at missing pattern ${nodeId}`,
+        ).toBeDefined();
+      }
+    }
+  });
 
   it('emits every expected seed rule with seeds that resolve to compiled nodes', async () => {
     const { snapshot } = await getCompilerOutput();
@@ -438,10 +473,10 @@ describe('Compiler / Spec-heuristic binding', () => {
     const rules = snapshot.heuristicSeedRules ?? [];
     const alignment = snapshot.routeGraph.nodes['route:project-alignment'];
 
-    if (!alignment) {
-      expect(rules.filter((rule) => rule.routeId === 'route:project-alignment')).toEqual([]);
-      return;
-    }
+    expect(
+      alignment,
+      'route:project-alignment disappeared from the public MCP route surface',
+    ).toBeDefined();
 
     const routeBound = rules.filter((rule) => rule.routeId === 'route:project-alignment');
     expect(routeBound.map((rule) => rule.name)).toEqual([

--- a/tests/fpf-spec-runtime.test.ts
+++ b/tests/fpf-spec-runtime.test.ts
@@ -232,7 +232,7 @@ describe('FpfRuntime', () => {
     expect(boundedContextTrace.selectedNodeIds[0]).toBe('A.1.1');
   }, 40_000);
 
-  it('returns the project-alignment route from the preface and J.4 route surfaces', async () => {
+  it('returns the project-alignment route from the public adoption overlay', async () => {
     await runtime.refresh();
     const routes = await runtime.browse({ kind: 'route' });
     const routeIds = new Set(routes.entries.map((entry) => entry.id));
@@ -258,9 +258,7 @@ describe('FpfRuntime', () => {
     expect(route.ids).toContain('F.17');
     expect(route.answer).toContain('Acceptance check:');
     expect(route.answer).toContain('Next move:');
-    expect(route.citations).toEqual(
-      expect.arrayContaining(['Preface/Where to start', 'J.4']),
-    );
+    expect(route.citations).toContain('fpf-reference-adoption-overlay:project-alignment');
 
     const trace = await runtime.trace(
       'What is the recommended first route when vocabulary is overloaded across teams?',
@@ -417,7 +415,9 @@ describe('FpfRuntime', () => {
     expect(inspectAnchor.neighbors).toEqual(inspectById.neighbors);
 
     if (routeIds.has('route:project-alignment')) {
-      const inspectSyntheticAnchor = await runtime.inspectAnchor('Preface/Where to start');
+      const inspectSyntheticAnchor = await runtime.inspectAnchor(
+        'fpf-reference-adoption-overlay:project-alignment',
+      );
       expect(inspectSyntheticAnchor.status).toBe('ok');
       expect(inspectSyntheticAnchor.ownerNode?.kind).toBe('route');
     }
@@ -449,7 +449,7 @@ describe('FpfRuntime', () => {
 
     const inspectById = await runtime.inspect('A.1.1', 'id');
     const citationId = inspectById.anchors[0]!.id;
-    const syntheticCitationId = 'Preface/Where to start';
+    const syntheticCitationId = 'fpf-reference-adoption-overlay:project-alignment';
     const routes = await runtime.browse({ kind: 'route' });
     const routeIds = new Set(routes.entries.map((entry) => entry.id));
     const citationIds =


### PR DESCRIPTION
## Summary
- restores the public FPF Reference adoption routes when the upstream spec snapshot omits a machine-readable route table
- filters overlay route references against the compiled pattern graph and adds inspectable overlay citations instead of pretending the routes came from source lines
- regenerates the published snapshot, manifest, and generated search registry so the hosted MCP surface serves the fixed route graph

## Root Cause
The hosted MCP runtime was healthy at the transport layer, but `published/current/fpf-index/snapshot.json` had an empty `routeGraph.nodes`. Route-bound query heuristics were therefore skipped and project-alignment prompts fell back to ambiguous lexical matches.

## Validation
- `bun run check`
- `bun run lint`
- `bun run test`
- `bun run docs:build`
- `bun run vercel:mcp:build`
- local MCP Q&A bench against `http://127.0.0.1:4111/api/mcp/fpf_reference/mcp`: OK/failed 8/0
- production MCP Q&A bench against `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`: OK/failed 8/0

## Production
Deployed the fixed MCP bundle to Vercel deployment `dpl_7aLEZbnnzkFcEDmvNyN3T3L9vVLC` and aliased it to `https://mcp.fpf.sh`. Live status reports compiler fingerprint `sha256:0c8fc337946799add7f525e712ecc3a9149e7111de4b2c0cd765db761f945a29`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persisted snapshot shape and MCP retrieval behavior for adoption-route queries; risk is mitigated by strict compiler binding tests and republished fingerprints, but hosted clients depend on the new overlay graph being correct.
> 
> **Overview**
> Restores the **public FPF Reference adoption route layer** when the synced upstream spec no longer exposes a machine-readable route table (empty `routeGraph.nodes` broke route-bound heuristics and pushed MCP queries toward weak lexical matches).
> 
> The compiler now **injects overlay routes** from declarative `REFERENCE_ROUTE_DEFS` in `spec-heuristics.ts` after normal preface/J.4 parsing: pattern references are **filtered to the compiled graph**, and routes are cited via **`fpf-reference-adoption-overlay:*`** anchors instead of spec line citations. **Compiler contract tests** pin the three routes (`project alignment`, `boundary unpacking`, `writing or reviewing patterns`) and their resolved pattern IDs.
> 
> **Published artifacts** are regenerated—`published/current/manifest.json` (new compiler fingerprint), `snapshot.json` with populated routes, and `generated-search-id-registry.ts` listing the three route pages for docs/MCP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29e9204025e3b19a1a91dcfa28db9e8165694d5d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->