### PR TITLE
fix: repoint sync worker deploys at the venikmans-projects Vercel scope

### DIFF
--- a/.github/workflows/sync-fpf.yml
+++ b/.github/workflows/sync-fpf.yml
@@ -195,7 +195,7 @@ jobs:
         if: steps.detect.outputs.changed == 'false' && github.ref == 'refs/heads/main'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          FPF_VERCEL_SCOPE: team_CnO1I5xd2OS0lzbbc4RkW7Ym
+          FPF_VERCEL_SCOPE: venikmans-projects
         run: |
           set -euo pipefail
 
@@ -306,7 +306,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          FPF_VERCEL_SCOPE: team_CnO1I5xd2OS0lzbbc4RkW7Ym
+          FPF_VERCEL_SCOPE: venikmans-projects
           PR_NUMBER: ${{ steps.pr.outputs.pull-request-number }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
The sync worker's two deploy steps still pin the dead Vercel team scope `team_CnO1I5xd2OS0lzbbc4RkW7Ym`; every `deploy:prod` fails with **The specified scope does not exist** ([run 33294746956](https://github.com/venikman/fpf-memory/actions/runs/33294746956)) and production is stuck on upstream `9dd92159` (2026-08-03).

Evidence the replacement scope is correct:
- `vercel teams ls` shows the team no longer exists; the only scope is `venikmans-projects`.
- `vercel project ls --scope venikmans-projects` lists both `fpf-sh` and `fpf-reference-mcp`.
- `vercel-spend-monitor.yml` and `weekly-metrics.yml` already use `FPF_VERCEL_SCOPE: venikmans-projects` with the same repo `VERCEL_TOKEN` — the spend monitor ran green today (33287282293), proving the secret works for the personal scope.

Two-line change, matching the two working workflows. After merge, dispatching `sync-fpf.yml` should complete the repair-deploy path (production redeploy + monitor green + auto-close of #270).

Follow-up (out of scope here): `DEFAULT_WEEKLY_METRICS_TEAM_ID` in `src/build/weekly-metrics.ts` still carries the dead team ID as a REST `teamId` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->