### PR TITLE
Minimize fpf.sh MCP handoff links

### DIFF
--- a/docs/automation-playbook.md
+++ b/docs/automation-playbook.md
@@ -96,7 +96,7 @@ Default prompt boundary:
 Use the Vercel MCP server named vercel for read-only deployment evidence. Inspect the relevant project, deployment, build logs, runtime logs, and protected preview URL if needed. Do not deploy, promote, alias, rollback, buy domains, or change settings unless the user explicitly approves that action.
 ```
 
-For project-scoped operations, use the project-specific URLs documented in the [operator packaging section on mcp.fpf.sh](https://mcp.fpf.sh/#operator-packaging) so the team/project context is explicit.
+For project-scoped operations, use the project-specific URLs documented in the operator packaging section on the MCP origin so the team/project context is explicit.
 
 ## Merge policy
 
@@ -267,7 +267,7 @@ FPF Reference compiles the published FPF spec into deterministic lookup surfaces
 Useful for PR review, project alignment, spec writing, and adoption UX checks.
 
 Docs: https://fpf.sh/
-MCP setup: https://mcp.fpf.sh/
+MCP setup: https://fpf.sh/connect-mcp
 
 Caveat: deterministic retrieval is the source of truth; request counts are not unique users.
 ```
@@ -290,7 +290,7 @@ FPF Reference is a compiler-backed runtime for the published First Principles Fr
 
 The current material:
 - Website: https://fpf.sh/
-- MCP setup: https://mcp.fpf.sh/
+- MCP setup: https://fpf.sh/connect-mcp
 - Hosted endpoint: https://mcp.fpf.sh/api/mcp/fpf_reference/mcp
 - Legacy endpoint during transition: https://mcp.fpf.sh/api/mcp/fpf_memory/mcp (blocked at Vercel routing during May 2026 cost incident mitigation)
 

--- a/docs/connect-mcp.md
+++ b/docs/connect-mcp.md
@@ -16,4 +16,4 @@ This page remains as a compatibility bridge from older `fpf.sh/connect-mcp` link
 - **FPF Reference MCP** is the programmatic lookup server named `fpf_reference`.
 - **FPF Reference MCP** is not agent memory, not a workflow engine, and not the upstream FPF specification.
 
-Use [Start Here](/start-here) or the [Pattern Catalog](/patterns) for the reference wiki. Use [mcp.fpf.sh](https://mcp.fpf.sh/) for client setup, first-call checks, troubleshooting, and package or self-hosting options.
+Use [Start Here](/start-here) or the [Pattern Catalog](/patterns) for the reference wiki. Use the MCP origin for client setup, first-call checks, troubleshooting, and package or self-hosting options.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -32,7 +32,7 @@ A task-sized checklist on this site that bundles the right route and patterns fo
 
 ### fpf_reference (the MCP server)
 
-The hosted MCP server name agents and editors use to query the spec by stable ID. Six public read-only tools; deterministic graph lookups, not embeddings; not agent memory. Setup and the public contract live on [mcp.fpf.sh](https://mcp.fpf.sh/#interface-contract).
+The hosted MCP server name agents and editors use to query the spec by stable ID. Six public read-only tools; deterministic graph lookups, not embeddings; not agent memory. Setup and the public contract live on the MCP origin.
 
 ### Snapshot and provenance
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -18,7 +18,7 @@ This is the adoption entry surface for the FPF Reference wiki. It helps a person
 
 **The situation.** You are kicking off a project. Responsibilities, working method, plans, and what actually happened keep blurring into one document.
 
-**Step 1 — ask.** Connect your agent or editor from the FPF Reference MCP setup home ([mcp.fpf.sh](https://mcp.fpf.sh/) takes about two minutes), then run:
+**Step 1 — ask.** If `fpf_reference` is already connected in your agent or editor, run:
 
 ```txt
 Use only fpf_reference. Call query_fpf_spec with question: "Project kickoff: align a project information system with roles and adoption next steps" and mode "compact". Return the most relevant FPF IDs, acceptance check, and next move.
@@ -59,8 +59,8 @@ The example above generalizes. Name your work shape, start from the matching doo
 | Dogfood a product as a user role | [Product-role feedback packet](/work-packets#product-role-feedback-packet) | Replayable job, friction evidence, proposed improvement, discussion-ready feedback |
 | Write a specification | [Specification writing packet](/work-packets#specification-writing-packet) | Clear pattern order, semantic change record, acceptance harness |
 | Unpack an API, contract, or promise | [Role, promise, and capability analysis packet](/work-packets#role-promise-and-capability-analysis-packet) | Atomic claims, boundary duties, evidence needs |
-| Compare options | [Pattern Catalog](/patterns) + [mcp.fpf.sh](https://mcp.fpf.sh/) | Governed shortlist or set result |
-| Use FPF inside an agent conversation | [mcp.fpf.sh](https://mcp.fpf.sh/) | Compact cited context instead of a full-spec paste |
+| Compare options | [Pattern Catalog](/patterns) + connected `fpf_reference` | Governed shortlist or set result |
+| Use FPF inside an agent conversation | connected `fpf_reference` | Compact cited context instead of a full-spec paste |
 
 ## Operating rule
 

--- a/docs/work-packets.md
+++ b/docs/work-packets.md
@@ -143,7 +143,7 @@ Goal: let an agent use FPF without loading the whole FPF.
 
 Use:
 
-- [mcp.fpf.sh](https://mcp.fpf.sh/)
+- a connected `fpf_reference` server
 - [Automation Playbook](/automation-playbook) when the work needs role boundaries, access rules, merge authority, or draft-only publishing packets
 - [E.8 Authoring conventions](/generated/patterns/E.8)
 - [E.19 — Pattern Quality Gates: Review & Refresh Profiles](/generated/patterns/E.19) — use as the pattern change-record gate

--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -11,7 +11,7 @@ import {
   OPTIONAL_TERM_LINKS,
   resolveOptionalTermPatternId,
 } from './optional-term-links.js';
-import { MCP_ORIGIN_HOME_URL } from './public-copy.js';
+import { WIKI_CONNECT_MCP_MARKDOWN_LINK } from './public-copy.js';
 import { normalizeForLookup, unique } from './text.js';
 
 export interface GeneratedDocPage {
@@ -532,7 +532,7 @@ function renderHomeMarkdown(
     '',
     'The **First Principles Framework (FPF)** is a pattern language for rigorous reasoning in engineering, research, and management, written by [Anatoly Levenchuk](https://github.com/ailev). Its named, interlinked patterns help teams and AI agents keep meanings, claims, evidence, and decisions stable as work moves between people, tools, and time.',
     '',
-    `This site is the FPF reference: a browsable wiki projection of the published spec (${referenceScope}, addressable by stable FPF IDs). Programmatic MCP lookup is documented separately on [mcp.fpf.sh](${MCP_ORIGIN_HOME_URL}).`,
+    `This site is the FPF reference: a browsable wiki projection of the published spec (${referenceScope}, addressable by stable FPF IDs). Programmatic MCP lookup is separate from this wiki; use ${WIKI_CONNECT_MCP_MARKDOWN_LINK} only when you need the setup handoff.`,
     '',
     // Wording deliberately avoids the exact phrase "Connecting an agent or
     // editor" from the entry-point table below — the preview Playwright
@@ -545,7 +545,7 @@ function renderHomeMarkdown(
     '| If you are... | Start with | Good first action |',
     '| --- | --- | --- |',
     '| New to FPF | [Start Here](/start-here) | Pick the work shape before opening the full catalog. |',
-    `| Connecting an agent or editor | [mcp.fpf.sh](${MCP_ORIGIN_HOME_URL}) | Add \`fpf_reference\`, then run \`get_fpf_index_status\`. |`,
+    `| Connecting an agent or editor | ${WIKI_CONNECT_MCP_MARKDOWN_LINK} | Open the setup handoff; registration details stay on the MCP origin. |`,
     '| Reviewing a project, PR, or design change | [Work Packets](/work-packets) | Use the PR/code review packet or product-role feedback packet. |',
     '| Looking up an exact ID | [Pattern Catalog](/patterns) | Search an ID like `A.2.3`. |',
     '',
@@ -565,7 +565,7 @@ function renderHomeMarkdown(
     '',
     'The full generated pattern catalog lives at [Pattern Catalog](/patterns); this home page stays focused on adoption paths and task entry points.',
     '',
-    `Agent/editor MCP setup lives on [mcp.fpf.sh](${MCP_ORIGIN_HOME_URL}). The reference wiki stays focused on the specification, generated IDs, routes, and glossary.`,
+    `Agent/editor MCP setup lives on the MCP origin; use ${WIKI_CONNECT_MCP_MARKDOWN_LINK} when you need the bridge. The reference wiki stays focused on the specification, generated IDs, routes, and glossary.`,
     '',
     'For framework orientation, see [Start Here](/start-here).',
     '',

--- a/src/core/public-copy.ts
+++ b/src/core/public-copy.ts
@@ -19,6 +19,10 @@ export const WIKI_BASE_URL = 'https://fpf.sh';
 // Compatibility bridge on the static reference site. New setup docs should
 // point at MCP_ORIGIN_HOME_URL so MCP instructions live on the MCP surface.
 export const WIKI_CONNECT_MCP_URL = `${WIKI_BASE_URL}/connect-mcp`;
+export const WIKI_CONNECT_MCP_PATH = '/connect-mcp';
+export const WIKI_CONNECT_MCP_LABEL = 'Connect MCP';
+export const WIKI_CONNECT_MCP_MARKDOWN_LINK =
+  `[${WIKI_CONNECT_MCP_LABEL}](${WIKI_CONNECT_MCP_PATH})`;
 
 export const MCP_ORIGIN_HOME_URL = 'https://mcp.fpf.sh/';
 

--- a/tests/docs-projection.test.ts
+++ b/tests/docs-projection.test.ts
@@ -484,7 +484,7 @@ describe('docs projection', () => {
       expect(rootIndex).toContain('## Choose your entry point');
       expect(rootIndex).toContain('| New to FPF | [Start Here](/start-here)');
       expect(rootIndex).toContain(
-        '| Connecting an agent or editor | [mcp.fpf.sh](https://mcp.fpf.sh/)',
+        '| Connecting an agent or editor | [Connect MCP](/connect-mcp)',
       );
       expect(rootIndex).toContain(
         '| Reviewing a project, PR, or design change | [Work Packets](/work-packets)',
@@ -493,7 +493,8 @@ describe('docs projection', () => {
       expect(rootIndex).toContain('## Reference shortcuts');
       expect(rootIndex).toContain('[Start here](/start-here)');
       expect(rootIndex).not.toContain('[Quick connect](/connect-local)');
-      expect(rootIndex).not.toContain('[Connect MCP](/connect-mcp)');
+      expect(rootIndex).toContain('[Connect MCP](/connect-mcp)');
+      expect(rootIndex).not.toContain('https://mcp.fpf.sh');
       expect(rootIndex).toContain('[Pattern Catalog](/patterns)');
       // Hero: plain-language answer (what FPF is / what this site adds /
       // what to do first) leads the page; the deep dive and provenance

--- a/tests/public-copy-parity.test.ts
+++ b/tests/public-copy-parity.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 import { describe, expect, it } from '@rstest/core';
@@ -15,6 +15,7 @@ import {
   MCP_ORIGIN_HOME_URL,
   MCP_SERVER_NAME,
   PUBLIC_MCP_TOOLS,
+  WIKI_CONNECT_MCP_MARKDOWN_LINK,
 } from '../src/core/public-copy.js';
 import * as toolContracts from '../src/mcp/tool-contracts.js';
 
@@ -64,10 +65,30 @@ describe('public adoption copy parity', () => {
     const startHere = await readFile(resolve(process.cwd(), 'docs/start-here.md'), 'utf8');
 
     expect(startHere).toContain('First Principles Framework (FPF)');
-    expect(startHere).toContain(MCP_ORIGIN_HOME_URL);
+    expect(startHere).not.toContain(WIKI_CONNECT_MCP_MARKDOWN_LINK);
+    expect(startHere).not.toContain(MCP_ORIGIN_HOME_URL);
     expect(startHere).toContain(FIRST_SUCCESSFUL_CALL_PROMPT);
     expect(startHere).toContain(MCP_SERVER_NAME);
     expect(startHere).toContain('query_fpf_spec');
+  });
+
+  it('keeps direct wiki-to-MCP markdown setup links constrained to the bridge page', async () => {
+    const bridge = await readFile(resolve(process.cwd(), 'docs/connect-mcp.md'), 'utf8');
+    const directBridgeLinks = bridge.match(/\]\(https:\/\/mcp\.fpf\.sh\/\)/g) ?? [];
+    expect(directBridgeLinks).toHaveLength(1);
+
+    const docsRoot = resolve(process.cwd(), 'docs');
+    const files = await readdir(docsRoot, { withFileTypes: true });
+    for (const file of files) {
+      if (!file.isFile() || !file.name.endsWith('.md') || file.name === 'connect-mcp.md') {
+        continue;
+      }
+      const markdown = await readFile(resolve(docsRoot, file.name), 'utf8');
+      // Operator runbooks may mention status or endpoint literals as evidence;
+      // public setup/home links should go through the compatibility bridge.
+      expect(markdown).not.toMatch(/\]\(https:\/\/mcp\.fpf\.sh\/(?:#[^)]+)?\)/);
+      expect(markdown).not.toMatch(/MCP setup:\s+https:\/\/mcp\.fpf\.sh\/(?=\s|$)/);
+    }
   });
 
   it('documents the FPF vs MCP explainer contract for wiki surfaces', () => {


### PR DESCRIPTION
## Summary
- route public wiki MCP setup references through the Connect MCP bridge instead of direct mcp.fpf.sh links
- keep only one direct MCP setup link on the bridge page while ordinary wiki pages retain the global nav link
- add parity coverage for the minimal handoff rule

## Validation
- bun run test tests/public-copy-parity.test.ts tests/docs-projection.test.ts tests/e2e/rendering.spec.ts
- bun run test tests/content-quality-monitor.test.ts tests/fpf-work-evaluator.test.ts
- bun run check
- bun run lint
- bun run vercel:website:build
- git diff --check
- bun run monitor:content -- --mode local --format markdown --fail-on-breach

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generated copy changes only, with parity tests; no runtime auth, API, or data-handling behavior changes.
> 
> **Overview**
> Wiki MCP setup copy now routes through **[Connect MCP](/connect-mcp)** instead of linking straight to `https://mcp.fpf.sh/` on ordinary adoption pages (`start-here`, `glossary`, `work-packets`, and the generated home in `documents.ts`). The bridge page keeps a single direct MCP-origin setup URL; other wiki prose points readers at the handoff or at an already-connected `fpf_reference` client.
> 
> Tests lock in the rule: home projection expects `[Connect MCP](/connect-mcp)` and no `mcp.fpf.sh` in generated index markdown; `public-copy-parity` asserts exactly one direct `](https://mcp.fpf.sh/)` link on `connect-mcp.md` and none on the other listed docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 534301ef58e23f5d7be12d9af1971e8962f8f6f4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->