### PR TITLE
fix: give the spend monitor's platform-errors guard a measured tail budget

### DIFF
--- a/.github/workflows/vercel-spend-monitor.yml
+++ b/.github/workflows/vercel-spend-monitor.yml
@@ -36,7 +36,12 @@ env:
   FPF_VERCEL_SPEND_WINDOW_MINUTES: ${{ github.event.inputs.window_minutes || '375' }}
   FPF_VERCEL_SPEND_MAX_FUNCTION_DURATION_GBHR: ${{ github.event.inputs.max_function_duration_gbhr || '3' }}
   FPF_VERCEL_SPEND_MAX_LEGACY_INVOCATIONS: '0'
-  FPF_VERCEL_SPEND_MAX_ERROR_INVOCATIONS: '0'
+  # Error budget, not zero-tolerance: ~18.5k invocations/day carry a ~0.03%
+  # timeout tail (worst observed 375m window: 3). At 0 this monitor flapped
+  # daily (#261). 10 stays above the tail; a real regression (1% errors ≈ 48
+  # per window) still breaches in one window. Keep in sync with
+  # DEFAULT_VERCEL_SPEND_MAX_ERROR_INVOCATIONS in src/build/vercel-spend-monitor.ts.
+  FPF_VERCEL_SPEND_MAX_ERROR_INVOCATIONS: '10'
   FPF_VERCEL_SPEND_LEGACY_PATH: /api/mcp/fpf_memory
   FPF_VERCEL_FUNCTION_DURATION_USD_PER_GBHR: '0.18'
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ own acceptance criteria and an auditable evidence link:
 | Promised effect | Published spec content matches upstream `main` |
 | Eligibility / access | Public, unauthenticated, via fpf.sh and mcp.fpf.sh |
 | Acceptance criterion | Time since the oldest upstream commit we could already have published ≤ 26h (falling back to the published artifact's own upstream date when the compare API is unavailable) |
-| Evidence | `/api/fpf/status` → `publication.upstreamDate`, plus `ailev/FPF/compare/<published>...<HEAD>` |
+| Evidence | `mcp.fpf.sh/api/fpf/status` → `publication.upstreamDate`, plus `ailev/FPF/compare/<published>...<HEAD>` (the status API lives on mcp.fpf.sh only; fpf.sh is the static docs host and 404s that path) |
 | Verdict owner | `.github/workflows/fpf-sync-monitor.yml` (independent of the sync worker) |
 
 26h = the ≤1-day promise plus slack for one missed run of a twice-daily worker.

--- a/docs/automation-playbook.md
+++ b/docs/automation-playbook.md
@@ -162,7 +162,16 @@ Rollback is a mutating action: it needs explicit operator approval per the acces
 ### Investigate a spend or function-duration breach
 
 1. `bun run monitor:vercel:spend -- --format markdown --fail-on-breach` — rerun the guardrail first, in the same failing form the scheduled monitor uses (without `--fail-on-breach` the command exits zero even on a breach, so a script or agent would sail past a blind or breached guard). It distinguishes `breach`, `config_error`, `metrics_unavailable`, and `expected_blocked_traffic`. The first three all require operator action — the monitor marks them operator-action-required and exits nonzero under `--fail-on-breach`. A `config_error` (missing token) or `metrics_unavailable` window means the guardrail itself is blind and must be repaired, not ignored. Only blocked legacy-route traffic is benign: it is expected, not a spend problem.
-2. For a breach, read runtime logs for the breach window (Vercel MCP evidence loop) to attribute the spend to a route and caller pattern.
+2. For a breach, attribute the error rows before touching anything. Runtime logs expire within hours, so use the metrics API, which retains days and is what the monitor itself queries:
+
+   ```bash
+   npx --yes vercel@54.7.1 metrics vercel.function_invocation.count \
+     --group-by request_path --group-by error_code --filter "error_code ne ''" \
+     --project fpf-reference-mcp --scope venikmans-projects \
+     --since 2880m --granularity 30m --format json --non-interactive
+   ```
+
+   Compare the nonzero buckets against `gh run list` timestamps to separate self-inflicted monitor traffic from external callers, and against total route volume (`--group-by request_path`, no filter) to judge whether the errors are a tail rate or a systematic break. The platform-errors threshold is a tail budget calibrated against measured volume (2026-07-31 calibration: ~18.5k invocations/day, 0.027% timeout tail, worst 375m window 3 → budget 10); if volume shifts by an order of magnitude, recalibrate the budget with this query rather than absorbing daily flapping or muting the alarm.
 3. Check the bundle and route shape locally: `bun run bench:vercel:function-size` after `bun run vercel:mcp:build`, since function-duration spikes often follow packaging regressions.
 4. Land the guardrail or fix as its own measured PR (P4 surface), and let the monitor close its issue after a clean window rather than closing it by hand.
 
@@ -286,7 +295,7 @@ Operational defaults:
 - `sync-fpf.yml` accepts `fpf-origin-updated` and `fpf-sync-updated` dispatches or manual runs, closes superseded sync PRs, opens a current PR, runs validation/build/preview, then auto-merges only after the review window and required evidence pass.
 - `fpf-sync-monitor.yml` polls daily (11:47 UTC), runs `bun run monitor:sync`, triggers `sync-fpf.yml` when upstream is ahead and no sync worker is queued or running, and fails the monitor if `mcp.fpf.sh` exceeds the drift SLO or the hosted runtime is stale. If a current generated PR already exists, the dispatch is a retry path for CI and merge eligibility rather than a duplicate PR path.
 - The default drift SLO is 26 hours. Drift is measured as the time since the oldest upstream commit that could already have been published — not the age of upstream HEAD, which resets on every upstream push and can never breach. The sync worker runs twice daily, so the healthy worst case is ~13h; past 26h, two consecutive slots failed.
-- `vercel-spend-monitor.yml` polls Vercel metrics every 6 hours with `bun run monitor:vercel:spend`, failing when Function Duration exceeds the configured GB-hour window, the legacy MCP route reaches Functions again, Vercel reports unexpected function error-code rows, credentials are missing, or metrics are unavailable. It reports expected blocked legacy traffic separately so operators do not treat blocked traffic as a spend breach. It prefers the repo secret `VERCEL_SPEND_MONITOR_TOKEN` and falls back to `VERCEL_TOKEN`.
+- `vercel-spend-monitor.yml` polls Vercel metrics every 6 hours with `bun run monitor:vercel:spend`, failing when Function Duration exceeds the configured GB-hour window, the legacy MCP route reaches Functions again, function error-code rows exceed the tail budget (10 per window; legacy-route isolation stays zero-tolerance), credentials are missing, or metrics are unavailable. It reports expected blocked legacy traffic separately so operators do not treat blocked traffic as a spend breach. It prefers the repo secret `VERCEL_SPEND_MONITOR_TOKEN` and falls back to `VERCEL_TOKEN`.
 
 ## Publishing and outreach packets
 

--- a/src/build/vercel-spend-monitor.ts
+++ b/src/build/vercel-spend-monitor.ts
@@ -2,7 +2,16 @@ export const DEFAULT_VERCEL_SPEND_PROJECT = 'fpf-reference-mcp';
 export const DEFAULT_VERCEL_SPEND_WINDOW_MINUTES = 30;
 export const DEFAULT_VERCEL_SPEND_MAX_FUNCTION_DURATION_GBHR = 0.25;
 export const DEFAULT_VERCEL_SPEND_MAX_LEGACY_INVOCATIONS = 0;
-export const DEFAULT_VERCEL_SPEND_MAX_ERROR_INVOCATIONS = 0;
+// Tail budget, not zero-tolerance: the canonical MCP route serves ~18.5k
+// invocations/day with a measured 0.027% timeout tail (10 of 37,085 over the
+// 48h ending 2026-07-31; worst 375m window saw 3). At 0 the monitor flapped
+// breach→ok four times in two days (#261), which is the alert-fatigue failure
+// mode that hid the #253 outage. 10 per window stays 3× above the observed
+// tail while a systematic regression (even 1% errors ≈ 48 per 375m window)
+// still breaches within one window. Legacy-route isolation stays at 0 —
+// zero-tolerance is correct there. Recalibrate if route volume changes
+// materially; the evidence query lives in the automation playbook.
+export const DEFAULT_VERCEL_SPEND_MAX_ERROR_INVOCATIONS = 10;
 export const DEFAULT_VERCEL_SPEND_LEGACY_PATH = '/api/mcp/fpf_memory';
 export const DEFAULT_LEGACY_FUNCTION_DURATION_USD_PER_GBHR = 0.18;
 

--- a/tests/vercel-spend-monitor.test.ts
+++ b/tests/vercel-spend-monitor.test.ts
@@ -93,6 +93,57 @@ describe('Vercel spend monitor', () => {
       .toBe('warn');
   });
 
+  it('tolerates canonical-route error rows within the tail budget', () => {
+    const report = evaluateVercelSpendMonitor({
+      project: 'fpf-reference-mcp',
+      windowMinutes: 375,
+      legacyPath: DEFAULT_VERCEL_SPEND_LEGACY_PATH,
+      now: new Date('2026-07-31T03:00:00Z'),
+      thresholds: makeThresholds({ maxErrorFunctionInvocations: 10 }),
+      metrics: makeSnapshot({
+        errorFunctionInvocations: 3,
+        errorInvocationRows: [
+          {
+            value: 3,
+            requestPath: '/api/mcp/fpf_reference/mcp',
+            errorCode: 'timeout',
+          },
+        ],
+      }),
+    });
+
+    expect(report.state).toBe('ok');
+    expect(report.breached).toBe(false);
+    expect(report.operatorActionRequired).toBe(false);
+    expect(report.quality.find((item) => item.characteristic === 'platform-errors')?.status)
+      .toBe('pass');
+  });
+
+  it('still breaches when error rows exceed the tail budget', () => {
+    const report = evaluateVercelSpendMonitor({
+      project: 'fpf-reference-mcp',
+      windowMinutes: 375,
+      legacyPath: DEFAULT_VERCEL_SPEND_LEGACY_PATH,
+      now: new Date('2026-07-31T03:00:00Z'),
+      thresholds: makeThresholds({ maxErrorFunctionInvocations: 10 }),
+      metrics: makeSnapshot({
+        errorFunctionInvocations: 48,
+        errorInvocationRows: [
+          {
+            value: 48,
+            requestPath: '/api/mcp/fpf_reference/mcp',
+            errorCode: 'internal',
+          },
+        ],
+      }),
+    });
+
+    expect(report.state).toBe('breach');
+    expect(report.operatorActionRequired).toBe(true);
+    expect(report.quality.find((item) => item.characteristic === 'platform-errors')?.status)
+      .toBe('fail');
+  });
+
   it('reports missing credentials as config_error with metrics not queried', () => {
     const report = createVercelSpendConfigErrorReport({
       project: 'fpf-reference-mcp',


### PR DESCRIPTION
## What

Recalibrates `FPF_VERCEL_SPEND_MAX_ERROR_INVOCATIONS` from **0 → 10** per 375-minute window (workflow env + code default), adds tests locking the budget semantics, records the attribution query + calibration evidence in the automation playbook, and fixes ROADMAP's freshness-evidence link to name `mcp.fpf.sh` (the status API's actual host).

## Why

The spend monitor breached four times in two days (runs on 07-29 08:15/13:41 and 07-30 13:23/19:06, issue #261), each time on the `platform-errors` characteristic, each time self-clearing on the next window. Attribution over the 48h ending 2026-07-31:

- **All 10 error rows are `timeout` on `/api/mcp/fpf_reference/mcp`** — no 5xx storm, no legacy-route traffic.
- Route volume: **37,085 invocations/48h (~18.5k/day)** → 0.027% error rate; worst 375m window saw 3.
- The 30m-bucket clusters (07-29 07:00Z, 07-30 09:00/11:00/14:00Z) mostly do **not** coincide with our scheduled workflows, and the content-quality monitor doesn't call the MCP route — this is external traffic's normal tail, not self-inflicted load.

A zero threshold on a public endpoint at this volume guarantees near-daily flapping — the alert-fatigue failure mode that let 34 sync failures pass unnoticed before #253. The guard's job is catching systematic breakage, which it still does: 1% errors ≈ 48/window and full breakage ≈ 4,800/window both breach within a single window. Legacy-route isolation stays zero-tolerance.

## P4 evidence ledger

- **Budget/blast radius:** threshold-only change; no route, deploy, or billing behavior touched. Worst case of a mis-set budget: up to 10 erroring invocations per 375m window go un-alarmed (~$0.001 in function time at observed durations).
- **Guard verdict (live):** current 375m window has **0** error rows vs budget 10 → `ok` (same pinned `vercel@54.7.1` metrics queries the monitor runs).
- **Stop/replan trigger:** if the monitor breaches again *post-merge*, that is ≥11 errors in one window — treat as real regression, not tail; the playbook's attribution query is step 2 of the runbook. Recalibrate only via that query's evidence if route volume shifts an order of magnitude.
- **Verification:** `bun run check` ✓ · `rstest run tests/vercel-spend-monitor.test.ts` ✓ (13 tests, incl. 2 new: ≤budget ok / >budget breach) · workflow YAML parses ✓ · `bun run docs:build` ✓ (playbook page publishes).

Timeout tail itself (~5/day at the 20s `maxDuration` cap) is real but separate — tracked as a follow-up, needs in-window log capture to attribute to cold starts vs heavy tool calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->