### PR TITLE
fix: authenticate publish:current's upstream commit lookup

### DIFF
--- a/.github/workflows/sync-fpf.yml
+++ b/.github/workflows/sync-fpf.yml
@@ -111,6 +111,10 @@ jobs:
         env:
           FPF_PUBLISH_SOURCE_PATH: .fpf-upstream/FPF-Spec.md
           FPF_UPSTREAM_REF: ${{ steps.upstream.outputs.ref }}
+          # Resolving the upstream commit hits api.github.com. Unauthenticated
+          # it is 60 req/hour per IP and runners share egress addresses, so the
+          # call 403s on a busy runner even for a public repo.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run publish:current
 
       - name: Assert per-section blame survived the publish

--- a/src/build/publish-current.ts
+++ b/src/build/publish-current.ts
@@ -78,12 +78,23 @@ async function defaultResolveUpstreamCommit(
   repo: string,
 ): Promise<{ sha: string; committedAt: string }> {
   const url = `https://api.github.com/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}`;
+  // Authenticate when a token is available. Unauthenticated api.github.com is
+  // limited to 60 requests/hour per source IP, and GitHub-hosted runners share
+  // egress IPs — so this 403s on a busy runner even though the repo is public.
+  // Same pattern as sync-monitor.ts. GH_TOKEN is what `gh` sets; GITHUB_TOKEN
+  // is the Actions default.
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
   const response = await fetch(url, {
-    headers: { Accept: 'application/vnd.github+json' },
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'fpf-reference-publish-current',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
   });
   if (!response.ok) {
     throw new Error(
-      `publish-current: GitHub API ${response.status} for ${url}`,
+      `publish-current: GitHub API ${response.status} for ${url}`
+      + `${token ? '' : ' (no GITHUB_TOKEN/GH_TOKEN set; unauthenticated requests are rate-limited to 60/hour per IP)'}`,
     );
   }
   const body = (await response.json()) as {


### PR DESCRIPTION
## What

Adds an `Authorization` header to `publish:current`'s upstream commit lookup.

## Why

The first sync run after the LFS unblock (#253) got past `actions/checkout` for the first time since 2026-07-16 — then died one step later:

```
publish-current: GitHub API 403 for https://api.github.com/repos/ailev/FPF/commits/main
```

`defaultResolveUpstreamCommit` fetched `api.github.com` with no `Authorization` header. Unauthenticated that endpoint allows 60 requests/hour **per source IP**, and GitHub-hosted runners share egress addresses — so it 403s on a busy runner even though `ailev/FPF` is public.

The LFS outage was masking this: for 12 days the job never reached the publish step. This is the next layer down, not a regression from #253.

## Type

`fix`

## Changes

- `src/build/publish-current.ts` — send `Authorization: Bearer` when `GITHUB_TOKEN` or `GH_TOKEN` is set (the pattern `sync-monitor.ts` already uses), add a `User-Agent`, and name the rate limit in the error text so the next 403 explains itself.
- `.github/workflows/sync-fpf.yml` — pass `secrets.GITHUB_TOKEN` into the "Publish current channel" step.

`ensure:snapshot` is unaffected — it overrides `resolveUpstreamCommit` with the committed manifest values precisely to stay hermetic and make no network call.

## Validation

- Verification profile: **P4** — sync worker and deploy automation.
- `bun run check` — exit 0
- `bun run lint` — 0 errors, 0 warnings across 161 files
- `bun run test` (publish-current suite) — 7/7 pass
- End-to-end: the real proof is the next `sync-fpf` dispatch getting past "Publish current channel". Reported on the PR before merge.

## Production evidence packet

### Promise checked

fpf.sh and mcp.fpf.sh stay ≤1 day behind `ailev/FPF`. Production is currently 16 days stale; this unblocks the worker that repairs it.

### URLs checked

`https://api.github.com/repos/ailev/FPF/commits/main` (403 unauthenticated from the runner; 200 authenticated)

### Commands run

```
gh run view 30351262487 --job 90249064089 --log
bun run check && bun run lint
```

### Expected semantic invariants

- **freshness/currentness**: the sync worker reaches publish, opens a PR, merges, and deploys
- **cost/risk guardrails**: no new secret; uses the Actions-default `GITHUB_TOKEN` already available to the job

### Actual output excerpt

Run 30351262487, after #253 merged — note it now fails at step 6 rather than step 1:

```
X Refresh published/current from ailev/FPF in 28s
  X Publish current channel
    error: publish-current: GitHub API 403 for .../repos/ailev/FPF/commits/main
✓ Escalate sync worker failure in 4s
```

That run is also the first live proof of #253's escalation path: the failure opened a tracking issue within 4 seconds, where the previous 34 failures opened none.

### Upstream ref / source hash

Unchanged by this PR — it changes how the upstream ref is *fetched*, not what is published.

### Deployment URL / alias checked

None; this PR does not deploy.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->