### PR TITLE
review: finish remaining contract-card findings for #206

### DIFF
--- a/docs/interface-contract.md
+++ b/docs/interface-contract.md
@@ -62,6 +62,12 @@ Before trust-sensitive use:
 
 When the hosted status page reports `freshness.upstreamCurrentness: "unknown"`, do not claim "latest upstream FPF" unless an external monitor has compared the hosted publication to the intended upstream/current artifact.
 
+## Output Expectations
+
+- Answers expose stable FPF IDs, citations or grounding, constraints or gaps, and snapshot metadata.
+- Catalog/search responses expose bounded result sets with source snapshot metadata.
+- Exact wording comes from read_fpf_doc rather than regenerated prose.
+
 ## Public Tool Contract
 
 | Tool | Purpose | Input contract | Output contract | Acceptance cue |

--- a/docs/interface-contract.md
+++ b/docs/interface-contract.md
@@ -24,12 +24,12 @@ It is not the upstream FPF specification, not agent memory, not workflow state, 
 
 | ID | Use in this contract |
 | --- | --- |
-| `A.1.1` | Bound local meanings for FPF Reference, MCP, runtime, and upstream FPF. |
-| `A.2.3` | Treat setup text as promise/access/acceptance content, not performed work. |
-| `A.6.B` | Keep laws, admissibility gates, commitments, and evidence claims separate. |
-| `A.6.C` | Unpack contract wording so the interface does not become memory, workflow, or policy. |
+| `A.1.1` | Bound the local meaning of FPF Reference, MCP, runtime, and upstream FPF. |
+| `A.2.3` | Treat public setup text as promise/access/acceptance content, not performed work. |
+| `A.6.B` | Separate laws, admissibility gates, commitments, and evidence claims. |
+| `A.6.C` | Unpack contract wording so the interface does not become agent memory or policy. |
 | `A.10` | Tie reliance-bearing claims to source, snapshot, status, and citation evidence. |
-| `B.3` | Scope assurance to the typed claim actually evidenced by the runtime. |
+| `B.3` | Keep assurance scoped to the typed claim actually evidenced by the runtime. |
 | `A.15.1` | Keep docs/status/test evidence separate from actual performed work. |
 
 ## Admissible Use
@@ -49,18 +49,15 @@ It is not the upstream FPF specification, not agent memory, not workflow state, 
 
 ## Reliance Gate
 
-Before trust-sensitive use:
-
-1. Call `get_fpf_index_status`.
+1. Call `get_fpf_index_status` before trust-sensitive use.
 2. Proceed only when `snapshotExists` is true, `fresh` is true, and `currentSourceHash` matches `sourceHash`.
-3. Use `read_fpf_doc` for exact FPF wording.
-4. Use `ask_fpf` or `query_fpf_spec` for bounded context and route selection.
+3. Use `read_fpf_doc` for exact FPF wording; use `ask_fpf` or `query_fpf_spec` for bounded context.
 
 ## Freshness Semantics
 
-`status=ok` or `fresh=true` means the deployed runtime artifacts are internally consistent with the configured source. Internal consistency is not global upstream currentness.
-
-When the hosted status page reports `freshness.upstreamCurrentness: "unknown"`, do not claim "latest upstream FPF" unless an external monitor has compared the hosted publication to the intended upstream/current artifact.
+- status ok or fresh means the deployed runtime artifacts are internally consistent with the configured source.
+- Internal consistency is not global upstream currentness.
+- upstreamCurrentness = unknown means do not claim latest upstream FPF unless an external monitor proves it.
 
 ## Output Expectations
 

--- a/src/core/public-copy.ts
+++ b/src/core/public-copy.ts
@@ -351,12 +351,6 @@ export function renderPublicMcpToolsMarkdown(): string {
   return PUBLIC_MCP_TOOLS.map((tool) => `- \`${tool}\``).join('\n');
 }
 
-export function renderInterfaceContractAcceptanceMarkdown(): string {
-  return FPF_REFERENCE_INTERFACE_CONTRACT.acceptanceTests
-    .map((item) => `- ${item}`)
-    .join('\n');
-}
-
 export function renderHomeMcpToolsMarkdown(): string {
   const descriptions: Record<(typeof PUBLIC_MCP_TOOLS)[number], string> = {
     browse_fpf_catalog: 'paginate patterns, lexemes, preface, and any published routes',

--- a/tests/public-copy-parity.test.ts
+++ b/tests/public-copy-parity.test.ts
@@ -13,7 +13,6 @@ import {
   LEGACY_HOSTED_MCP_ENDPOINT,
   MCP_SERVER_NAME,
   PUBLIC_MCP_TOOLS,
-  renderInterfaceContractAcceptanceMarkdown,
   WIKI_CONNECT_MCP_URL,
   WIKI_INTERFACE_CONTRACT_URL,
 } from '../src/core/public-copy.js';
@@ -104,8 +103,14 @@ describe('public adoption copy parity', () => {
       expect(normalizedInterfaceContract).toContain(use.toLowerCase());
     }
 
-    for (const line of renderInterfaceContractAcceptanceMarkdown().split('\n')) {
-      expect(interfaceContract).toContain(line);
+    for (const item of FPF_REFERENCE_INTERFACE_CONTRACT.acceptanceTests) {
+      expect(interfaceContract).toContain(`- ${item}`);
+    }
+    for (const item of FPF_REFERENCE_INTERFACE_CONTRACT.outputExpectation) {
+      expect(interfaceContract).toContain(`- ${item}`);
+    }
+    for (const ref of FPF_REFERENCE_INTERFACE_CONTRACT.governingFpf) {
+      expect(interfaceContract).toContain(`\`${ref.id}\``);
     }
     for (const tool of FPF_REFERENCE_INTERFACE_CONTRACT.publicTools) {
       expect(interfaceContract).toContain(`| \`${tool.name}\` |`);

--- a/tests/public-copy-parity.test.ts
+++ b/tests/public-copy-parity.test.ts
@@ -109,8 +109,18 @@ describe('public adoption copy parity', () => {
     for (const item of FPF_REFERENCE_INTERFACE_CONTRACT.outputExpectation) {
       expect(interfaceContract).toContain(`- ${item}`);
     }
+    // The doc wraps code terms in backticks that the canonical strings omit,
+    // so strip them before exact-wording comparison.
+    const plainInterfaceContract = interfaceContract.replaceAll('`', '');
     for (const ref of FPF_REFERENCE_INTERFACE_CONTRACT.governingFpf) {
       expect(interfaceContract).toContain(`\`${ref.id}\``);
+      expect(plainInterfaceContract).toContain(ref.purpose);
+    }
+    for (const item of FPF_REFERENCE_INTERFACE_CONTRACT.relianceGate) {
+      expect(plainInterfaceContract).toContain(item);
+    }
+    for (const item of FPF_REFERENCE_INTERFACE_CONTRACT.freshnessSemantics) {
+      expect(plainInterfaceContract).toContain(item);
     }
     for (const tool of FPF_REFERENCE_INTERFACE_CONTRACT.publicTools) {
       expect(interfaceContract).toContain(`| \`${tool.name}\` |`);


### PR DESCRIPTION
Stacked on #206. **Rebuilt** after `9072234` ("Address interface contract review comments") landed on the base branch — that commit resolved findings 1 and 4 from [the review](https://github.com/venikman/fpf-memory/pull/206#issuecomment-4663520326) and most of 5, so this PR now contains only the three leftovers (also flagged inline [here](https://github.com/venikman/fpf-memory/pull/206#pullrequestreview-4462005713)):

1. **Remove `renderInterfaceContractAcceptanceMarkdown`** — `9072234` deleted its sibling but kept this one; it's still exported from production code yet only called by the parity test. The test now derives the same lines from `FPF_REFERENCE_INTERFACE_CONTRACT` directly.
2. **Surface `outputExpectation`** — the field was defined and populated but consumed nowhere. Now rendered as an "Output Expectations" section in `docs/interface-contract.md`.
3. **Close the last parity gaps** — the doc-alignment test now also checks `outputExpectation` items and `governingFpf` ids, so those sections can't drift from the constant silently.

## Validation

- `bun run check` — clean
- `bun run lint` — 0 errors, 0 warnings (151 files)
- `bun run test -- tests/public-copy-parity.test.ts tests/hosted-home-page.test.ts` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)