### PR TITLE
ci: fix sync auto-merge livelock (rollup never sees dispatched CI checks)

### DIFF
--- a/.github/workflows/sync-fpf.yml
+++ b/.github/workflows/sync-fpf.yml
@@ -320,7 +320,36 @@ jobs:
             exit 0
           fi
 
-          CHECKS_JSON=$(gh pr checks "$PR_NUMBER" --json name,bucket,state,link)
+          # `gh pr checks` reads the PR's statusCheckRollup, which never
+          # includes check runs from workflow_dispatch-triggered workflows —
+          # and that is exactly how this workflow runs CI, because a
+          # GITHUB_TOKEN-created PR cannot trigger pull_request events. The
+          # rollup alone therefore reports the required CI checks as missing
+          # forever and the sync PR never auto-merges (PR #245 sat open 1.5
+          # days while production breached the sync SLO). Union the rollup
+          # (Vercel app checks + commit statuses) with the commit's REST check
+          # runs (where the dispatched CI reports); on a name collision the
+          # REST entry wins because the check-runs API returns the latest run.
+          ROLLUP_CHECKS=$(gh pr checks "$PR_NUMBER" --json name,bucket,state,link)
+          REST_CHECKS=$(gh api "repos/${{ github.repository }}/commits/$PR_HEAD_SHA/check-runs?per_page=100" --paginate --jq '
+            .check_runs[]
+            | {
+                name,
+                started: (.started_at // ""),
+                bucket: (
+                  if .status != "completed" then "pending"
+                  elif .conclusion == "success" then "pass"
+                  elif (.conclusion == "skipped" or .conclusion == "neutral") then "skipping"
+                  else "fail"
+                  end
+                ),
+                state: (.conclusion // .status),
+                link: .html_url
+              }' | jq -s 'sort_by(.started) | group_by(.name) | map(.[-1] | del(.started))')
+          CHECKS_JSON=$(jq -n --argjson rollup "$ROLLUP_CHECKS" --argjson rest "$REST_CHECKS" '
+            ($rest | map(.name)) as $restNames
+            | ($rollup | map(select(.name as $n | ($restNames | index($n)) | not))) + $rest
+          ')
           CHECK_COUNT=$(jq 'length' <<<"$CHECKS_JSON")
           if [ "$CHECK_COUNT" -eq 0 ]; then
             echo "::warning::No checks reported for PR #$PR_NUMBER after the two-hour window; leaving it open."


### PR DESCRIPTION
## Why production keeps falling behind upstream

The freshness pipeline was designed to be fully automatic: hourly sentinel (`fpf-sync-monitor.yml`) → sync worker (`sync-fpf.yml`) opens a PR → after a 2-hour review window the worker auto-merges it and runs `deploy:prod`. But the auto-merge gate has been in a **livelock** since the check-verification was added:

1. The sync PR is created with `GITHUB_TOKEN`, so GitHub (by design, anti-recursion) never fires `pull_request` workflows for it — that's why the worker manually dispatches `ci.yml` via `workflow_dispatch`.
2. The dispatched CI runs and passes, and its check runs land on the PR's head commit (visible via REST `/commits/:sha/check-runs`).
3. But the merge gate reads `gh pr checks` — the PR's **statusCheckRollup** — which never includes workflow_dispatch check suites. It saw only the Vercel app checks.
4. Required check `Build (docs + MCP + Vercel dry-runs)` therefore read as *missing* on every hourly recheck → "leaving it open" → sync PRs sat open forever.

Evidence: #245 sat unmerged for ~1.5 days with all checks green while mcp.fpf.sh breached the 10h sync SLO by 43h (every hourly worker run logged `- missing or not passing: Build (docs + MCP + Vercel dry-runs)`).

## Fix

Build the eligibility set as a **union**: the rollup (Vercel app checks + commit statuses) plus the commit's REST check runs (where dispatched CI reports). On a name collision the REST entry wins (the check-runs API returns the latest run per check). Required-names and not-ready logic unchanged.

## Verification

Dry-ran the exact new shell/jq pipeline against #245's real head commit (`8dcd75cb`): 13 checks visible (was 4), required set fully passing, not-ready count 0 — i.e. #245 would have auto-merged and auto-deployed on its own.

(#245 has since been merged manually and production redeployed; the sync monitor now reports **ok**. This PR fixes the recurrence.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)