### PR TITLE
docs: Glaze companion design exploration (claim register + build prompt)

### DIFF
--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -52,7 +52,7 @@ Maps `get_fpf_index_status` directly: a pill in the sidebar footer is green when
 
 ### Ask
 
-Maps `ask_fpf` (`mode: compact` default; `verbose`/`proof` toggle) — the human-facing twin of `query_fpf_spec`, whose structured envelope stays deliberately unused in this app. Renders the `markdown` answer; `ids` as chips that open the Reader; `citations`, `constraints`, `gaps`, and `confidence` as a grounding footer. `status` enum handling: `ok` renders normally; `not_found` offers Search; `ambiguous` renders `candidateIds` as suggestion chips; `unsupported` explains the bound; `stale_snapshot_prevented` triggers the stale banner and a status re-check.
+Maps `ask_fpf` — the human-facing twin of `query_fpf_spec`, whose structured envelope stays deliberately unused in this app. The app always sends `mode` explicitly (`compact` unless the user toggles `verbose`/`proof`): the server-side default is deployment-configured (`FPF_QUERY_DEFAULT_MODE`, `verbose` in production), so omitting `mode` must not be relied on for the quick-answer UX. Renders the `markdown` answer; `ids` as chips that open the Reader; `citations`, `constraints`, `gaps`, and `confidence` as a grounding footer. `status` enum handling: `ok` renders normally; `not_found` offers Search; `ambiguous` renders `candidateIds` as suggestion chips; `unsupported` explains the bound; `stale_snapshot_prevented` triggers the stale banner and a status re-check.
 
 ### Search
 
@@ -86,9 +86,13 @@ only (it equips the build agent, not the shipped app). The app itself must
 implement a plain HTTP client for the endpoint above using the MCP
 Streamable HTTP transport: JSON-RPC 2.0 POSTs (one initialize handshake,
 then tools/call with the tool name and arguments), parsing each JSON
-result. Do not depend on any Glaze MCP server connection existing at
-runtime — if the generated app cannot reach the endpoint with its own
-HTTP client, the build has failed acceptance check 1.
+result. In every tools/call response, the tool payload lives in the
+JSON-RPC envelope's result.structuredContent — NOT directly on result
+(result.content is only a human-readable text fallback); read all fields
+below from structuredContent. Do not depend on any Glaze MCP server
+connection existing at runtime — if the generated app cannot reach the
+endpoint with its own HTTP client, the build has failed acceptance
+check 1.
 
 Call only these five tools through that client, nothing else:
 - get_fpf_index_status {} -> { sourcePath, sourceHash?, builtAt?,
@@ -106,7 +110,10 @@ Call only these five tools through that client, nothing else:
   -> { markdown, ids, citations, constraints, gaps, confidence (nullable),
   candidateIds?, status, snapshot }
   (candidateIds carries the structured suggestions rendered as chips when
-  status is "ambiguous" — never scrape them from the markdown)
+  status is "ambiguous" — never scrape them from the markdown. ALWAYS send
+  mode explicitly, "compact" unless the user toggles otherwise: the
+  server-side default is deployment-configured and is verbose in
+  production, so omitting mode gives slow verbose answers)
 - read_fpf_doc { selector (<=256 chars), mode?: preview|full, maxChars? }
   -> { title?, nodeId?, markdown?, markdownChars?, truncated?, headings?,
   preview?, docRef?: { staticPath }, snapshot }

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -86,21 +86,28 @@ only (it equips the build agent, not the shipped app). The app itself must
 implement a plain HTTP client for the endpoint above using the MCP
 Streamable HTTP transport, with the full lifecycle:
 1. every request sends header "Accept: application/json, text/event-stream";
-2. POST a JSON-RPC 2.0 initialize request, then POST the
-   notifications/initialized notification;
+2. POST a JSON-RPC 2.0 initialize request whose params include
+   protocolVersion ("2025-06-18"), capabilities ({} suffices for this
+   read-only client), and clientInfo ({ name: "fpf-companion", version });
+   then POST the notifications/initialized notification;
 3. after initialize, send header "MCP-Protocol-Version: <the version
    returned in the initialize result>" (currently 2025-06-18) on every
    subsequent request;
 4. if any response returns an Mcp-Session-Id header, echo it as a header
    on every subsequent request;
-5. then POST tools/call requests with the tool name and arguments,
-   parsing each JSON result;
+5. then POST tools/call requests with the tool name and arguments; each
+   response arrives as Content-Type application/json (parse directly) or
+   text/event-stream (read the SSE stream and parse the JSON-RPC message
+   from its data: lines) — support both, as the Accept header promises;
 6. handle failures without crashing: a JSON-RPC response may carry an
    "error" member instead of "result" — surface its message in the UI as
    a readable error state; HTTP failures and timeouts (use a 15 s request
    timeout and at most one retry, consistent with the bounded-request
    rule) switch the app to the offline state of behavior 6, keeping
-   cached content readable and labeled. In every tools/call response, the tool payload lives in the
+   cached content readable and labeled.
+Where this recipe is silent, follow the official MCP Streamable HTTP
+transport and lifecycle spec (modelcontextprotocol.io, revision
+2025-06-18) — it wins over any shortcut a code generator might prefer. In every tools/call response, the tool payload lives in the
 JSON-RPC envelope's result.structuredContent — NOT directly on result
 (result.content is only a human-readable text fallback); read all fields
 below from structuredContent. Do not depend on any Glaze MCP server

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -99,8 +99,9 @@ Streamable HTTP transport, with the full lifecycle:
    response arrives as Content-Type application/json (parse directly) or
    text/event-stream (read the SSE stream until the JSON-RPC message whose
    id matches the request id; earlier events may be notifications or
-   server requests — skip anything the app does not handle) — support
-   both, as the Accept header promises;
+   server requests — answer a ping request with an empty result, skip
+   other messages the app does not handle) — support both, as the Accept
+   header promises;
 6. handle failures without crashing: a JSON-RPC response may carry an
    "error" member instead of "result" — surface its message in the UI as
    a readable error state; an HTTP 404 received while sending
@@ -174,8 +175,11 @@ Non-negotiable behaviors:
 6. Cache responses keyed by (tool, arguments, sourceHash); drop the cache
    when the status hash changes. Offline: cached pages stay readable,
    labeled "offline — freshness unverified" with their snapshot hash.
-7. Enforce input caps client-side: question 2000, search 1000, selector 256
-   characters. Debounce search; page the catalog with nextOffset; never poll.
+7. Enforce input bounds client-side: question <= 2000 characters, search
+   query <= 1000 and never empty, selector <= 256, catalog part/status
+   filters <= 64; omit empty optional fields entirely instead of sending
+   empty strings. Debounce search; page the catalog with nextOffset;
+   never poll.
 8. Freshness means internal consistency of the deployed snapshot only —
    never display any claim that upstream FPF is current.
 9. The service name is fpf_reference. Never reference "fpf_memory" anywhere:

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -1,0 +1,170 @@
+# Glaze Companion Design (Exploration)
+
+## Objective
+
+Decide whether Glaze (<https://www.glaze.app/>, Raycast's AI desktop-app builder for macOS) can benefit this project, and — for the one admissible integration — specify it precisely enough that building it cannot blur the `fpf_reference` interface contract.
+
+## Verdict
+
+- Glaze is admissible **only** as an optional, read-only, native macOS client over the hosted public `fpf_reference` MCP surface. It is one more consumer of the published interface contract, exactly like Codex or Claude Code.
+- Glaze brings **no value to the core**: the deterministic vectorless runtime, the publication pipeline, and the agent-facing MCP surface. Glaze generates apps with a non-deterministic LLM step; the publication path here is deterministic and evidence-audited. A generated app may consume the contract; it must never participate in producing published artifacts.
+- Priority: opportunistic, low. Nothing in this repo's runtime, CI, or published surfaces may depend on the companion existing.
+
+## Context
+
+The hosted MCP endpoint and the static reference site already serve the two primary audiences (agents and humans in a browser). A native macOS companion is a plausible third client surface: menu-bar quick lookup, offline reading of already-fetched pages, and a windowed reader for people who live outside the browser. Glaze makes that buildable from a single prompt without adding Swift to anyone's plate, and its store gives a small distribution channel.
+
+Glaze constraints as of this design (2026-07-07): macOS Tahoe + Apple Silicon only; apps are local-first and run without a server; apps can call external APIs and AI-model integrations; distribution is unlisted sharing or the public Glaze Store.
+
+## FPF Grounding
+
+`ask_fpf` on the production runtime routed this exact decision ("external client surface as optional read-only consumer of a published interface contract") to **route:boundary-unpacking**, ordered entry `A.6` → `A.6.B` → `A.6.C`, confidence 0.92. The route's acceptance check: mixed boundary statements get stable claim IDs in a claim register, and each atomic claim routes to one owner layer. The claim register below is this spec's implementation of that check.
+
+Repo QA anchors reused: `B.5.1` (this doc is exploration/shaping, separated from operation), `A.10`/`G.6` (snapshot hash and builtAt as the evidence spine), `E.19` (explicit, separate quality gates), `C.24` (bounded tool-call behavior for the client).
+
+The runtime snapshot used throughout this design: `sha256:f916341a8b3711b847c8a701f8b71e0ee155d9e5517be3ed36363fa6621ccf2b`, built `2026-07-03T21:18:14Z`, `fresh: true` — identical hash reported by `get_fpf_index_status` and echoed in every payload captured in the Evidence section.
+
+## Claim register
+
+| ID | Atomic claim | Owner layer |
+| --- | --- | --- |
+| GLZ-1 | The companion calls only the six public tools: `browse_fpf_catalog`, `search_fpf`, `ask_fpf`, `query_fpf_spec`, `read_fpf_doc`, `get_fpf_index_status`. | Interface contract (mcp.fpf.sh) |
+| GLZ-2 | Expert tools (`inspect_*`, `trace_fpf_path`, `refresh_fpf_index`) are never assumed on the hosted endpoint and never appear in the app. | Interface contract |
+| GLZ-3 | Reliance gate: before trust-sensitive display, `get_fpf_index_status` must show `snapshotExists: true`, `fresh: true`, and `currentSourceHash === sourceHash`; otherwise every surface renders a degraded state and answers are labeled unverified. | Interface contract |
+| GLZ-4 | Exact wording flows only through `read_fpf_doc`; `ask_fpf` output is presented as a grounded summary, never as canonical spec text. | Interface contract |
+| GLZ-5 | The companion is not agent memory, job state, a workflow engine, or a policy authority — the contract's non-admissible uses stay non-admissible in the client UI and copy. | Interface contract |
+| GLZ-6 | The app, its configuration, and any store listing use the canonical `fpf_reference` endpoint and name; the legacy `fpf_memory` name appears nowhere. | Repo policy (AGENTS.md) |
+| GLZ-7 | Every rendered answer or page footer carries `snapshot.sourceHash` (short form) and `builtAt` from that same response; a mismatch against the status hash renders a stale banner. | Client app |
+| GLZ-8 | Freshness is shown as internal consistency only; the app never claims upstream currentness (`upstreamCurrentness` is `unknown` by design on the public status). | Interface contract |
+| GLZ-9 | Client-side caching is keyed by `(tool, arguments, sourceHash)` — admissible because tool responses are deterministic per snapshot — and invalidated when the status hash changes. | Client app |
+| GLZ-10 | Input caps are mirrored client-side (question ≤ 2000 chars, search query ≤ 1000, selector ≤ 256; bounded reads via `maxChars`), so the app never emits schema-rejected input. | Client app (mirrors `src/mcp/tool-contracts.ts`) |
+| GLZ-11 | Requests stay bounded: search fires on submit (or ≥ 300 ms debounce), catalog pages via `nextOffset`, status is checked at launch and on manual refresh only — courtesy to the hosted spend guardrails. | Client app |
+| GLZ-12 | Publishing to the Glaze Store is external publication and requires explicit human approval; unlisted sharing is the default distribution. | Repo policy (AGENTS.md autonomy norms) |
+| GLZ-13 | Nothing in this repo's runtime, pipeline, CI, or published surfaces depends on the companion; removing it is a no-op for the project. | Repo policy |
+
+## Design
+
+Working name: **FPF Companion**. One dependency: `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`. Shape: a menu-bar quick-search plus a main window with five surfaces.
+
+### Status (freshness spine)
+
+Maps `get_fpf_index_status` directly: a pill in the sidebar footer is green when the GLZ-3 gate passes, amber otherwise. The detail view lists `sourceHash`, `builtAt`, `compilerMode: local_vectorless`, and the artifact booleans. The pill's state gates the trust labeling on every other surface.
+
+### Ask
+
+Maps `ask_fpf` (`mode: compact` default; `verbose`/`proof` toggle). Renders the `markdown` answer; `ids` as chips that open the Reader; `citations`, `constraints`, `gaps`, and `confidence` as a grounding footer. `status` enum handling: `ok` renders normally; `not_found` offers Search; `ambiguous` renders `candidateIds` as suggestion chips; `unsupported` explains the bound; `stale_snapshot_prevented` triggers the stale banner and a status re-check.
+
+### Search
+
+Maps `search_fpf`. Hit rows show `kind` badge (pattern / route / lexeme / preface), `title`, `id`, `part`, `status`, and the `snippet`; selecting a hit opens the Reader. Optional `kind` filter mirrors the schema enum.
+
+### Catalog
+
+Maps `browse_fpf_catalog` with `part` / `status` / `kind` filters, paged by `nextOffset`, honoring `didYouMean.part` for near-miss filters.
+
+### Reader
+
+Maps `read_fpf_doc`. Hover cards use `mode: "preview"` (headings + snippet, no body). Full pages request `maxChars: 20000` first and offer "load full page" when `truncated: true` (`markdownChars` tells the user the full size). Header shows `title`, resolved `nodeId`, and an "open on fpf.sh" link derived from `docRef.staticPath`. Typing an ID (`A.1.1`) or route (`route:project-alignment`) anywhere jumps straight here via selector auto-resolution.
+
+### Offline behavior
+
+Local-first apps keep working offline: cached pages stay readable but are labeled with their snapshot short-hash plus "offline — freshness unverified", and the GLZ-3 gate re-runs on reconnect.
+
+## Glaze build prompt
+
+The operational artifact — paste into Glaze as-is:
+
+```text
+Build a macOS app called "FPF Companion": a read-only reader and lookup client
+for the First Principles Framework reference, backed by exactly one external
+service, the hosted MCP endpoint:
+
+  https://mcp.fpf.sh/api/mcp/fpf_reference/mcp   (server name: fpf_reference)
+
+Use only these six MCP tools, nothing else:
+- get_fpf_index_status {} -> { sourcePath, sourceHash, builtAt, snapshotExists,
+  currentSourceHash, fresh, compilerMode, artifacts }
+- search_fpf { query (<=1000 chars), kind?: pattern|route|lexeme|preface,
+  limit?: 1..100 } -> { hits: [{ id, kind, title, status?, part?, score,
+  snippet }], total, snapshot }
+- browse_fpf_catalog { part?, status?, kind?, limit?: 1..500, offset? }
+  -> { entries: [{ id, kind, title, status?, part?, description }], total,
+  nextOffset?, didYouMean?, snapshot }
+- ask_fpf { question (<=2000 chars), mode?: compact|verbose|proof }
+  -> { markdown, ids, citations, constraints, gaps, confidence, status,
+  snapshot }
+- query_fpf_spec { question, mode? } -> structured envelope (same family)
+- read_fpf_doc { selector (<=256 chars), mode?: preview|full, maxChars? }
+  -> { title?, nodeId?, markdown?, markdownChars?, truncated?, headings?,
+  preview?, docRef?: { staticPath }, snapshot }
+
+App shape: a menu-bar icon with a global-shortcut quick-search (top 5
+search_fpf hits; Enter opens the reader; typing an exact ID like "A.1.1" or
+"route:project-alignment" opens the reader directly), and a main window with
+a sidebar: Ask, Search, Catalog, Reader, Status.
+
+Non-negotiable behaviors:
+1. On launch and on manual refresh call get_fpf_index_status. Trusted state
+   requires snapshotExists && fresh && currentSourceHash === sourceHash.
+   Show a green "Fresh" pill when trusted, amber "Degraded" otherwise, and
+   label all content "unverified" in degraded state.
+2. Every answer and page shows a footer with the response's own
+   snapshot.sourceHash (first 12 hex chars) and builtAt. If it differs from
+   the status hash, show a stale banner.
+3. ask_fpf answers are grounded summaries. For exact spec wording always
+   fetch read_fpf_doc and say so in the UI ("Exact text").
+4. Handle the answer status enum: ok; not_found (offer search); ambiguous
+   (render candidateIds as suggestions); unsupported (explain);
+   stale_snapshot_prevented (stale banner + status re-check).
+5. Reader fetches use maxChars 20000 first; when truncated is true show
+   "Load full page (N chars)". Preview/hover cards use mode "preview".
+6. Cache responses keyed by (tool, arguments, sourceHash); drop the cache
+   when the status hash changes. Offline: cached pages stay readable,
+   labeled "offline — freshness unverified" with their snapshot hash.
+7. Enforce input caps client-side: question 2000, search 1000, selector 256
+   characters. Debounce search; page the catalog with nextOffset; never poll.
+8. Freshness means internal consistency of the deployed snapshot only —
+   never display any claim that upstream FPF is current.
+9. The service name is fpf_reference. Never reference "fpf_memory" anywhere:
+   not in code, settings, copy, or the store listing.
+10. The app is read-only: no notes, no memory, no editing, no workflow
+    features. Link out to https://fpf.sh/ for the full site.
+
+Visual: native macOS feel, quiet reference-tool aesthetic, monospace for
+IDs and hashes, kind badges for pattern/route/lexeme/preface.
+```
+
+## Evidence (design-time payloads, production endpoint, 2026-07-07)
+
+`get_fpf_index_status`:
+
+```json
+{"sourceHash":"sha256:f916341a8b37…","builtAt":"2026-07-03T21:18:14Z",
+ "snapshotExists":true,"currentSourceHash":"sha256:f916341a8b37…",
+ "fresh":true,"compilerMode":"local_vectorless"}
+```
+
+`search_fpf { query: "bounded context", limit: 3 }` → 1689 total; top hits `lex:bounded-context` (lexeme, score 160.8), `A.1.1` "U.BoundedContext Semantic Frame" (pattern, Stable), `A.2.5` (pattern, Stable) — same snapshot hash echoed.
+
+`browse_fpf_catalog { kind: "route", limit: 3 }` → 3 routes total: `route:boundary-unpacking`, `route:project-alignment`, `route:writing-or-reviewing-patterns`, each with a task-oriented `description`.
+
+`ask_fpf` (boundary question) → `route:boundary-unpacking`, IDs `A.6, A.6.B, A.6.C` (+ conditional `A.6.P, C.16.Q, A.6.A`), confidence 0.92, status `ok`.
+
+## Non-goals
+
+- No Glaze anywhere in the build/publish/sync path; the README scope list (no vector DB, no remote indexing, no LLM step in the docs pipeline) stays authoritative and untouched.
+- No expert tools; no bundling of the local stdio runtime inside the app.
+- No cross-platform promise — the website remains the canonical human surface; the companion is macOS-only by Glaze's own constraint.
+- Not an FPF authoring or editing surface, and not a second source of adoption copy: endpoint/setup wording keeps its SSOT in `src/core/public-copy.ts`.
+
+## Acceptance checks (app-level, mirroring the contract's)
+
+1. With outbound network restricted to `mcp.fpf.sh`, all five surfaces function — proving the single-dependency boundary (GLZ-1, GLZ-13).
+2. Simulating `fresh: false` or a hash mismatch degrades every surface and labels all content unverified (GLZ-3, GLZ-7).
+3. A search of the generated app's source contains zero occurrences of `fpf_memory` (GLZ-6).
+4. Every rendered answer/page shows its snapshot short-hash; in the nominal state it equals the status hash (GLZ-7).
+5. Any store or unlisted listing names `fpf_reference`, links `https://fpf.sh/`, and ships only after explicit human approval (GLZ-6, GLZ-12).
+
+## Decision
+
+Park as an optional exploration: the benefit is real but minor (a nicer native lookup surface plus a small discovery channel), the cost of a clean build is one prompt, and the boundary above keeps it from ever leaking into the core. If nobody wants the desktop experience, dropping this doc is the entire cost of exit.

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -36,7 +36,7 @@ The runtime snapshot used throughout this design: `sha256:f916341a8b3711b847c8a7
 | GLZ-6 | The app, its configuration, and any store listing use the canonical `fpf_reference` endpoint and name; the legacy `fpf_memory` name appears nowhere. | Repo policy (AGENTS.md) |
 | GLZ-7 | Every rendered answer or page footer carries `snapshot.sourceHash` (short form) and `builtAt` from that same response; a mismatch against the status hash renders a stale banner. | Client app |
 | GLZ-8 | Freshness is shown as internal consistency only; the app never claims upstream currentness — `get_fpf_index_status` proves the deployed snapshot's internal consistency, and upstream currentness is by design unknowable from the endpoint alone. | Interface contract |
-| GLZ-9 | Client-side caching is keyed by `(tool, arguments, sourceHash)` — admissible because tool responses are deterministic per snapshot — and invalidated when the status hash changes. | Client app |
+| GLZ-9 | Client-side caching is keyed by `(tool, arguments, sourceHash)` — admissible because tool responses are deterministic per snapshot — and invalidated when the status hash changes; `get_fpf_index_status` itself is never cached, since it is the invalidation oracle. | Client app |
 | GLZ-10 | Input bounds are mirrored client-side (question ≤ 2000 chars and non-empty, search query ≤ 1000 and non-empty, selector ≤ 256 and non-empty, catalog filters ≤ 64; `maxChars` within [100, 200000]), so the app never emits schema-rejected input. | Client app (mirrors `src/mcp/tool-contracts.ts`) |
 | GLZ-11 | Requests stay bounded: search fires on submit (or ≥ 300 ms debounce), catalog pages via `nextOffset`, and status is checked only at launch, on manual refresh, after a `stale_snapshot_prevented` answer, or on network reconnect — never on a timer. Courtesy to the hosted spend guardrails. | Client app |
 | GLZ-12 | Publishing to the Glaze Store is external publication and requires explicit human approval; unlisted sharing is the default distribution. | Repo policy (AGENTS.md autonomy norms) |
@@ -48,11 +48,11 @@ Working name: **FPF Companion**. One dependency: the hosted `fpf_reference` MCP 
 
 ### Status (Freshness Spine)
 
-Maps `get_fpf_index_status` directly: a pill in the sidebar footer is green when the GLZ-3 gate passes, amber otherwise. The detail view lists `sourceHash`, `builtAt`, `compilerMode: local_vectorless`, and the artifact booleans. The pill's state gates the trust labeling on every other surface.
+Maps `get_fpf_index_status` directly: a pill in the sidebar footer is green when the GLZ-3 gate passes, amber otherwise. The detail view lists `sourcePath`, `sourceHash`, `builtAt`, `compilerMode: local_vectorless`, and the artifact booleans. The pill's state gates the trust labeling on every other surface.
 
 ### Ask
 
-Maps `ask_fpf` — the human-facing twin of `query_fpf_spec`, whose structured envelope stays deliberately unused in this app. The app always sends `mode` explicitly (`compact` unless the user toggles `verbose`/`proof`): the server-side default is deployment-configured (`FPF_QUERY_DEFAULT_MODE`, `verbose` in production), so omitting `mode` must not be relied on for the quick-answer UX. Renders the `markdown` answer; `ids` as chips that open the Reader; `citations`, `constraints`, `gaps`, and `confidence` as a grounding footer. `status` enum handling: `ok` renders normally; `not_found` offers Search; `ambiguous` renders `candidateIds` as suggestion chips; `unsupported` explains the bound; `stale_snapshot_prevented` triggers the stale banner and a status re-check.
+Maps `ask_fpf` — the human-facing twin of `query_fpf_spec`, whose structured envelope stays deliberately unused in this app. The app always sends `mode` explicitly (`compact` unless the user toggles `verbose`/`proof`): the server-side default is deployment-configured (`FPF_QUERY_DEFAULT_MODE`, `verbose` in production), so omitting `mode` must not be relied on for the quick-answer UX. Renders the `markdown` answer; `ids` as chips that open the Reader; a grounding footer (`confidence`, `status`, snapshot short-hash, `builtAt`) with `citations`, `constraints`, and `gaps` listed beneath it. `status` enum handling: `ok` renders normally; `not_found` offers Search; `ambiguous` renders `candidateIds` as suggestion chips; `unsupported` explains the bound; `stale_snapshot_prevented` triggers the stale banner and a status re-check.
 
 ### Search
 
@@ -125,7 +125,8 @@ network dependency.
 
 Call only these five tools through that client, nothing else:
 - get_fpf_index_status {} -> { sourcePath, sourceHash?, builtAt?,
-  snapshotExists, currentSourceHash, fresh, compilerMode, artifacts }
+  snapshotExists, currentSourceHash, fresh, compilerMode, artifacts,
+  sessionCache }
   (sourceHash and builtAt are OMITTED when no snapshot could be loaded —
   exactly the degraded case; parse them as optional or the degraded render
   itself breaks)
@@ -179,8 +180,10 @@ Non-negotiable behaviors:
    — maxChars must always stay within the schema bounds [100, 200000].
    Preview/hover cards use mode "preview".
 6. Cache responses keyed by (tool, arguments, sourceHash); drop the cache
-   when the status hash changes. Offline: cached pages stay readable,
-   labeled "offline — freshness unverified" with their snapshot hash.
+   when the status hash changes. NEVER cache get_fpf_index_status itself —
+   it is the invalidation oracle and always goes to the network. Offline:
+   cached pages stay readable, labeled "offline — freshness unverified"
+   with their snapshot hash.
 7. Enforce input bounds client-side: question <= 2000 characters and never
    empty, search query <= 1000 and never empty, selector <= 256 and never
    empty, catalog part/status filters <= 64, maxChars within [100, 200000];
@@ -191,7 +194,8 @@ Non-negotiable behaviors:
 8. Freshness means internal consistency of the deployed snapshot only —
    never display any claim that upstream FPF is current.
 9. The service name is fpf_reference. Never reference "fpf_memory" anywhere:
-   not in code, settings, copy, or the store listing.
+   not in code, settings, copy, or the store listing. Any store or unlisted
+   listing must name fpf_reference and link https://fpf.sh/.
 10. The app is read-only: no notes, no memory, no editing, no workflow
     features. Link out to https://fpf.sh/ for the full site, and give
     every Reader page an "open on fpf.sh" link built from its
@@ -212,11 +216,12 @@ brand palette. The only required visual elements are functional:
 - Monospace for every FPF ID, snapshot hash, and payload value.
 - Components: search hits as rows (kind badge, title + monospace ID,
   part/status, one-line snippet, score); FPF IDs rendered as chips that
-  open the Reader; every answer and page ends with a grounding footer
+  open the Reader; every answer ends with a grounding footer
   (confidence · status · snapshot short-hash · builtAt), with the
-  answer's citations, constraints, and gaps listed beneath it; the
-  Status surface's detail view lists sourcePath, sourceHash, builtAt,
-  compilerMode, and the artifact booleans.
+  answer's citations, constraints, and gaps listed beneath it; every
+  Reader page ends with a footer (status · snapshot short-hash ·
+  builtAt); the Status surface's detail view lists sourcePath,
+  sourceHash, builtAt, compilerMode, and the artifact booleans.
 ```
 
 ## Evidence (Design-Time Payloads, Production Endpoint, 2026-07-07)
@@ -229,7 +234,7 @@ brand palette. The only required visual elements are functional:
  "fresh":true,"compilerMode":"local_vectorless"}
 ```
 
-(Abbreviated: hashes shortened, and the full payload also carried `sourcePath` plus the eight artifact booleans, all `true` — the always-present fields the prompt's schema declares.)
+(Abbreviated: hashes shortened, and the full payload also carried `sourcePath`, the eight artifact booleans (all `true`), and the `sessionCache` object — the always-present fields the prompt's schema declares.)
 
 `search_fpf { query: "bounded context", limit: 3 }` → 1689 total; top hits `lex:bounded-context` (lexeme, score 160.8), `A.1.1` "U.BoundedContext Semantic Frame" (pattern, Stable), `A.2.5` (pattern, Stable) — same snapshot hash echoed.
 
@@ -246,11 +251,11 @@ brand palette. The only required visual elements are functional:
 
 ## Acceptance Checks (App-Level, Mirroring the Contract's)
 
-1. With outbound network restricted to `mcp.fpf.sh`, all five surfaces function — proving the single-dependency boundary (GLZ-1, GLZ-2).
+1. With outbound network restricted to `mcp.fpf.sh`, all five surfaces function — proving the single-dependency boundary (GLZ-1).
 2. Simulating `fresh: false` degrades every surface and labels all content unverified; simulating a response-vs-status hash mismatch renders the stale banner (GLZ-3, GLZ-7).
-3. A search of the generated app's source contains zero occurrences of `fpf_memory` (GLZ-6).
+3. A search of the generated app's source contains zero occurrences of `fpf_memory` and zero references to the non-public tools (`inspect_*`, `trace_fpf_path`, `expand_fpf_citations`, `refresh_fpf_index`) (GLZ-2, GLZ-6).
 4. Every rendered answer/page shows its snapshot short-hash and `builtAt`; in the nominal state the hash equals the status hash (GLZ-7).
-5. Any store or unlisted listing names `fpf_reference`, links `https://fpf.sh/`, and ships only after explicit human approval (GLZ-6, GLZ-12).
+5. Any store or unlisted listing names `fpf_reference` and links `https://fpf.sh/`; Glaze Store publication additionally ships only after explicit human approval (GLZ-6, GLZ-12).
 
 ## Decision
 

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -24,29 +24,29 @@ Repo QA anchors reused: `B.5.1` (this doc is exploration/shaping, separated from
 
 The runtime snapshot used throughout this design: `sha256:f916341a8b3711b847c8a701f8b71e0ee155d9e5517be3ed36363fa6621ccf2b`, built `2026-07-03T21:18:14Z`, `fresh: true` — identical hash reported by `get_fpf_index_status` and echoed in every payload captured in the Evidence section.
 
-## Claim register
+## Claim Register
 
 | ID | Atomic claim | Owner layer |
 | --- | --- | --- |
 | GLZ-1 | The companion calls only tools from the contract's six-tool public roster (`browse_fpf_catalog`, `search_fpf`, `ask_fpf`, `query_fpf_spec`, `read_fpf_doc`, `get_fpf_index_status`) — and ships using five of them: `query_fpf_spec` is intentionally unused (agent-facing structured envelope; `ask_fpf` is its human-facing twin). | Interface contract (mcp.fpf.sh) |
-| GLZ-2 | Expert tools (`inspect_*`, `trace_fpf_path`, `refresh_fpf_index`) are never assumed on the hosted endpoint and never appear in the app. | Interface contract |
+| GLZ-2 | Expert tools (`inspect_*`, `trace_fpf_path`, `expand_fpf_citations`) and the admin tool `refresh_fpf_index` are never assumed on the hosted endpoint and never appear in the app. | Interface contract |
 | GLZ-3 | Reliance gate: before trust-sensitive display, `get_fpf_index_status` must show `snapshotExists: true`, `fresh: true`, and `currentSourceHash === sourceHash`; otherwise every surface renders a degraded state and answers are labeled unverified. | Interface contract |
 | GLZ-4 | Exact wording flows only through `read_fpf_doc`; `ask_fpf` output is presented as a grounded summary, never as canonical spec text. | Interface contract |
 | GLZ-5 | The companion is not agent memory, job state, a workflow engine, or a policy authority — the contract's non-admissible uses stay non-admissible in the client UI and copy. | Interface contract |
 | GLZ-6 | The app, its configuration, and any store listing use the canonical `fpf_reference` endpoint and name; the legacy `fpf_memory` name appears nowhere. | Repo policy (AGENTS.md) |
 | GLZ-7 | Every rendered answer or page footer carries `snapshot.sourceHash` (short form) and `builtAt` from that same response; a mismatch against the status hash renders a stale banner. | Client app |
-| GLZ-8 | Freshness is shown as internal consistency only; the app never claims upstream currentness (`upstreamCurrentness` is `unknown` by design on the public status). | Interface contract |
+| GLZ-8 | Freshness is shown as internal consistency only; the app never claims upstream currentness — `get_fpf_index_status` proves the deployed snapshot's internal consistency, and upstream currentness is by design unknowable from the endpoint alone. | Interface contract |
 | GLZ-9 | Client-side caching is keyed by `(tool, arguments, sourceHash)` — admissible because tool responses are deterministic per snapshot — and invalidated when the status hash changes. | Client app |
-| GLZ-10 | Input caps are mirrored client-side (question ≤ 2000 chars, search query ≤ 1000, selector ≤ 256; bounded reads via `maxChars`), so the app never emits schema-rejected input. | Client app (mirrors `src/mcp/tool-contracts.ts`) |
-| GLZ-11 | Requests stay bounded: search fires on submit (or ≥ 300 ms debounce), catalog pages via `nextOffset`, status is checked at launch and on manual refresh only — courtesy to the hosted spend guardrails. | Client app |
+| GLZ-10 | Input bounds are mirrored client-side (question ≤ 2000 chars and non-empty, search query ≤ 1000 and non-empty, selector ≤ 256 and non-empty, catalog filters ≤ 64; `maxChars` within [100, 200000]), so the app never emits schema-rejected input. | Client app (mirrors `src/mcp/tool-contracts.ts`) |
+| GLZ-11 | Requests stay bounded: search fires on submit (or ≥ 300 ms debounce), catalog pages via `nextOffset`, and status is checked only at launch, on manual refresh, after a `stale_snapshot_prevented` answer, or on network reconnect — never on a timer. Courtesy to the hosted spend guardrails. | Client app |
 | GLZ-12 | Publishing to the Glaze Store is external publication and requires explicit human approval; unlisted sharing is the default distribution. | Repo policy (AGENTS.md autonomy norms) |
 | GLZ-13 | Nothing in this repo's runtime, pipeline, CI, or published surfaces depends on the companion; removing it is a no-op for the project. | Repo policy |
 
 ## Design
 
-Working name: **FPF Companion**. One dependency: `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`. Shape: a menu-bar quick-search plus a main window with five surfaces.
+Working name: **FPF Companion**. One dependency: the hosted `fpf_reference` MCP endpoint (the dated value is quoted once, in the build prompt below, under its SSOT caveat). Shape: a menu-bar quick-search plus a main window with five surfaces.
 
-### Status (freshness spine)
+### Status (Freshness Spine)
 
 Maps `get_fpf_index_status` directly: a pill in the sidebar footer is green when the GLZ-3 gate passes, amber otherwise. The detail view lists `sourceHash`, `builtAt`, `compilerMode: local_vectorless`, and the artifact booleans. The pill's state gates the trust labeling on every other surface.
 
@@ -56,7 +56,7 @@ Maps `ask_fpf` — the human-facing twin of `query_fpf_spec`, whose structured e
 
 ### Search
 
-Maps `search_fpf`. Hit rows show `kind` badge (pattern / route / lexeme / preface), `title`, `id`, `part`, `status`, and the `snippet`; selecting a hit opens the Reader. Optional `kind` filter mirrors the schema enum.
+Maps `search_fpf`. Hit rows show `kind` badge (pattern / route / lexeme / preface), `title`, `id`, `part`, `status`, `score`, and the `snippet`; selecting a hit opens the Reader. Optional `kind` filter mirrors the schema enum.
 
 ### Catalog
 
@@ -66,11 +66,11 @@ Maps `browse_fpf_catalog` with `part` / `status` / `kind` filters, paged by `nex
 
 Maps `read_fpf_doc`. Hover cards use `mode: "preview"` (headings + snippet, no body). Full pages request `maxChars: 20000` first and offer "load full page" when `truncated: true` (`markdownChars` tells the user the full size). Header shows `title`, resolved `nodeId`, and an "open on fpf.sh" link derived from `docRef.staticPath`. Typing an ID (`A.1.1`) or route (`route:project-alignment`) anywhere jumps straight here via selector auto-resolution.
 
-### Offline behavior
+### Offline Behavior
 
 Local-first apps keep working offline: cached pages stay readable but are labeled with their snapshot short-hash plus "offline — freshness unverified", and the GLZ-3 gate re-runs on reconnect.
 
-## Glaze build prompt
+## Glaze Build Prompt
 
 The operational artifact — paste into Glaze as-is. One caveat first: the endpoint and server name below are quoted **as of the design date**; their SSOT is `src/core/public-copy.ts` (surfaced at mcp.fpf.sh and the Connect MCP page), and this dated exploration page sits outside the adoption-copy parity tests. Before pasting, confirm both values still match the SSOT — if they have moved, this prompt is stale, not authoritative.
 
@@ -99,9 +99,10 @@ Streamable HTTP transport, with the full lifecycle:
    response arrives as Content-Type application/json (parse directly) or
    text/event-stream (read the SSE stream until the JSON-RPC message whose
    id matches the request id; earlier events may be notifications or
-   server requests — answer a ping request with an empty result, skip
-   other messages the app does not handle) — support both, as the Accept
-   header promises;
+   server requests — answer a ping request with an empty result, answer
+   any other server request with JSON-RPC error -32601 (method not
+   found), and skip only notifications the app does not handle) —
+   support both, as the Accept header promises;
 6. handle failures without crashing: a JSON-RPC response may carry an
    "error" member instead of "result" — surface its message in the UI as
    a readable error state; an HTTP 404 received while sending
@@ -118,8 +119,9 @@ JSON-RPC envelope's result.structuredContent — NOT directly on result
 (result.content is only a human-readable text fallback); read all fields
 below from structuredContent. Do not depend on any Glaze MCP server
 connection existing at runtime — if the generated app cannot reach the
-endpoint with its own HTTP client, the build has failed acceptance
-check 1.
+endpoint with its own HTTP client, the build has failed its primary
+acceptance test: the app must function with this endpoint as its only
+network dependency.
 
 Call only these five tools through that client, nothing else:
 - get_fpf_index_status {} -> { sourcePath, sourceHash?, builtAt?,
@@ -158,7 +160,9 @@ search_fpf hits; Enter opens the reader; typing an exact ID like "A.1.1" or
 a sidebar: Ask, Search, Catalog, Reader, Status.
 
 Non-negotiable behaviors:
-1. On launch and on manual refresh call get_fpf_index_status. Trusted state
+1. Call get_fpf_index_status at launch, on manual refresh, after any
+   stale_snapshot_prevented answer, and on network reconnect — never on a
+   timer. Trusted state
    requires snapshotExists && fresh && currentSourceHash === sourceHash.
    Show a green "Fresh" pill when trusted, amber "Degraded" otherwise, and
    label all content "unverified" in degraded state.
@@ -171,21 +175,27 @@ Non-negotiable behaviors:
    (render candidateIds as suggestions); unsupported (explain);
    stale_snapshot_prevented (stale banner + status re-check).
 5. Reader fetches use maxChars 20000 first; when truncated is true show
-   "Load full page (N chars)". Preview/hover cards use mode "preview".
+   "Load full page (N chars)" and re-fetch with maxChars = min(N, 200000)
+   — maxChars must always stay within the schema bounds [100, 200000].
+   Preview/hover cards use mode "preview".
 6. Cache responses keyed by (tool, arguments, sourceHash); drop the cache
    when the status hash changes. Offline: cached pages stay readable,
    labeled "offline — freshness unverified" with their snapshot hash.
-7. Enforce input bounds client-side: question <= 2000 characters, search
-   query <= 1000 and never empty, selector <= 256, catalog part/status
-   filters <= 64; omit empty optional fields entirely instead of sending
-   empty strings. Debounce search; page the catalog with nextOffset;
-   never poll.
+7. Enforce input bounds client-side: question <= 2000 characters and never
+   empty, search query <= 1000 and never empty, selector <= 256 and never
+   empty, catalog part/status filters <= 64, maxChars within [100, 200000];
+   omit empty optional fields entirely instead of sending empty strings.
+   Debounce search by >= 300 ms (or fire on submit); page the catalog with
+   nextOffset, and when a browse response carries didYouMean.part, offer it
+   as a one-tap corrected filter; never poll.
 8. Freshness means internal consistency of the deployed snapshot only —
    never display any claim that upstream FPF is current.
 9. The service name is fpf_reference. Never reference "fpf_memory" anywhere:
    not in code, settings, copy, or the store listing.
 10. The app is read-only: no notes, no memory, no editing, no workflow
-    features. Link out to https://fpf.sh/ for the full site.
+    features. Link out to https://fpf.sh/ for the full site, and give
+    every Reader page an "open on fpf.sh" link built from its
+    docRef.staticPath.
 
 Visual design: default native macOS look — standard system appearance,
 system fonts, light and dark mode both supported. Do not invent a custom
@@ -201,12 +211,15 @@ brand palette. The only required visual elements are functional:
   tints.
 - Monospace for every FPF ID, snapshot hash, and payload value.
 - Components: search hits as rows (kind badge, title + monospace ID,
-  one-line snippet, score); FPF IDs rendered as chips that open the
-  Reader; every answer and page ends with a grounding footer
-  (confidence · status · snapshot short-hash).
+  part/status, one-line snippet, score); FPF IDs rendered as chips that
+  open the Reader; every answer and page ends with a grounding footer
+  (confidence · status · snapshot short-hash · builtAt), with the
+  answer's citations, constraints, and gaps listed beneath it; the
+  Status surface's detail view lists sourcePath, sourceHash, builtAt,
+  compilerMode, and the artifact booleans.
 ```
 
-## Evidence (design-time payloads, production endpoint, 2026-07-07)
+## Evidence (Design-Time Payloads, Production Endpoint, 2026-07-07)
 
 `get_fpf_index_status`:
 
@@ -216,25 +229,27 @@ brand palette. The only required visual elements are functional:
  "fresh":true,"compilerMode":"local_vectorless"}
 ```
 
+(Abbreviated: hashes shortened, and the full payload also carried `sourcePath` plus the eight artifact booleans, all `true` — the always-present fields the prompt's schema declares.)
+
 `search_fpf { query: "bounded context", limit: 3 }` → 1689 total; top hits `lex:bounded-context` (lexeme, score 160.8), `A.1.1` "U.BoundedContext Semantic Frame" (pattern, Stable), `A.2.5` (pattern, Stable) — same snapshot hash echoed.
 
 `browse_fpf_catalog { kind: "route", limit: 3 }` → 3 routes total: `route:boundary-unpacking`, `route:project-alignment`, `route:writing-or-reviewing-patterns`, each with a task-oriented `description`.
 
 `ask_fpf` (boundary question) → `route:boundary-unpacking`, IDs `A.6, A.6.B, A.6.C` (+ conditional `A.6.P, C.16.Q, A.6.A`), confidence 0.92, status `ok`.
 
-## Non-goals
+## Non-Goals
 
 - No Glaze anywhere in the build/publish/sync path; the README scope list (no vector DB, no remote indexing, no LLM step in the docs pipeline) stays authoritative and untouched.
 - No expert tools; no bundling of the local stdio runtime inside the app.
 - No cross-platform promise — the website remains the canonical human surface; the companion is macOS-only by Glaze's own constraint.
 - Not an FPF authoring or editing surface, and not a second source of adoption copy: endpoint/setup wording keeps its SSOT in `src/core/public-copy.ts`.
 
-## Acceptance checks (app-level, mirroring the contract's)
+## Acceptance Checks (App-Level, Mirroring the Contract's)
 
-1. With outbound network restricted to `mcp.fpf.sh`, all five surfaces function — proving the single-dependency boundary (GLZ-1, GLZ-13).
-2. Simulating `fresh: false` or a hash mismatch degrades every surface and labels all content unverified (GLZ-3, GLZ-7).
+1. With outbound network restricted to `mcp.fpf.sh`, all five surfaces function — proving the single-dependency boundary (GLZ-1, GLZ-2).
+2. Simulating `fresh: false` degrades every surface and labels all content unverified; simulating a response-vs-status hash mismatch renders the stale banner (GLZ-3, GLZ-7).
 3. A search of the generated app's source contains zero occurrences of `fpf_memory` (GLZ-6).
-4. Every rendered answer/page shows its snapshot short-hash; in the nominal state it equals the status hash (GLZ-7).
+4. Every rendered answer/page shows its snapshot short-hash and `builtAt`; in the nominal state the hash equals the status hash (GLZ-7).
 5. Any store or unlisted listing names `fpf_reference`, links `https://fpf.sh/`, and ships only after explicit human approval (GLZ-6, GLZ-12).
 
 ## Decision

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -81,7 +81,16 @@ service, the hosted MCP endpoint:
 
   https://mcp.fpf.sh/api/mcp/fpf_reference/mcp   (server name: fpf_reference)
 
-Use only these five MCP tools, nothing else:
+IMPORTANT — runtime transport: Glaze's own MCP integration is build-time
+only (it equips the build agent, not the shipped app). The app itself must
+implement a plain HTTP client for the endpoint above using the MCP
+Streamable HTTP transport: JSON-RPC 2.0 POSTs (one initialize handshake,
+then tools/call with the tool name and arguments), parsing each JSON
+result. Do not depend on any Glaze MCP server connection existing at
+runtime — if the generated app cannot reach the endpoint with its own
+HTTP client, the build has failed acceptance check 1.
+
+Call only these five tools through that client, nothing else:
 - get_fpf_index_status {} -> { sourcePath, sourceHash?, builtAt?,
   snapshotExists, currentSourceHash, fresh, compilerMode, artifacts }
   (sourceHash and builtAt are OMITTED when no snapshot could be loaded —

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -72,7 +72,7 @@ Local-first apps keep working offline: cached pages stay readable but are labele
 
 ## Glaze build prompt
 
-The operational artifact — paste into Glaze as-is:
+The operational artifact — paste into Glaze as-is. One caveat first: the endpoint and server name below are quoted **as of the design date**; their SSOT is `src/core/public-copy.ts` (surfaced at mcp.fpf.sh and the Connect MCP page), and this dated exploration page sits outside the adoption-copy parity tests. Before pasting, confirm both values still match the SSOT — if they have moved, this prompt is stale, not authoritative.
 
 ```text
 Build a macOS app called "FPF Companion": a read-only reader and lookup client

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -178,21 +178,19 @@ Non-negotiable behaviors:
 10. The app is read-only: no notes, no memory, no editing, no workflow
     features. Link out to https://fpf.sh/ for the full site.
 
-Visual design — reproduce this design system exactly (it is the approved
-mock's token set; follow native macOS conventions only where they conflict):
+Visual design: default native macOS look — standard system appearance,
+system fonts, light and dark mode both supported. Do not invent a custom
+brand palette. The only required visual elements are functional:
 - Layout: left sidebar (Ask, Search, Catalog, Reader, Status) + content
-  pane; freshness pill pinned at the sidebar bottom with the snapshot
-  short-hash beneath it; window footer bar with endpoint name, snapshot
+  pane; freshness pill at the sidebar bottom with the snapshot
+  short-hash beneath it; window footer with endpoint name, snapshot
   short-hash, and freshness state.
-- Color, light theme: background #F6F6F3, surface #FFFFFF, ink #1B1D20,
-  accent petrol #136A63, fresh green #1F7A46, warning amber #996A13.
-- Color, dark theme: background #141619, surface #1D2024, ink #E7E7E2,
-  accent #3FB8AC, fresh green #4CC38A, warning amber #D9A441.
-  Fresh/warning are semantic states, kept distinct from the accent.
-- Kind badges (uppercase micro-labels): pattern = petrol accent,
-  route = amber #8A5A0A, lexeme = plum #6E4A8E, preface = grey.
-- Type: system San Francisco for UI text; monospace (SF Mono) for every
-  FPF ID, snapshot hash, and payload value.
+- Semantic states: the freshness pill uses the platform's standard
+  positive color when trusted and warning color when degraded; the stale
+  banner uses the warning color. Kind badges (pattern / route / lexeme /
+  preface) are visually distinct from each other using system-appropriate
+  tints.
+- Monospace for every FPF ID, snapshot hash, and payload value.
 - Components: search hits as rows (kind badge, title + monospace ID,
   one-line snippet, score); FPF IDs rendered as chips that open the
   Reader; every answer and page ends with a grounding footer

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -84,9 +84,14 @@ service, the hosted MCP endpoint:
 IMPORTANT — runtime transport: Glaze's own MCP integration is build-time
 only (it equips the build agent, not the shipped app). The app itself must
 implement a plain HTTP client for the endpoint above using the MCP
-Streamable HTTP transport: JSON-RPC 2.0 POSTs (one initialize handshake,
-then tools/call with the tool name and arguments), parsing each JSON
-result. In every tools/call response, the tool payload lives in the
+Streamable HTTP transport, with the full lifecycle:
+1. every request sends header "Accept: application/json, text/event-stream";
+2. POST a JSON-RPC 2.0 initialize request, then POST the
+   notifications/initialized notification;
+3. if any response returns an Mcp-Session-Id header, echo it as a header
+   on every subsequent request;
+4. then POST tools/call requests with the tool name and arguments,
+   parsing each JSON result. In every tools/call response, the tool payload lives in the
 JSON-RPC envelope's result.structuredContent — NOT directly on result
 (result.content is only a human-readable text fallback); read all fields
 below from structuredContent. Do not depend on any Glaze MCP server

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -82,8 +82,11 @@ service, the hosted MCP endpoint:
   https://mcp.fpf.sh/api/mcp/fpf_reference/mcp   (server name: fpf_reference)
 
 Use only these five MCP tools, nothing else:
-- get_fpf_index_status {} -> { sourcePath, sourceHash, builtAt, snapshotExists,
-  currentSourceHash, fresh, compilerMode, artifacts }
+- get_fpf_index_status {} -> { sourcePath, sourceHash?, builtAt?,
+  snapshotExists, currentSourceHash, fresh, compilerMode, artifacts }
+  (sourceHash and builtAt are OMITTED when no snapshot could be loaded —
+  exactly the degraded case; parse them as optional or the degraded render
+  itself breaks)
 - search_fpf { query (<=1000 chars), kind?: pattern|route|lexeme|preface,
   limit?: 1..100 } -> { hits: [{ id, kind, title, status?, part?, score,
   snippet }], total, snapshot }
@@ -91,8 +94,10 @@ Use only these five MCP tools, nothing else:
   -> { entries: [{ id, kind, title, status?, part?, description }], total,
   nextOffset?, didYouMean?, snapshot }
 - ask_fpf { question (<=2000 chars), mode?: compact|verbose|proof }
-  -> { markdown, ids, citations, constraints, gaps, confidence, status,
-  snapshot }
+  -> { markdown, ids, citations, constraints, gaps, confidence (nullable),
+  candidateIds?, status, snapshot }
+  (candidateIds carries the structured suggestions rendered as chips when
+  status is "ambiguous" — never scrape them from the markdown)
 - read_fpf_doc { selector (<=256 chars), mode?: preview|full, maxChars? }
   -> { title?, nodeId?, markdown?, markdownChars?, truncated?, headings?,
   preview?, docRef?: { staticPath }, snapshot }

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -94,7 +94,13 @@ Streamable HTTP transport, with the full lifecycle:
 4. if any response returns an Mcp-Session-Id header, echo it as a header
    on every subsequent request;
 5. then POST tools/call requests with the tool name and arguments,
-   parsing each JSON result. In every tools/call response, the tool payload lives in the
+   parsing each JSON result;
+6. handle failures without crashing: a JSON-RPC response may carry an
+   "error" member instead of "result" — surface its message in the UI as
+   a readable error state; HTTP failures and timeouts (use a 15 s request
+   timeout and at most one retry, consistent with the bounded-request
+   rule) switch the app to the offline state of behavior 6, keeping
+   cached content readable and labeled. In every tools/call response, the tool payload lives in the
 JSON-RPC envelope's result.structuredContent — NOT directly on result
 (result.content is only a human-readable text fallback); read all fields
 below from structuredContent. Do not depend on any Glaze MCP server

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -28,7 +28,7 @@ The runtime snapshot used throughout this design: `sha256:f916341a8b3711b847c8a7
 
 | ID | Atomic claim | Owner layer |
 | --- | --- | --- |
-| GLZ-1 | The companion calls only the six public tools: `browse_fpf_catalog`, `search_fpf`, `ask_fpf`, `query_fpf_spec`, `read_fpf_doc`, `get_fpf_index_status`. | Interface contract (mcp.fpf.sh) |
+| GLZ-1 | The companion calls only tools from the contract's six-tool public roster (`browse_fpf_catalog`, `search_fpf`, `ask_fpf`, `query_fpf_spec`, `read_fpf_doc`, `get_fpf_index_status`) — and ships using five of them: `query_fpf_spec` is intentionally unused (agent-facing structured envelope; `ask_fpf` is its human-facing twin). | Interface contract (mcp.fpf.sh) |
 | GLZ-2 | Expert tools (`inspect_*`, `trace_fpf_path`, `refresh_fpf_index`) are never assumed on the hosted endpoint and never appear in the app. | Interface contract |
 | GLZ-3 | Reliance gate: before trust-sensitive display, `get_fpf_index_status` must show `snapshotExists: true`, `fresh: true`, and `currentSourceHash === sourceHash`; otherwise every surface renders a degraded state and answers are labeled unverified. | Interface contract |
 | GLZ-4 | Exact wording flows only through `read_fpf_doc`; `ask_fpf` output is presented as a grounded summary, never as canonical spec text. | Interface contract |
@@ -52,7 +52,7 @@ Maps `get_fpf_index_status` directly: a pill in the sidebar footer is green when
 
 ### Ask
 
-Maps `ask_fpf` (`mode: compact` default; `verbose`/`proof` toggle). Renders the `markdown` answer; `ids` as chips that open the Reader; `citations`, `constraints`, `gaps`, and `confidence` as a grounding footer. `status` enum handling: `ok` renders normally; `not_found` offers Search; `ambiguous` renders `candidateIds` as suggestion chips; `unsupported` explains the bound; `stale_snapshot_prevented` triggers the stale banner and a status re-check.
+Maps `ask_fpf` (`mode: compact` default; `verbose`/`proof` toggle) — the human-facing twin of `query_fpf_spec`, whose structured envelope stays deliberately unused in this app. Renders the `markdown` answer; `ids` as chips that open the Reader; `citations`, `constraints`, `gaps`, and `confidence` as a grounding footer. `status` enum handling: `ok` renders normally; `not_found` offers Search; `ambiguous` renders `candidateIds` as suggestion chips; `unsupported` explains the bound; `stale_snapshot_prevented` triggers the stale banner and a status re-check.
 
 ### Search
 
@@ -81,7 +81,7 @@ service, the hosted MCP endpoint:
 
   https://mcp.fpf.sh/api/mcp/fpf_reference/mcp   (server name: fpf_reference)
 
-Use only these six MCP tools, nothing else:
+Use only these five MCP tools, nothing else:
 - get_fpf_index_status {} -> { sourcePath, sourceHash, builtAt, snapshotExists,
   currentSourceHash, fresh, compilerMode, artifacts }
 - search_fpf { query (<=1000 chars), kind?: pattern|route|lexeme|preface,
@@ -93,10 +93,13 @@ Use only these six MCP tools, nothing else:
 - ask_fpf { question (<=2000 chars), mode?: compact|verbose|proof }
   -> { markdown, ids, citations, constraints, gaps, confidence, status,
   snapshot }
-- query_fpf_spec { question, mode? } -> structured envelope (same family)
 - read_fpf_doc { selector (<=256 chars), mode?: preview|full, maxChars? }
   -> { title?, nodeId?, markdown?, markdownChars?, truncated?, headings?,
   preview?, docRef?: { staticPath }, snapshot }
+
+(The endpoint also exposes a sixth public tool, query_fpf_spec; it returns an
+agent-facing structured envelope and is intentionally NOT used by this app —
+do not call it or generate code for it.)
 
 App shape: a menu-bar icon with a global-shortcut quick-search (top 5
 search_fpf hits; Enter opens the reader; typing an exact ID like "A.1.1" or

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -97,14 +97,19 @@ Streamable HTTP transport, with the full lifecycle:
    on every subsequent request;
 5. then POST tools/call requests with the tool name and arguments; each
    response arrives as Content-Type application/json (parse directly) or
-   text/event-stream (read the SSE stream and parse the JSON-RPC message
-   from its data: lines) — support both, as the Accept header promises;
+   text/event-stream (read the SSE stream until the JSON-RPC message whose
+   id matches the request id; earlier events may be notifications or
+   server requests — skip anything the app does not handle) — support
+   both, as the Accept header promises;
 6. handle failures without crashing: a JSON-RPC response may carry an
    "error" member instead of "result" — surface its message in the UI as
-   a readable error state; HTTP failures and timeouts (use a 15 s request
-   timeout and at most one retry, consistent with the bounded-request
-   rule) switch the app to the offline state of behavior 6, keeping
-   cached content readable and labeled.
+   a readable error state; an HTTP 404 received while sending
+   Mcp-Session-Id means the session expired — discard the session id and
+   re-run the initialize flow once before concluding anything is wrong;
+   other HTTP failures and timeouts (use a 15 s request timeout and at
+   most one retry, consistent with the bounded-request rule) switch the
+   app to the offline state of behavior 6, keeping cached content
+   readable and labeled.
 Where this recipe is silent, follow the official MCP Streamable HTTP
 transport and lifecycle spec (modelcontextprotocol.io, revision
 2025-06-18) — it wins over any shortcut a code generator might prefer. In every tools/call response, the tool payload lives in the

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -88,9 +88,12 @@ Streamable HTTP transport, with the full lifecycle:
 1. every request sends header "Accept: application/json, text/event-stream";
 2. POST a JSON-RPC 2.0 initialize request, then POST the
    notifications/initialized notification;
-3. if any response returns an Mcp-Session-Id header, echo it as a header
+3. after initialize, send header "MCP-Protocol-Version: <the version
+   returned in the initialize result>" (currently 2025-06-18) on every
+   subsequent request;
+4. if any response returns an Mcp-Session-Id header, echo it as a header
    on every subsequent request;
-4. then POST tools/call requests with the tool name and arguments,
+5. then POST tools/call requests with the tool name and arguments,
    parsing each JSON result. In every tools/call response, the tool payload lives in the
 JSON-RPC envelope's result.structuredContent — NOT directly on result
 (result.content is only a human-readable text fallback); read all fields
@@ -120,8 +123,11 @@ Call only these five tools through that client, nothing else:
   server-side default is deployment-configured and is verbose in
   production, so omitting mode gives slow verbose answers)
 - read_fpf_doc { selector (<=256 chars), mode?: preview|full, maxChars? }
-  -> { title?, nodeId?, markdown?, markdownChars?, truncated?, headings?,
+  -> { status: ok|not_found, resolvedAs: id|route|lexeme|not_found,
+  title?, nodeId?, markdown?, markdownChars?, truncated?, headings?,
   preview?, docRef?: { staticPath }, snapshot }
+  (on status "not_found" the content fields are absent — render the
+  Reader's not-found recovery state offering Search, never an empty page)
 
 (The endpoint also exposes a sixth public tool, query_fpf_spec; it returns an
 agent-facing structured envelope and is intentionally NOT used by this app —

--- a/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
+++ b/docs/superpowers/specs/2026-07-07-glaze-companion-design.md
@@ -133,8 +133,25 @@ Non-negotiable behaviors:
 10. The app is read-only: no notes, no memory, no editing, no workflow
     features. Link out to https://fpf.sh/ for the full site.
 
-Visual: native macOS feel, quiet reference-tool aesthetic, monospace for
-IDs and hashes, kind badges for pattern/route/lexeme/preface.
+Visual design — reproduce this design system exactly (it is the approved
+mock's token set; follow native macOS conventions only where they conflict):
+- Layout: left sidebar (Ask, Search, Catalog, Reader, Status) + content
+  pane; freshness pill pinned at the sidebar bottom with the snapshot
+  short-hash beneath it; window footer bar with endpoint name, snapshot
+  short-hash, and freshness state.
+- Color, light theme: background #F6F6F3, surface #FFFFFF, ink #1B1D20,
+  accent petrol #136A63, fresh green #1F7A46, warning amber #996A13.
+- Color, dark theme: background #141619, surface #1D2024, ink #E7E7E2,
+  accent #3FB8AC, fresh green #4CC38A, warning amber #D9A441.
+  Fresh/warning are semantic states, kept distinct from the accent.
+- Kind badges (uppercase micro-labels): pattern = petrol accent,
+  route = amber #8A5A0A, lexeme = plum #6E4A8E, preface = grey.
+- Type: system San Francisco for UI text; monospace (SF Mono) for every
+  FPF ID, snapshot hash, and payload value.
+- Components: search hits as rows (kind badge, title + monospace ID,
+  one-line snippet, score); FPF IDs rendered as chips that open the
+  Reader; every answer and page ends with a grounding footer
+  (confidence · status · snapshot short-hash).
 ```
 
 ## Evidence (design-time payloads, production endpoint, 2026-07-07)


### PR DESCRIPTION
## What

Adds `docs/superpowers/specs/2026-07-07-glaze-companion-design.md`: a design exploration answering "can this project benefit from Glaze (glaze.app)?" and bounding the one admissible integration — an optional, read-only native macOS companion client over the hosted public `fpf_reference` MCP surface.

## Why

Glaze (Raycast's AI desktop-app builder) can consume MCP/APIs, and this repo publishes a hosted MCP endpoint — so a native companion client is plausible, but only if it cannot blur the interface contract. `ask_fpf` on the production runtime routed the decision to `route:boundary-unpacking` (entry `A.6 → A.6.B → A.6.C`, confidence 0.92), whose acceptance check requires atomic claims with stable IDs in a claim register, each routed to one owner layer. This spec implements exactly that.

## Type

- `docs` — documentation only

## Changes

- New spec with: verdict (client-only, core out of bounds), a 13-claim boundary register (GLZ-1…GLZ-13) with owner layers, per-surface tool mappings derived from `src/mcp/tool-contracts.ts`, a complete copy-paste Glaze build prompt, design-time production payload evidence (snapshot `sha256:f916341a8b37…`, built 2026-07-03T21:18:14Z), app-level acceptance checks mirroring the contract's, and non-goals.
- No runtime, contract, pipeline, CI, or published-surface changes.

## Validation

- Verification profile: P2
- Profile reason: one hand-authored markdown page added under the Rspress content root (`docs/superpowers/specs/`); no public promises, routes, schemas, deploy, monitors, or generated artifacts altered.
- Focused local command or static inspection: `bun run docs:build`
- Broader checks skipped, if any: `bun run test` skipped — no code touched; confirmed `tests/public-copy-parity.test.ts` scans only top-level `docs/*.md`, so this nested page is outside its scope and adoption-copy SSOT (`src/core/public-copy.ts`) is unaffected.
- `bun run lint` — N/A (no TypeScript touched; P2 reason above)
- `bun run check` — N/A (no TypeScript touched)
- `bun run test` — N/A (no code touched; parity-test scope confirmed as above)
- No new warnings introduced
- `bun run build` — N/A (no runtime/server code touched)
- `bun run docs:build` succeeds — page renders at `doc_build/superpowers/specs/2026-07-07-glaze-companion-design.html`
- Relevant docs updated: this PR is the doc
- End-to-end verification command + output excerpt: `bun run docs:build` → completed with full route listing; new page present in `doc_build/superpowers/specs/`. Additionally `bun run cli -- evaluate-work --target current-pr --base origin/main` → overall `usable_with_followups`, 0 blocker/high findings; the single medium finding (F.17 term-sheet navigation) pre-exists on `main` and is untouched by this one-file branch.
- Caveats or blocker: the page becomes a public route under `/superpowers/specs/` on the next routine website deploy, same as the existing 2026-06-10 verification-profiles spec.

## Production evidence packet

Not applicable in full: no production-facing behavior, deployment, automation, monitoring, MCP route, or published artifact changes. For the record: design-time payloads in the spec were captured from the production endpoint on 2026-07-07 against source hash `sha256:f916341a8b3711b847c8a701f8b71e0ee155d9e5517be3ed36363fa6621ccf2b` (matches committed `published/current/**`); rollback target is reverting this single docs commit.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts` — untouched; the spec mirrors them read-only

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Claude Code (remote session) |
| Task source | Interactive session request: evaluate glaze.app fit, propose for feedback |
| Privacy check | No raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers included. |

---

Feedback wanted on three decisions in particular:
1. Is the client-only verdict right, or is there a core-adjacent use I dismissed too fast?
2. Claim register (GLZ-1…13): any missing claim, wrong owner layer, or claim that should be tightened?
3. Should the Glaze build prompt live in the spec (current choice) or move nearer the adoption surface if this ever ships?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXdSiCc7JfEfRzPH2Xt11x

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXdSiCc7JfEfRzPH2Xt11x)_