### PR TITLE
docs: fix dead vercel config links on packaging page

### DIFF
--- a/docs/vercel-mcp-packaging.md
+++ b/docs/vercel-mcp-packaging.md
@@ -79,8 +79,8 @@ bun run deploy:prod
 
 Config files:
 
-- [`vercel.mcp.json`](../vercel.mcp.json) — MCP/API project (`buildCommand`: `bun run vercel:mcp:build`)
-- [`vercel.json`](../vercel.json) — static wiki project
+- [`vercel.mcp.json`](https://github.com/venikman/fpf-memory/blob/main/vercel.mcp.json) — MCP/API project (`buildCommand`: `bun run vercel:mcp:build`)
+- [`vercel.json`](https://github.com/venikman/fpf-memory/blob/main/vercel.json) — static wiki project
 
 ## Safety switches
 


### PR DESCRIPTION
## Summary

The two config-file links on the Vercel packaging page (`../vercel.mcp.json`, `../vercel.json`) point outside the docs root, so rspress emits the raw relative hrefs and both links 404 on the published wiki (`doc_build/vercel-mcp-packaging.html` literally contained `href="../vercel.json"`). The dead-link checker can't catch this class — `checkDeadLinks.excludes` skips `./` and `../` URLs. Switched to GitHub blob URLs, which resolve both on github.com and on the built site.

This is the one live analogue from the retro review of #43 (same mechanism as the `docs/deploy.md` finding there); everything else from that review targets code that no longer exists on main.

## Verification

`bun run docs:build` passes, and the built page now emits:

```
href="https://github.com/venikman/fpf-memory/blob/main/vercel.json"
href="https://github.com/venikman/fpf-memory/blob/main/vercel.mcp.json"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only href changes with no runtime, auth, or deploy behavior impact.
> 
> **Overview**
> Fixes broken config links on the **Vercel MCP Packaging** operator page by replacing `../vercel.mcp.json` and `../vercel.json` with stable **GitHub blob URLs** on `main`.
> 
> Relative paths escaped the docs build root, so the published wiki kept raw `../` hrefs and returned **404**; the docs dead-link checker does not validate parent-relative URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 885ae6757916face38005beb65bc7e6358f41253. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->