### PR TITLE
fix: fall back to the spend-monitor Vercel token for sync deploys

### DIFF
--- a/.github/workflows/sync-fpf.yml
+++ b/.github/workflows/sync-fpf.yml
@@ -194,7 +194,13 @@ jobs:
       - name: Repair production deploy when published/current is already current
         if: steps.detect.outputs.changed == 'false' && github.ref == 'refs/heads/main'
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          # Plain VERCEL_TOKEN was re-minted 2026-07-05 for the Vercel team
+          # that no longer exists, so it cannot see the venikmans-projects
+          # scope ("The specified scope does not exist", runs 33294746956 /
+          # 33295310184). Prefer a dedicated deploy token when one is minted,
+          # then fall through the same chain the spend monitor and weekly
+          # metrics workflows already run green with.
+          VERCEL_TOKEN: ${{ secrets.VERCEL_SYNC_DEPLOY_TOKEN || secrets.VERCEL_SPEND_MONITOR_TOKEN || secrets.VERCEL_TOKEN }}
           FPF_VERCEL_SCOPE: venikmans-projects
         run: |
           set -euo pipefail
@@ -305,7 +311,13 @@ jobs:
         if: steps.detect.outputs.changed == 'true' && steps.pr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          # Plain VERCEL_TOKEN was re-minted 2026-07-05 for the Vercel team
+          # that no longer exists, so it cannot see the venikmans-projects
+          # scope ("The specified scope does not exist", runs 33294746956 /
+          # 33295310184). Prefer a dedicated deploy token when one is minted,
+          # then fall through the same chain the spend monitor and weekly
+          # metrics workflows already run green with.
+          VERCEL_TOKEN: ${{ secrets.VERCEL_SYNC_DEPLOY_TOKEN || secrets.VERCEL_SPEND_MONITOR_TOKEN || secrets.VERCEL_TOKEN }}
           FPF_VERCEL_SCOPE: venikmans-projects
           PR_NUMBER: ${{ steps.pr.outputs.pull-request-number }}
         run: |


### PR DESCRIPTION
Second stacked deploy blocker behind #302: the repo's plain `VERCEL_TOKEN` (re-minted 2026-07-05) was team-scoped, and that team no longer exists — so the sync worker's `deploy:prod` still fails with **The specified scope does not exist** ([run 33295310184](https://github.com/venikman/fpf-memory/actions/runs/33295310184)) even after the scope repoint.

`vercel-spend-monitor.yml` (green today) and `weekly-metrics.yml` (green 08-17, 08-24) already solved this with a prefer-dedicated-then-fall-back token chain; the live token is `VERCEL_SPEND_MONITOR_TOKEN`. This PR adopts the same chain for the sync worker's two deploy-bearing steps:

`VERCEL_SYNC_DEPLOY_TOKEN || VERCEL_SPEND_MONITOR_TOKEN || VERCEL_TOKEN`

**Board note (Stas):** minting a personal-scope `VERCEL_SYNC_DEPLOY_TOKEN` (or replacing `VERCEL_TOKEN` with a personal-scope token) gives deploys their own credential; the chain picks it up with no further workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/fpf-memory/pull/303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->