### PR TITLE
docs: record About-panel count drift; test: un-flake publish-current for the grown corpus

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,10 +33,20 @@ the delivery is what let a 16-day outage report "within SLO" (see #253).
    distribution move below it. Needs Stas to pick (MIT or Apache-2.0), and the
    file must scope repo code separately from the mirrored upstream spec text in
    `published/current/`.
-2. **Make the plugin discoverable — remaining scope: a `docs/` mention.** The
-   README quick-install block and the `src/core/public-copy.ts` card shipped in
-   #250 (2026-07-28), and the GitHub description now states the live counts
-   (292 patterns / 3 curated routes, corrected 2026-07-28).
+2. **Make the plugin discoverable — remaining scope: a `docs/` mention, plus
+   the About-text swap below.** The README quick-install block and the
+   `src/core/public-copy.ts` card shipped in #250 (2026-07-28). The GitHub
+   About was hand-corrected to live counts on 2026-07-28 and was stale again
+   by the 2026-08-01 sync (292 → 294 patterns; flagged 2026-08-03). Lesson:
+   repo metadata must not quote numbers only the compiled snapshot knows —
+   the corpus changes twice a day and the About is hand-edited. Live counts
+   stay on surfaces that compute them (`src/core/documents.ts`, fpf.sh).
+   Canonical count-free About text (needs a repo admin — description edits
+   are not exposed to session tooling):
+   > Hosted MCP server + slim wiki projection of the First Principles
+   > Framework (FPF) by Anatoly Levenchuk. Bounded, vectorless retrieval
+   > over the full pattern catalog and curated routes — addressable by
+   > stable FPF IDs, synced daily from ailev/FPF.
 3. **Publish to `registry.modelcontextprotocol.io`.** Zero listings today and no
    publication was ever attempted. The freshness gate cleared 2026-07-28 (see
    Shipped); what remains is the board go/no-go. Note repo-root `server.json`

--- a/tests/publish-current.test.ts
+++ b/tests/publish-current.test.ts
@@ -16,6 +16,11 @@ const STUB_UPSTREAM_RESOLVER = async (ref: string) => ({
   committedAt: '2026-01-15T00:00:00.000Z',
 });
 
+// Every test here publishes the real spec (DEFAULT_SOURCE_PATH), so each
+// publishCurrent/validatePublishedSurface pair pays one or two full compiles
+// of a corpus that grows with upstream — 12.2 MB as of the 2026-08-01 sync,
+// which pushed the two-compile tests past the old 30s ceiling on loaded CI
+// runners. Budgets are ceilings for hang detection, not targets.
 describe('publishCurrent', () => {
   let tempRoot: string;
   let publishSourcePath: string;
@@ -70,7 +75,7 @@ describe('publishCurrent', () => {
     const secondManifest = await readFile(publishedManifestPath, 'utf8');
 
     expect(secondManifest).toBe(firstManifest);
-  }, 30_000);
+  }, 120_000);
 
   it('republishes the same ref byte-identically from a clean tree', async () => {
     // Reproduces the CI sync worker: it republishes from a fresh `main`
@@ -111,7 +116,7 @@ describe('publishCurrent', () => {
     expect(await readFile(resolve(publishedArtifactDir, 'snapshot.json'), 'utf8')).toBe(
       firstSnapshot,
     );
-  }, 30_000);
+  }, 120_000);
 
   it('resolves the default runtime artifact dir relative to the publish source root', async () => {
     await publishCurrent(
@@ -128,7 +133,7 @@ describe('publishCurrent', () => {
     );
 
     expect(await readFile(publishedManifestPath, 'utf8')).toContain('"channel": "latest-published"');
-  }, 30_000);
+  }, 120_000);
 
   it('keeps the published surface stable across equivalent publish roots', async () => {
     const config = {
@@ -168,7 +173,7 @@ describe('publishCurrent', () => {
     expect(await readFile(resolve(publishedArtifactDir, 'snapshot.json'), 'utf8')).toBe(
       firstSnapshot,
     );
-  }, 30_000);
+  }, 120_000);
 
   it('writes a compiler fingerprint into the published manifest and snapshot', async () => {
     await publishCurrent(
@@ -198,7 +203,7 @@ describe('publishCurrent', () => {
 
     expect(manifest.compilerFingerprint).toMatch(/^sha256:/);
     expect(snapshot.compilerFingerprint).toBe(manifest.compilerFingerprint);
-  }, 30_000);
+  }, 120_000);
 
   it('rebuilds the runtime snapshot when the published compiler fingerprint is stale', async () => {
     await publishCurrent(
@@ -253,7 +258,7 @@ describe('publishCurrent', () => {
     ) as Record<string, unknown>;
 
     expect(republishedSnapshot.staleCompilerOnlyMarker).toBeUndefined();
-  }, 30_000);
+  }, 120_000);
 
   it('rejects a published surface whose compiler fingerprint drifted', async () => {
     await publishCurrent(
@@ -285,5 +290,5 @@ describe('publishCurrent', () => {
         publishedManifestPath: 'published/current/manifest.json',
       }),
     ).rejects.toThrow(/compilerFingerprint/);
-  }, 30_000);
+  }, 120_000);
 });


### PR DESCRIPTION
## What

1. Corrects ROADMAP.md item 2: the GitHub About panel does **not** "state the live counts" anymore — it says 292 patterns while the published snapshot has **294** (routes still 3). The item now records the drift, the lesson, and the canonical **count-free** About text for a repo admin to paste (description edits are not exposed to session tooling).
2. Un-flakes `tests/publish-current.test.ts`, which failed this PR's shard-3 gate for reasons unrelated to the diff: per-test budgets raised 30s → 120s.

## Why

**Docs:** The About was hand-corrected to live counts on 2026-07-28 and was stale again by the 2026-08-01 sync — wrong within four days, flagged by the board 2026-08-03. The corpus syncs twice daily; a hand-edited count in repo metadata structurally cannot stay true. Live counts belong on surfaces that compute them from the snapshot (`src/core/documents.ts`, fpf.sh). The same trap existed in ROADMAP.md itself, which restated "292" as settled fact — removed here too.

**Test:** Shard 3 failed on "rejects a published surface whose compiler fingerprint drifted" — a 30s timeout with no assertions completed, reproduced locally at 30.3s on the identical `rstest run --shard=3/4` invocation. Every test in that file compiles the **real spec** (`DEFAULT_SOURCE_PATH`), which reached 12.2 MB with the 2026-08-01 upstream sync; the two-compile tests (publish + validating recompile) now straddle the 30s ceiling on loaded runners. This is a latent flake on `main` tripped by corpus growth, not by this PR's markdown edit. 120s stays a hang detector without being a corpus-growth tripwire.

## Type

- `docs` — ROADMAP correction
- `fix` — CI flake (test timeout budget)

## Changes

- `ROADMAP.md` item 2: replaces the stale "description now states the live counts (292 / 3)" claim with the drift record, the no-hardcoded-counts rule for repo metadata, and the paste-ready count-free About text.
- `tests/publish-current.test.ts`: all seven per-test timeouts 30_000 → 120_000, plus a comment stating the constraint (real-spec compiles; corpus grows with upstream).

## Validation

- Verification profile: P2
- Profile reason: docs wording plus a test-budget change with local behavior impact; no production-control or security boundary touched.
- Focused local commands:
  - `rstest run tests/publish-current.test.ts` — **7/7 pass** with the new budgets (previously the drift test timed out at 30.3s vs 30s).
  - `rstest run tests/sync-slo-parity.test.ts` (only executable consumer of ROADMAP.md) — passes.
  - `rslint --type-check tests/publish-current.test.ts` — 0 errors, 0 warnings; `bun run check` (tsc) clean.
  - Count claim verified: `bun run ensure:snapshot` (regenerated + validated), then `Object.keys(snapshot.patternGraph.nodes).length` = **294**, `routeGraph.nodes` = **3** — the same count definition the runtime's own copy uses (`src/core/documents.ts:517`).
- Broader checks skipped: full 4-shard suite locally — CI runs it on this PR; shard 3 is the one that contained the flake.
- No new warnings introduced
- `bun run build` — N/A (no runtime/server code touched)
- `bun run docs:build` — N/A (repo-root file, not under `docs/`)
- Relevant docs updated: this PR is the doc update

## Production evidence packet

N/A — no production-facing behavior changes. Evidence for the factual claim the PR records:

### Promise checked

Published catalog counts vs. GitHub About text.

### URLs checked

Hosted index status via the live MCP surface (mcp.fpf.sh): `fresh: true`, sourceHash `sha256:135b2bd2…` — identical to local `published/current/manifest.json`, so the local snapshot count is what production serves.

### Commands run

`bun run ensure:snapshot`; node counts read from `published/current/fpf-index/snapshot.json`.

### Upstream ref / source hash

Upstream `ailev/FPF@9a9a42e4` (2026-08-01), sourceHash `sha256:135b2bd2ac115eddddd0508f7340431e66359ae2faf394065d1f3e4411023171`.

### What would falsify this success claim?

A snapshot built from the same source hash whose `patternGraph.nodes` count ≠ 294, or a route count ≠ 3. For the flake diagnosis: the drift test still timing out under a 120s budget (that would indicate a hang, not corpus growth).

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts` (untouched)

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Claude Code (maintainer session) |
| Task source | Board flag 2026-08-03: screenshot of the repo About panel, "this is wrong" |
| Privacy check | No raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers included. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwTVn2WQkfd2BmBs34LHTz