### PR TITLE
feat(plugin): add fpf-reference Claude Code plugin + marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "name": "fpf",
+  "owner": {
+    "name": "venikman",
+    "url": "https://github.com/venikman/fpf-memory"
+  },
+  "metadata": {
+    "description": "FPF Reference agent resources: the setup plugin for the FPF Reference MCP server (fpf_reference).",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "fpf-reference",
+      "source": "./plugins/fpf-reference",
+      "description": "Install, connect, validate, or self-host the FPF Reference MCP server (fpf_reference). Bundles the setup skill, the hosted MCP registration, and a validation command.",
+      "version": "0.1.0",
+      "author": {
+        "name": "venikman",
+        "url": "https://github.com/venikman"
+      },
+      "homepage": "https://mcp.fpf.sh/",
+      "license": "ISC",
+      "keywords": ["fpf", "fpf-reference", "mcp", "first-principles-framework", "spec-lookup"]
+    }
+  ]
+}

--- a/plugins/fpf-reference/.claude-plugin/plugin.json
+++ b/plugins/fpf-reference/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "fpf-reference",
+  "version": "0.1.0",
+  "description": "Install, connect, validate, or self-host the FPF Reference MCP server (fpf_reference). Bundles the setup skill, the hosted MCP registration, and a validation command.",
+  "author": {
+    "name": "venikman",
+    "url": "https://github.com/venikman"
+  },
+  "homepage": "https://mcp.fpf.sh/",
+  "repository": "https://github.com/venikman/fpf-memory",
+  "license": "ISC",
+  "keywords": ["fpf", "fpf-reference", "mcp", "first-principles-framework", "spec-lookup"]
+}

--- a/plugins/fpf-reference/.mcp.json
+++ b/plugins/fpf-reference/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "fpf_reference": {
+      "type": "http",
+      "url": "https://mcp.fpf.sh/api/mcp/fpf_reference/mcp"
+    }
+  }
+}

--- a/plugins/fpf-reference/README.md
+++ b/plugins/fpf-reference/README.md
@@ -1,0 +1,44 @@
+# fpf-reference plugin
+
+A Claude Code plugin that gives AI coding tools a one-command path to add,
+connect, validate, or self-host the **FPF Reference MCP** server (`fpf_reference`).
+
+It bundles:
+
+| Component | What it provides |
+| --- | --- |
+| **Skill** `fpf-reference-mcp` | Setup guidance for all three paths (hosted remote, local full runtime, stdio bridge) plus the validation contract and guardrails. |
+| **MCP registration** (`.mcp.json`) | Registers the hosted `fpf_reference` Streamable HTTP endpoint (`https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`). |
+| **Command** `/fpf-reference:validate` | Runs the first-call validation contract and reports layered evidence. |
+
+## Install
+
+This repository (`venikman/fpf-memory`) is a plugin marketplace. From Claude Code:
+
+```text
+/plugin marketplace add venikman/fpf-memory
+/plugin install fpf-reference@fpf
+```
+
+Once installed, the hosted `fpf_reference` server is registered automatically.
+Run `/fpf-reference:validate` to confirm the connection with a real first call.
+
+## What you get
+
+- **Hosted by default** — the public `fpf_reference` endpoint is unauthenticated,
+  read-only FPF lookup. You do not install FPF itself.
+- **Self-host option** — the `fpf-reference-mcp` skill documents running the local
+  full-surface stdio runtime (`FPF_MCP_SURFACE=full`) for the expert tools
+  (`inspect_*`, `trace_fpf_path`, `refresh_fpf_index`).
+- **Bridge option** — for stdio-only clients, the skill documents an `mcp-remote`
+  bridge to the hosted endpoint.
+
+## Related
+
+- MCP setup origin: <https://mcp.fpf.sh/>
+- Health endpoint: <https://mcp.fpf.sh/api/fpf/status>
+- Repo usage notes: [`AGENTS.md`](../../AGENTS.md)
+
+> **FPF** is the upstream specification. **FPF Reference** is the product/surface.
+> `fpf_reference` is the MCP server name. `fpf-memory` is the repo/package literal.
+> Legacy `fpf_memory` is compatibility-only.

--- a/plugins/fpf-reference/commands/validate.md
+++ b/plugins/fpf-reference/commands/validate.md
@@ -1,0 +1,31 @@
+---
+description: Run the FPF Reference MCP validation contract (index status + tool list + compact route query) and report layered evidence.
+---
+
+Run the FPF Reference MCP **validation contract** against the hosted `fpf_reference`
+server and report the result as separated evidence layers. Use only the
+`fpf_reference` server. Do not paste the whole FPF spec.
+
+1. **Connection** — call `get_fpf_index_status`. Confirm `fresh: true` and that the
+   snapshot artifacts are present. Confirm the client lists the six public tools:
+   `browse_fpf_catalog`, `search_fpf`, `ask_fpf`, `query_fpf_spec`, `read_fpf_doc`,
+   `get_fpf_index_status`. (If `inspect_*` / `trace_fpf_path` appear, you are on a
+   local full-surface runtime, not the hosted endpoint — note that.)
+
+2. **Runtime** — call `query_fpf_spec` with:
+   - question: `Project kickoff: align a project information system with roles and adoption next steps`
+   - mode: `compact`
+
+   Report the route ID, ordered IDs, acceptance check, and next move.
+
+3. **Verdict** — a good first answer includes `route:project-alignment`. If it does
+   not, explain why the current published index cannot return that route.
+
+Report four separate evidence layers:
+
+- **Configuration** — the client setting used to reach the server.
+- **Connection** — the tool list and `get_fpf_index_status` output.
+- **Runtime** — the compact `query_fpf_spec` result.
+- **Freshness** — source hash / `builtAt` versus the published surface (or the
+  `https://mcp.fpf.sh/api/fpf/status` health endpoint), not just that a call
+  succeeded.

--- a/plugins/fpf-reference/skills/fpf-reference-mcp/SKILL.md
+++ b/plugins/fpf-reference/skills/fpf-reference-mcp/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: fpf-reference-mcp
+description: Install, connect, validate, or self-host the FPF Reference MCP server. Use for hosted remote setup, local stdio or HTTP runtime setup, and local bridge/proxy setup for clients that need a localhost MCP URL while using the hosted remote endpoint.
+---
+
+# FPF Reference MCP
+
+Use this skill when a user wants to add, verify, troubleshoot, self-host, or locally bridge FPF Reference MCP.
+
+## Core facts
+
+- Public MCP server name: `fpf_reference`.
+- Hosted endpoint: `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`.
+- Browser-readable health endpoint: `https://mcp.fpf.sh/api/fpf/status`.
+- Public source repo: `https://github.com/venikman/fpf-memory`.
+- Upstream FPF spec repo: `https://github.com/ailev/FPF`.
+- A browser `GET` to the MCP endpoint returning `405 Method Not Allowed` is expected; it is a JSON-RPC Streamable HTTP endpoint, not a web page.
+- Legacy `fpf_memory` is compatibility-only. Do not use it in new snippets unless the task is explicitly migration from the legacy name.
+
+Public tools normally exposed:
+
+- `browse_fpf_catalog`
+- `search_fpf`
+- `ask_fpf`
+- `query_fpf_spec`
+- `read_fpf_doc`
+- `get_fpf_index_status`
+
+## Pick the setup path
+
+- **Hosted remote, no local server** — use when the client supports HTTP or Streamable HTTP MCP servers. Read `references/connect.md`.
+- **Local FPF runtime** — use when the user wants local artifacts, self-hosting, or the full expert tool surface. Read `references/install.md`.
+- **Local server that connects to remote** — use when the user needs a localhost URL but wants the hosted endpoint as source of truth. Read `references/local-remote-server.md`.
+
+If the client only supports a local stdio command and cannot register HTTP MCP URLs, do not claim the remote proxy solves that. Use the local stdio runtime, or verify a separate stdio-to-HTTP adapter against current upstream docs before giving exact install commands.
+
+## Validation contract
+
+After any setup, require a real first-call check:
+
+1. Call `get_fpf_index_status`.
+2. Confirm the client sees the public tools listed above.
+3. Run one compact query:
+
+   > Use only `fpf_reference`. Call `query_fpf_spec` with question: "Project kickoff: align a project information system with roles and adoption next steps" and mode "compact". Return the route ID, ordered IDs, acceptance check, and next move.
+
+A good first answer should include `route:project-alignment` or explain why the current published index cannot return that route.
+
+Keep evidence layers separate:
+
+- **Configuration evidence**: the snippet or client setting that was added.
+- **Connection evidence**: tool list or `get_fpf_index_status`.
+- **Runtime evidence**: compact query result.
+- **Freshness evidence**: production/currentness monitor or repo deployment check, not just the status endpoint.
+
+The `/fpf-reference:validate` command runs this contract end to end.
+
+## Guardrails
+
+- Default users to the hosted endpoint. They do not install FPF itself.
+- Use **FPF Reference** for the product/surface and `fpf_reference` for the MCP server.
+- Treat `fpf-memory` as the repo/package literal only.
+- Do not paste the whole FPF spec into a chat; ask for compact answers and read exact docs only when wording matters.
+- Before changing or publishing the source repo, read its current `AGENTS.md` and use current repo checks as authority.

--- a/plugins/fpf-reference/skills/fpf-reference-mcp/references/connect.md
+++ b/plugins/fpf-reference/skills/fpf-reference-mcp/references/connect.md
@@ -1,0 +1,62 @@
+# Connect: hosted remote (no local server)
+
+Default path for most adopters. The hosted `fpf_reference` server is a public,
+read-only, JSON-RPC **Streamable HTTP** endpoint — no authentication, no local
+install of FPF itself.
+
+- Endpoint: `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`
+- Health (browser-readable): `https://mcp.fpf.sh/api/fpf/status`
+- A browser `GET` to the MCP endpoint returns `405 Method Not Allowed`. That is expected — it is a JSON-RPC transport, not a web page.
+
+## Per-client setup
+
+### Claude Code
+
+```bash
+claude mcp add --transport http fpf_reference https://mcp.fpf.sh/api/mcp/fpf_reference/mcp
+```
+
+Or add a project-scoped `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "fpf_reference": {
+      "type": "http",
+      "url": "https://mcp.fpf.sh/api/mcp/fpf_reference/mcp"
+    }
+  }
+}
+```
+
+### Claude.ai and Claude Desktop
+
+Add a custom connector (Settings → Connectors → Add custom connector):
+
+- Name: `FPF Reference`
+- URL: `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`
+
+### Cursor / Windsurf
+
+```json
+{
+  "mcpServers": {
+    "fpf_reference": {
+      "url": "https://mcp.fpf.sh/api/mcp/fpf_reference/mcp"
+    }
+  }
+}
+```
+
+(Windsurf uses `"serverUrl"` instead of `"url"`.)
+
+### VS Code (MCP: Add Server → HTTP)
+
+- URL: `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`
+- Name: `fpf_reference`
+
+## Validate
+
+Run the validation contract from `SKILL.md` (or the `/fpf-reference:validate`
+command): call `get_fpf_index_status`, confirm the six public tools, then run the
+compact `query_fpf_spec` kickoff query and check for `route:project-alignment`.

--- a/plugins/fpf-reference/skills/fpf-reference-mcp/references/connect.md
+++ b/plugins/fpf-reference/skills/fpf-reference-mcp/references/connect.md
@@ -36,7 +36,7 @@ Add a custom connector (Settings → Connectors → Add custom connector):
 - Name: `FPF Reference`
 - URL: `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp`
 
-### Cursor / Windsurf
+### Cursor
 
 ```json
 {
@@ -48,7 +48,19 @@ Add a custom connector (Settings → Connectors → Add custom connector):
 }
 ```
 
-(Windsurf uses `"serverUrl"` instead of `"url"`.)
+### Windsurf
+
+Windsurf uses `"serverUrl"` instead of `"url"`:
+
+```json
+{
+  "mcpServers": {
+    "fpf_reference": {
+      "serverUrl": "https://mcp.fpf.sh/api/mcp/fpf_reference/mcp"
+    }
+  }
+}
+```
 
 ### VS Code (MCP: Add Server → HTTP)
 

--- a/plugins/fpf-reference/skills/fpf-reference-mcp/references/install.md
+++ b/plugins/fpf-reference/skills/fpf-reference-mcp/references/install.md
@@ -1,0 +1,70 @@
+# Install: local FPF runtime (self-host / full expert surface)
+
+Use when the user wants local artifacts, self-hosting, or the **full** expert
+tool surface (`inspect_*`, `trace_fpf_path`, `refresh_fpf_index`) that the hosted
+endpoint does not expose. This runs the same runtime that backs `mcp.fpf.sh`,
+as a local stdio MCP server.
+
+## Prerequisites
+
+- [Bun](https://bun.sh) (`bun@1.3.5` per the repo `packageManager`), Node.js >= 22.13.
+- A local clone of `https://github.com/venikman/fpf-memory`.
+
+## Steps
+
+```bash
+git clone https://github.com/venikman/fpf-memory
+cd fpf-memory
+bun install --frozen-lockfile
+
+# The committed spec surface under published/current/** is the default source.
+# To refresh from upstream ailev/FPF first:
+#   bun run spec:download && bun run publish:current
+
+# Run the local full-surface stdio MCP server:
+FPF_MCP_SURFACE=full bun run mcp
+```
+
+## Register in a client
+
+Register as `fpf_reference_local` so it does not collide with the hosted
+`fpf_reference` key (see the collision rule below). Example `.mcp.json` entry:
+
+```json
+{
+  "mcpServers": {
+    "fpf_reference_local": {
+      "command": "bun",
+      "args": ["src/entrypoints/mcp-stdio.ts"],
+      "env": {
+        "FPF_SPEC_SOURCE_PATH": "published/current/FPF-Spec.md",
+        "FPF_RUNTIME_ARTIFACT_DIR": ".runtime/fpf-index",
+        "FPF_MCP_SURFACE": "full"
+      }
+    }
+  }
+}
+```
+
+`server.json` in the repo carries the same stdio definition (`FPF_MCP_SURFACE=full`).
+The protocol `serverInfo.name` remains `fpf_reference`; the client key is what you
+name it (`fpf_reference_local`).
+
+## Tool surfaces
+
+- **Public** (also on hosted): `browse_fpf_catalog`, `search_fpf`, `ask_fpf`, `query_fpf_spec`, `read_fpf_doc`, `get_fpf_index_status`.
+- **Expert** (local full only): `inspect_fpf_node`, `inspect_fpf_anchor`, `expand_fpf_citations`, `trace_fpf_path`.
+- **Admin** (local): `refresh_fpf_index`.
+
+Never assume expert tools exist on the hosted endpoint.
+
+## Collision rule
+
+Do not register the hosted HTTP server and the local stdio server under the same
+client key in one session. Prefer one active server per session, or use distinct
+keys: `fpf_reference` (hosted) vs. `fpf_reference_local` (local full).
+
+## Validate
+
+Run `get_fpf_index_status` against the runtime you are about to rely on, then the
+compact `query_fpf_spec` kickoff query. See `SKILL.md` for the validation contract.

--- a/plugins/fpf-reference/skills/fpf-reference-mcp/references/install.md
+++ b/plugins/fpf-reference/skills/fpf-reference-mcp/references/install.md
@@ -28,7 +28,11 @@ FPF_MCP_SURFACE=full bun run mcp
 ## Register in a client
 
 Register as `fpf_reference_local` so it does not collide with the hosted
-`fpf_reference` key (see the collision rule below). Example `.mcp.json` entry:
+`fpf_reference` key (see the collision rule below). Set `cwd` to your local clone
+path: the `args` and `env` paths are relative, so the client resolves them against
+its own working directory (usually the user's active project) unless `cwd` pins
+them to the `fpf-memory` checkout — otherwise the server fails to start. Example
+`.mcp.json` entry:
 
 ```json
 {
@@ -36,6 +40,7 @@ Register as `fpf_reference_local` so it does not collide with the hosted
     "fpf_reference_local": {
       "command": "bun",
       "args": ["src/entrypoints/mcp-stdio.ts"],
+      "cwd": "/path/to/fpf-memory",
       "env": {
         "FPF_SPEC_SOURCE_PATH": "published/current/FPF-Spec.md",
         "FPF_RUNTIME_ARTIFACT_DIR": ".runtime/fpf-index",
@@ -46,7 +51,8 @@ Register as `fpf_reference_local` so it does not collide with the hosted
 }
 ```
 
-`server.json` in the repo carries the same stdio definition (`FPF_MCP_SURFACE=full`).
+`server.json` in the repo carries the same stdio definition (`FPF_MCP_SURFACE=full`,
+with `cwd` set to `.` because it is loaded from within the repo).
 The protocol `serverInfo.name` remains `fpf_reference`; the client key is what you
 name it (`fpf_reference_local`).
 

--- a/plugins/fpf-reference/skills/fpf-reference-mcp/references/local-remote-server.md
+++ b/plugins/fpf-reference/skills/fpf-reference-mcp/references/local-remote-server.md
@@ -1,0 +1,42 @@
+# Local server that connects to remote (stdio bridge)
+
+Use when a client can only register a **local stdio command** and cannot register
+an HTTP / Streamable HTTP MCP URL, but you still want the **hosted** endpoint as
+the source of truth (no local FPF runtime, no self-hosting).
+
+This bridges a local stdio process to the hosted `fpf_reference` endpoint. It does
+**not** run FPF locally — it proxies to `mcp.fpf.sh`.
+
+## Bridge with `mcp-remote`
+
+```json
+{
+  "mcpServers": {
+    "fpf_reference": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.fpf.sh/api/mcp/fpf_reference/mcp"]
+    }
+  }
+}
+```
+
+The client launches `npx mcp-remote <url>` as a stdio server; `mcp-remote`
+forwards JSON-RPC to the hosted Streamable HTTP endpoint and streams responses
+back over stdio.
+
+## Before giving exact commands
+
+- `mcp-remote` is a third-party adapter, not part of this repo. Verify its current
+  package name, flags, and transport behavior against its upstream docs before
+  handing a user exact install commands — do not assume this snippet is current.
+- If the client *does* support HTTP MCP URLs, skip the bridge entirely and use the
+  direct hosted setup in `references/connect.md`. The bridge only exists for
+  stdio-only clients.
+- The hosted endpoint is unauthenticated and read-only, so no token or OAuth flow
+  is involved in the bridge.
+
+## Validate
+
+Same validation contract as every path: `get_fpf_index_status`, confirm the six
+public tools, then the compact `query_fpf_spec` kickoff query expecting
+`route:project-alignment`. See `SKILL.md`.


### PR DESCRIPTION
## What

Package the FPF Reference MCP setup surface as an installable Claude Code plugin, and make this repo a plugin marketplace. Adopters get a one-command install path that registers the hosted `fpf_reference` server and bundles the setup skill + a validation command.

```text
/plugin marketplace add venikman/fpf-memory
/plugin install fpf-reference@fpf
```

## Why

The repo already ships the hosted `fpf_reference` MCP server and its Vercel deploy tooling, but there was **no one-command install path** for the setup skill — the only "prong" missing from the two-pronged agent-resources model (remote MCP **+** installable plugin). This adds the plugin prong without touching the live server, routes, or deploy.

## Type

`feat` — new capability (additive; no existing code changed)

## Changes

- `.claude-plugin/marketplace.json` — designates this repo as a plugin marketplace (`fpf`).
- `plugins/fpf-reference/.claude-plugin/plugin.json` — plugin manifest (v0.1.0, ISC).
- `plugins/fpf-reference/.mcp.json` — registers the hosted `fpf_reference` Streamable HTTP endpoint.
- `plugins/fpf-reference/skills/fpf-reference-mcp/` — the setup skill (`SKILL.md`) with the three setup paths as references (`connect.md` hosted remote, `install.md` local full runtime, `local-remote-server.md` stdio bridge), the validation contract, and guardrails.
- `plugins/fpf-reference/commands/validate.md` — `/fpf-reference:validate` runs the first-call validation contract and reports layered evidence.
- `plugins/fpf-reference/README.md` — human-facing overview.

## Validation

- **Verification profile:** P2
- **Profile reason:** Additive setup/adoption tooling (config + docs). No runtime, MCP route/tool-contract, transport, deploy, monitor, or `published/current/**` change. The plugin only *documents and registers* the already-live, already-validated hosted surface; nothing is deployed by this PR.
- **Focused local command / static inspection:**
  - `claude plugin validate ./plugins/fpf-reference` → `√ Validation passed`
  - JSON parse + cross-field consistency (marketplace↔manifest name/version/source, canonical MCP URL, `type: http`, skill frontmatter `name`/`description`, all references + command present) → all passed
  - Repo work evaluator `bun run evaluate:work` → `usable_with_followups`, **0 blocker/high**
- **Broader checks skipped, if any:** lint / check / test / build / docs:build — the plugin lives under `plugins/`, outside those scopes (`src`, `tests`, `scripts`, `*.config.ts`, docs generator). No TS/runtime/docs-site code touched.
- `bun run lint` — N/A with profile reason (no lint-scoped files touched)
- `bun run check` — N/A with profile reason (no TypeScript added)
- `bun run test` — N/A with profile reason (no test-scoped files touched)
- No new warnings introduced
- `bun run build` — N/A (no runtime/server code touched)
- `bun run docs:build` — N/A (no docs-site content touched)
- Relevant docs updated: plugin `README.md` added. Hosted adoption copy parity (`src/core/public-copy.ts`) intentionally deferred to a follow-up (see below).
- **End-to-end verification:** earlier in the authoring session the live hosted endpoint passed the same validation contract the plugin ships — `get_fpf_index_status` returned `fresh: true`, and `query_fpf_spec` (compact) returned `route:project-alignment`. The plugin's `.mcp.json` registers that same endpoint.
- **Caveats or blocker:** none.

## Production evidence packet

Not required for this PR: it changes no production-facing behavior, deployment, automation, monitoring, hosted docs, MCP routes, or published artifacts. The supporting live check below is from validating the existing surface the plugin points at, not a change introduced here.

### Promise checked

Hosted `fpf_reference` answers the canned kickoff validation query with route `route:project-alignment` (the contract shipped in the plugin).

### URLs checked

- `https://mcp.fpf.sh/api/mcp/fpf_reference/mcp` (live, exercised during authoring)
- `https://mcp.fpf.sh/api/fpf/status` (documented browser-readable health endpoint)

### Commands run

`get_fpf_index_status`; `query_fpf_spec` (mode `compact`)

### Expected semantic invariants

- HTTP availability: endpoint reachable; browser `GET` → `405` (expected for JSON-RPC Streamable HTTP)
- semantic correctness: compact query returns `route:project-alignment` with ordered IDs `A.1.1 → A.15 → B.5.1`
- freshness/currentness: `fresh: true`
- route naming: `route:project-alignment`
- live behavior: index status reports all snapshot artifacts present
- cost/risk guardrails: read-only, unauthenticated lookup; no writes

### Actual output excerpt

`get_fpf_index_status` → `fresh: true`, `builtAt: 2026-07-03T21:18:14Z`, all artifacts present. `query_fpf_spec` (compact) → `route:project-alignment`, `status: ok`, `confidence: 0.92`.

### Upstream ref / source hash

`sha256:f916341a8b3711b847c8a701f8b71e0ee155d9e5517be3ed36363fa6621ccf2b` (matches the committed `published/current` surface; repo sync commit `3c63176`).

### Deployment URL / alias checked

N/A — nothing deployed in this PR.

### Rollback target

Revert this PR (additive files only; no deployed state to roll back).

### Known caveats

`mcp-remote` in the stdio-bridge reference is a third-party adapter; the doc tells users to verify its current package/flags against upstream before use.

### What would falsify this success claim?

The published index no longer returning `route:project-alignment` for the kickoff query, or `claude plugin validate` failing on the manifest.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added ✓ (unchanged)
- No vector database or remote indexing introduced ✓
- No Python code added ✓
- MCP tool contracts are in `src/mcp/tool-contracts.ts` ✓ (unchanged; the plugin only registers the existing hosted server)

## Follow-ups (out of scope for this PR)

The work evaluator flagged three pre-existing, repo-wide gaps (not introduced by this change):

- **E.14 working-model** — surface published channel / source hash / upstream ref / validation stance in README/wiki
- **F.17 term-sheet** — expose glossary + change-log routes alongside patterns/routes
- **G.5 selected-publication** — keep landing/staging as selected projections over the committed publication surface

A natural next PR is **connect-docs parity**: mirror the plugin's per-client setup + `mcp-remote` bridge in the `src/core/public-copy.ts` SSOT, which also nibbles at E.14/F.17.

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Claude Code |
| Task source | Maintainer request in a Claude Code session |
| Privacy check | No raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers included. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F4jeNwrnokCiik1nXgqAU

---
_Generated by [Claude Code](https://claude.ai/code/session_016F4jeNwrnokCiik1nXgqAU)_