### PR TITLE
fix: weekly review first-run defects — boundedFetch TDZ and token scope

### DIFF
--- a/.github/workflows/weekly-metrics.yml
+++ b/.github/workflows/weekly-metrics.yml
@@ -65,7 +65,12 @@ jobs:
         continue-on-error: true
         timeout-minutes: 5
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_WEEKLY_METRICS_TOKEN || secrets.VERCEL_TOKEN }}
+          # VERCEL_SPEND_MONITOR_TOKEN sits in the fallback chain because it
+          # is the proven team-scoped token (the spend monitor queries the
+          # venikmans-projects scope with it every 6 hours). The first live
+          # run showed plain VERCEL_TOKEN cannot see that team: the CLI says
+          # "The specified scope does not exist" and REST returns 403.
+          VERCEL_TOKEN: ${{ secrets.VERCEL_WEEKLY_METRICS_TOKEN || secrets.VERCEL_SPEND_MONITOR_TOKEN || secrets.VERCEL_TOKEN }}
         run: |
           set -euo pipefail
           for project in fpf-sh fpf-reference-mcp; do
@@ -86,7 +91,7 @@ jobs:
         continue-on-error: true
         timeout-minutes: 6
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_USAGE_REPORT_TOKEN || secrets.VERCEL_TOKEN }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_USAGE_REPORT_TOKEN || secrets.VERCEL_SPEND_MONITOR_TOKEN || secrets.VERCEL_TOKEN }}
         run: |
           bun run usage:report -- \
             --source vercel \
@@ -97,7 +102,7 @@ jobs:
       - name: Build weekly metrics report
         id: metrics
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_WEEKLY_METRICS_TOKEN || secrets.VERCEL_TOKEN }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_WEEKLY_METRICS_TOKEN || secrets.VERCEL_SPEND_MONITOR_TOKEN || secrets.VERCEL_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
           # Usage-report verdict from its GITHUB_OUTPUT, so a failing or
           # breaching sample becomes a top-level finding in the weekly state

--- a/scripts/weekly-metrics.ts
+++ b/scripts/weekly-metrics.ts
@@ -34,6 +34,18 @@ const DEPLOYMENTS_PAGE_LIMIT = 100;
 // pretending the page was the whole window.
 const DEPLOYMENTS_MAX_PAGES = 5;
 
+// Declared before the top-level report assembly below: as a `const` this does
+// NOT hoist, and loadFreshness() runs during module evaluation — declaring it
+// later dies with a temporal-dead-zone error, which is exactly what broke the
+// freshness section of the first live run (issue #276). Bun's `typeof fetch`
+// carries the `preconnect` static, so the wrapper forwards it to stay a
+// drop-in replacement type-wise.
+const boundedFetch: typeof fetch = Object.assign(
+  (input: string | URL | Request, init?: RequestInit) =>
+    fetch(input, { ...init, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) }),
+  { preconnect: fetch.preconnect.bind(fetch) },
+);
+
 const flags = parseFlagMap(process.argv.slice(2));
 const windowLabel = readString(
   flags,
@@ -259,14 +271,6 @@ function vercelFetch(url: URL): Promise<Response> {
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
 }
-
-// Bun's `typeof fetch` carries the `preconnect` static, so the wrapper
-// forwards it to stay a drop-in replacement type-wise.
-const boundedFetch: typeof fetch = Object.assign(
-  (input: string | URL | Request, init?: RequestInit) =>
-    fetch(input, { ...init, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) }),
-  { preconnect: fetch.preconnect.bind(fetch) },
-);
 
 function parseProjects(raw: string | undefined): WeeklyMetricsProjectRef[] {
   if (!raw) {


### PR DESCRIPTION
## What

Fixes the two defects the first live Weekly Metrics Review run surfaced (issue #276, run [31150599806](https://github.com/venikman/fpf-memory/actions/runs/31150599806)) — every one of them was visible in the ledger as a finding, which is the guard system doing its job:

- **`boundedFetch` temporal-dead-zone crash**: it became a `const` when it gained Bun's `typeof fetch` typing (the `preconnect` static), so it stopped hoisting while the top-level `loadFreshness()` still ran before its declaration. The freshness section died with `Cannot access 'boundedFetch' before initialization`. It now sits with the other constants above the report assembly.
- **Token scope**: plain `VERCEL_TOKEN` cannot see the `venikmans-projects` team — the Vercel CLI reports `The specified scope does not exist` (enablement + usage-sample steps) and REST returns 403 (deployments + Web Analytics). The spend monitor works on the same scope because it prefers `VERCEL_SPEND_MONITOR_TOKEN`; that proven team-scoped secret joins all three fallback chains between the step-specific override and `VERCEL_TOKEN`.

## Why

The first dispatched run published issue #276 with six findings, four of them credential-related and one my bug. This PR clears both root causes so the re-dispatched run can enable Web Analytics, query deployments/analytics, and measure freshness for real.

## Type

- `fix` — bug fix

## Changes

- `scripts/weekly-metrics.ts` — `boundedFetch` declared before module evaluation reaches the report assembly, with a comment naming the TDZ failure so it doesn't regress.
- `.github/workflows/weekly-metrics.yml` — `VERCEL_SPEND_MONITOR_TOKEN` added to the three token fallback chains, with the evidence noted.

## Validation

- Verification profile: **P4** (workflow + autonomous-monitor path)
- Profile reason: same surfaces as #275; this is the first-run repair.
- Focused local command: `bun scripts/weekly-metrics.ts --no-write` — freshness now degrades to a real network finding (this sandbox's unauthenticated GitHub API 403), not the TDZ error; the section machinery executes.
- `bun run lint` clean (0/0/0, 164 files); `bun run check` clean; 20 weekly-metrics tests green; workflow YAML parses.
- Broader checks skipped: full shard suite unchanged by this diff (script + workflow only); CI runs it anyway.
- End-to-end verification: after merge, re-dispatch the workflow with `publish=true` — acceptance is issue #276 updating with deployments/analytics sections leaving `config_error`, and `get_web_analytics` no longer returning 404 after the enablement step.

**P4 ledger note** — no new permissions, no new automation paths; the change narrows to declaration order and secret fallback. Evidence trail: issue #276 findings ↔ run 31150599806 logs ↔ this diff.

## Production evidence packet

### Promise checked
First-run repair of the weekly review ledger; the mirror promise itself is untouched.

### URLs checked
- Issue #276 — findings enumerate both root causes verbatim
- Run 31150599806 logs — `The specified scope does not exist` (CLI ×3), HTTP 403 (REST ×4), TDZ error (freshness)
- Web Analytics API — still 404 not_found pre-fix (enablement never executed successfully)

### Commands run
`bun scripts/weekly-metrics.ts --no-write` · `bun run lint` · `bun run check` · `bunx rstest run tests/weekly-metrics.test.ts` · YAML parse

### Expected semantic invariants
- The freshness section produces a real state on every run (ok/pending/breach/unavailable-with-cause)
- Token selection prefers the narrowest configured secret and falls back to the proven team-scoped one
- All degradation states remain findings (unchanged)

### Actual output excerpt
`- Freshness could not be measured: sync-monitor: GitHub API 403 for https://api.github.com/repos/ailev/FPF/commits/main` (sandbox network limitation — the TDZ message is gone)

### Upstream ref / source hash
Unchanged by this PR (report tooling only).

### Deployment URL / alias checked
None — no deploy path touched.

### Rollback target
Revert this commit; the weekly workflow keeps publishing degraded-but-honest reports either way.

### Known caveats
- If `VERCEL_SPEND_MONITOR_TOKEN` is also unavailable to Actions for some step, the report still renders `config_error` findings — same visible failure mode as today.
- Beacon pageview collection still waits on the next production deploy (sync pipeline #270).

### What would falsify this success claim?
The re-dispatched run's issue still showing `config_error` for deployments/analytics, or `get_web_analytics` still returning 404 after a green enablement step.

## Boundary check

- Runtime remains a single spec file via `FPF_SPEC_SOURCE_PATH` — no additional corpora added
- No vector database or remote indexing introduced
- No Python code added
- MCP tool contracts are in `src/mcp/tool-contracts.ts` — untouched

## Agent metadata

| Field   | Value |
| ------- | ----- |
| Agent   | Claude Code (sole-maintainer session) |
| Task source | First-run validation of the weekly metrics review (follow-up to #275) |
| Privacy check | No raw user questions, prompts, answer text, selectors, markdown bodies, session IDs, IPs, or user identifiers included. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJieqUW8rUBRetunbJT3AL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJieqUW8rUBRetunbJT3AL)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->