### PR TITLE
fix(docs): drop dead H.1 links unblocking FPF sync/publish

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -6,7 +6,7 @@ outline: deep
 
 # Glossary
 
-Plain-language definitions of the terms you will meet on this site, in roughly the order you will meet them. Every entry links to the canonical FPF pattern so you can audit the full definition. For the spec's own exhaustive index of every `U.Type`, relation, and operator, see the [H.1 Alphabetic Glossary](/generated/patterns/H.1).
+Plain-language definitions of the terms you will meet on this site, in roughly the order you will meet them. Every entry links to the canonical FPF pattern so you can audit the full definition.
 
 ## The site
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -68,4 +68,4 @@ Do not ask people to read all of FPF before they can benefit from it. Ask for th
 
 ## When to use the full catalog
 
-Use the [Pattern Catalog](/patterns) when the doorway is not enough, when an exact pattern clause matters, or when a reader needs to audit the source. Definitions live in the [Glossary](/glossary); the spec's own term index is [H.1](/generated/patterns/H.1).
+Use the [Pattern Catalog](/patterns) when the doorway is not enough, when an exact pattern clause matters, or when a reader needs to audit the source. Definitions live in the [Glossary](/glossary).


### PR DESCRIPTION
Upstream ailev/FPF removed the H.* section; two hand-authored docs (glossary.md, start-here.md) still linked /generated/patterns/H.1, failing the rspress dead-link check in vercel:website:build inside sync-fpf.yml. That froze publication at the Jun-8 snapshot and made every hourly sync run fail at ~2m30s. Removes the stale refs; on-site /glossary and /patterns already cover it. Verified locally: all 278 hand-authored /generated/patterns links resolve (DEAD=0).